### PR TITLE
Fix warnings

### DIFF
--- a/include/sundials/sundials_types.h
+++ b/include/sundials/sundials_types.h
@@ -155,6 +155,20 @@ typedef int sunindextype;
 #define SUNTRUE 1
 #endif
 
+/*
+ *------------------------------------------------------------------
+ * Macro : UNUSED(x)
+ *------------------------------------------------------------------
+ * The macro UNUSED gives the user a conventient way to explicitly
+ * mark variable `x` as unused. Explicit marking suppresses compiler
+ * warnings. This enables the user to "take seriously" other warnings
+ * about variables that were UNINTENDEDLY not used.
+ *------------------------------------------------------------------
+ */
+
+#ifndef UNUSED
+#define UNUSED(x) (void)(x)
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/arkode/arkode.c
+++ b/src/arkode/arkode.c
@@ -4778,6 +4778,8 @@ static int arkNlsNewton(ARKodeMem ark_mem, int nflag)
 ---------------------------------------------------------------*/
 static int arkNlsAccelFP(ARKodeMem ark_mem, int nflag)
 {
+  UNUSED(nflag);
+  
   /* local variables */
   int retval;
   realtype del, delp, dcon;
@@ -5851,6 +5853,10 @@ static int arkAdaptImExGus(ARKodeMem ark_mem, realtype *hnew)
 ---------------------------------------------------------------*/
 int arkExpStab(N_Vector y, realtype t, realtype *hstab, void *data)
 {
+  UNUSED(y);
+  UNUSED(t);
+  UNUSED(data);
+  
   /* explicit stability not used by default, 
      set to zero to disable */
   *hstab = RCONST(0.0);

--- a/src/arkode/arkode_bandpre.c
+++ b/src/arkode/arkode_bandpre.c
@@ -435,6 +435,13 @@ static int ARKBandPrecSolve(realtype t, N_Vector y, N_Vector fy,
                             realtype gamma, realtype delta,
                             int lr, void *bp_data)
 {
+  UNUSED(t);
+  UNUSED(y);
+  UNUSED(fy);
+  UNUSED(gamma);
+  UNUSED(delta);
+  UNUSED(lr);
+  
   ARKBandPrecData pdata;
   int retval;
 

--- a/src/arkode/arkode_bbdpre.c
+++ b/src/arkode/arkode_bbdpre.c
@@ -456,6 +456,8 @@ static int ARKBBDPrecSetup(realtype t, N_Vector y, N_Vector fy,
 			   booleantype jok, booleantype *jcurPtr, 
 			   realtype gamma, void *bbd_data)
 {
+  UNUSED(fy);
+  
   sunindextype ier;
   ARKBBDPrecData pdata;
   ARKodeMem ark_mem;
@@ -553,6 +555,13 @@ static int ARKBBDPrecSolve(realtype t, N_Vector y, N_Vector fy,
 			   realtype gamma, realtype delta,
 			   int lr, void *bbd_data)
 {
+  UNUSED(t);
+  UNUSED(y);
+  UNUSED(fy);
+  UNUSED(gamma);
+  UNUSED(delta);
+  UNUSED(lr);
+  
   int retval;
   ARKBBDPrecData pdata;
 

--- a/src/arkode/arkode_direct.c
+++ b/src/arkode/arkode_direct.c
@@ -710,6 +710,8 @@ int arkDlsDQJac(realtype t, N_Vector y, N_Vector fy,
                 SUNMatrix Jac, void *arkode_mem, N_Vector tmp1, 
                 N_Vector tmp2, N_Vector tmp3)
 {
+  UNUSED(tmp3);
+  
   int retval;
   ARKodeMem ark_mem;
   ark_mem = (ARKodeMem) arkode_mem;
@@ -828,6 +830,8 @@ int arkDlsBandDQJac(realtype t, N_Vector y, N_Vector fy,
                     SUNMatrix Jac, ARKodeMem ark_mem,
                     N_Vector tmp1, N_Vector tmp2)
 {
+  UNUSED(t);
+  
   N_Vector ftemp, ytemp;
   realtype fnorm, minInc, inc, inc_inv, srur;
   realtype *col_j, *ewt_data, *fy_data, *ftemp_data, *y_data, *ytemp_data;
@@ -1105,6 +1109,9 @@ int arkDlsSetup(ARKodeMem ark_mem, int convfail, N_Vector ypred,
 ---------------------------------------------------------------*/
 int arkDlsSolve(ARKodeMem ark_mem, N_Vector b, N_Vector ycur, N_Vector fcur)
 {
+  UNUSED(ycur);
+  UNUSED(fcur);
+  
   int retval;
   ARKDlsMem arkdls_mem;
 

--- a/src/arkode/arkode_spils.c
+++ b/src/arkode/arkode_spils.c
@@ -1520,6 +1520,10 @@ int arkSpilsSetup(ARKodeMem ark_mem, int convfail, N_Vector ypred,
                   N_Vector fpred, booleantype *jcurPtr, 
                   N_Vector vtemp1, N_Vector vtemp2, N_Vector vtemp3)
 {
+  UNUSED(vtemp1);
+  UNUSED(vtemp2);
+  UNUSED(vtemp3);
+  
   realtype dgamma;
   int  retval;
   ARKSpilsMem arkspils_mem;
@@ -1795,6 +1799,10 @@ int arkSpilsMassInitialize(ARKodeMem ark_mem)
 int arkSpilsMassSetup(ARKodeMem ark_mem, N_Vector vtemp1,
                       N_Vector vtemp2, N_Vector vtemp3)
 {
+  UNUSED(vtemp1);
+  UNUSED(vtemp2);
+  UNUSED(vtemp3);
+  
   int retval;
   ARKSpilsMassMem arkspils_mem;
 

--- a/src/cvode/cvode_bandpre.c
+++ b/src/cvode/cvode_bandpre.c
@@ -433,6 +433,13 @@ static int CVBandPrecSolve(realtype t, N_Vector y, N_Vector fy,
                            N_Vector r, N_Vector z, realtype gamma, 
                            realtype delta, int lr, void *bp_data)
 {
+  UNUSED(t);
+  UNUSED(y);
+  UNUSED(fy);
+  UNUSED(gamma);
+  UNUSED(delta);
+  UNUSED(lr);
+  
   CVBandPrecData pdata;
   int retval;
 

--- a/src/cvode/cvode_bbdpre.c
+++ b/src/cvode/cvode_bbdpre.c
@@ -451,6 +451,8 @@ static int CVBBDPrecSetup(realtype t, N_Vector y, N_Vector fy,
                           booleantype jok, booleantype *jcurPtr, 
                           realtype gamma, void *bbd_data)
 {
+  UNUSED(fy);
+  
   sunindextype ier;
   CVBBDPrecData pdata;
   CVodeMem cv_mem;
@@ -547,6 +549,13 @@ static int CVBBDPrecSolve(realtype t, N_Vector y, N_Vector fy,
                           realtype gamma, realtype delta,
                           int lr, void *bbd_data)
 {
+  UNUSED(t);
+  UNUSED(y);
+  UNUSED(fy);
+  UNUSED(gamma);
+  UNUSED(delta);
+  UNUSED(lr);
+  
   int retval;
   CVBBDPrecData pdata;
 

--- a/src/cvode/cvode_diag.c
+++ b/src/cvode/cvode_diag.c
@@ -317,6 +317,9 @@ static int CVDiagSetup(CVodeMem cv_mem, int convfail, N_Vector ypred,
                        N_Vector fpred, booleantype *jcurPtr, N_Vector vtemp1,
                        N_Vector vtemp2, N_Vector vtemp3)
 {
+  UNUSED(convfail);
+  UNUSED(vtemp3);
+  
   realtype r;
   N_Vector ftemp, y;
   booleantype invOK;
@@ -386,6 +389,10 @@ static int CVDiagSetup(CVodeMem cv_mem, int convfail, N_Vector ypred,
 static int CVDiagSolve(CVodeMem cv_mem, N_Vector b, N_Vector weight,
                        N_Vector ycur, N_Vector fcur)
 {
+  UNUSED(weight);
+  UNUSED(ycur);
+  UNUSED(fcur);
+  
   booleantype invOK;
   realtype r;
   CVDiagMem cvdiag_mem;

--- a/src/cvode/cvode_direct.c
+++ b/src/cvode/cvode_direct.c
@@ -374,6 +374,8 @@ int cvDlsDQJac(realtype t, N_Vector y, N_Vector fy,
                SUNMatrix Jac, void *cvode_mem, N_Vector tmp1, 
                N_Vector tmp2, N_Vector tmp3)
 {
+  UNUSED(tmp3);
+  
   int retval;
   CVodeMem cv_mem;
   cv_mem = (CVodeMem) cvode_mem;
@@ -492,6 +494,8 @@ int cvDlsDenseDQJac(realtype t, N_Vector y, N_Vector fy,
 int cvDlsBandDQJac(realtype t, N_Vector y, N_Vector fy, SUNMatrix Jac, 
                    CVodeMem cv_mem, N_Vector tmp1, N_Vector tmp2)
 {
+  UNUSED(t);
+  
   N_Vector ftemp, ytemp;
   realtype fnorm, minInc, inc, inc_inv, srur;
   realtype *col_j, *ewt_data, *fy_data, *ftemp_data, *y_data, *ytemp_data;
@@ -718,6 +722,10 @@ int cvDlsSetup(CVodeMem cv_mem, int convfail, N_Vector ypred,
 int cvDlsSolve(CVodeMem cv_mem, N_Vector b, N_Vector weight,
                N_Vector ycur, N_Vector fcur)
 {
+  UNUSED(weight);
+  UNUSED(ycur);
+  UNUSED(fcur);
+  
   int retval;
   CVDlsMem cvdls_mem;
 

--- a/src/cvode/cvode_spils.c
+++ b/src/cvode/cvode_spils.c
@@ -821,6 +821,10 @@ int cvSpilsSetup(CVodeMem cv_mem, int convfail, N_Vector ypred,
                  N_Vector fpred, booleantype *jcurPtr,
                  N_Vector vtemp1, N_Vector vtemp2, N_Vector vtemp3)
 {
+  UNUSED(vtemp1);
+  UNUSED(vtemp2);
+  UNUSED(vtemp3);
+  
   realtype dgamma;
   int  retval;
   CVSpilsMem cvspils_mem;

--- a/src/nvec_ser/nvector_serial.c
+++ b/src/nvec_ser/nvector_serial.c
@@ -61,6 +61,7 @@ static void VScaleBy_Serial(realtype a, N_Vector x);
  */
 N_Vector_ID N_VGetVectorID_Serial(N_Vector v)
 {
+  UNUSED(v);
   return SUNDIALS_NVEC_SERIAL;
 }
 

--- a/src/sundials/sundials_version.c
+++ b/src/sundials/sundials_version.c
@@ -22,7 +22,7 @@
 /* fill string with SUNDIALS version information */
 int SUNDIALSGetVersion(char *version, int len)
 {
-  if (strlen(SUNDIALS_VERSION) > len) {
+  if ((int)(strlen(SUNDIALS_VERSION)) > len) {
     return(-1);
   }
   
@@ -35,7 +35,7 @@ int SUNDIALSGetVersion(char *version, int len)
 int SUNDIALSGetVersionNumber(int *major, int *minor, int *patch, 
                              char *label, int len)
 {
-  if (strlen(SUNDIALS_VERSION_LABEL) > len) {
+  if ((int)(strlen(SUNDIALS_VERSION_LABEL)) > len) {
     return(-1);
   }
   

--- a/src/sunlinsol_band/sunlinsol_band.c
+++ b/src/sunlinsol_band/sunlinsol_band.c
@@ -137,6 +137,8 @@ SUNLinearSolver SUNBandLinearSolver(N_Vector y, SUNMatrix A)
 
 SUNLinearSolver_Type SUNLinSolGetType_Band(SUNLinearSolver S)
 {
+  UNUSED(S);
+  
   return(SUNLINEARSOLVER_DIRECT);
 }
 
@@ -191,6 +193,8 @@ int SUNLinSolSetup_Band(SUNLinearSolver S, SUNMatrix A)
 int SUNLinSolSolve_Band(SUNLinearSolver S, SUNMatrix A, N_Vector x, 
                         N_Vector b, realtype tol)
 {
+  UNUSED(tol);
+  
   realtype **A_cols, *xdata;
   sunindextype *pivots;
   

--- a/src/sunlinsol_dense/sunlinsol_dense.c
+++ b/src/sunlinsol_dense/sunlinsol_dense.c
@@ -131,6 +131,8 @@ SUNLinearSolver SUNDenseLinearSolver(N_Vector y, SUNMatrix A)
 
 SUNLinearSolver_Type SUNLinSolGetType_Dense(SUNLinearSolver S)
 {
+  UNUSED(S);
+  
   return(SUNLINEARSOLVER_DIRECT);
 }
 
@@ -179,6 +181,9 @@ int SUNLinSolSetup_Dense(SUNLinearSolver S, SUNMatrix A)
 int SUNLinSolSolve_Dense(SUNLinearSolver S, SUNMatrix A, N_Vector x, 
                         N_Vector b, realtype tol)
 {
+  UNUSED(S);
+  UNUSED(tol);
+  
   realtype **A_cols, *xdata;
   sunindextype *pivots;
   

--- a/src/sunlinsol_pcg/sunlinsol_pcg.c
+++ b/src/sunlinsol_pcg/sunlinsol_pcg.c
@@ -171,7 +171,9 @@ SUNDIALS_EXPORT int SUNPCGSetMaxl(SUNLinearSolver S, int maxl)
 
 SUNLinearSolver_Type SUNLinSolGetType_PCG(SUNLinearSolver S)
 {
-  return(SUNLINEARSOLVER_ITERATIVE);
+  UNUSED(S);
+  
+  return(SUNLINEARSOLVER_ITERATIVE);  
 }
 
 int SUNLinSolInitialize_PCG(SUNLinearSolver S)
@@ -223,6 +225,8 @@ int SUNLinSolSetPreconditioner_PCG(SUNLinearSolver S, void* PData,
 int SUNLinSolSetScalingVectors_PCG(SUNLinearSolver S, N_Vector s,
                                    N_Vector nul)
 {
+  UNUSED(nul);
+  
   /* set N_Vector pointer to integrator-supplied scaling vector
      (only use the first one), and return with success */
   if (S == NULL) return(SUNLS_MEM_NULL);
@@ -234,6 +238,8 @@ int SUNLinSolSetScalingVectors_PCG(SUNLinearSolver S, N_Vector s,
 
 int SUNLinSolSetup_PCG(SUNLinearSolver S, SUNMatrix nul)
 {
+  UNUSED(nul);
+  
   int ier;
   PSetupFn Psetup;
   void* PData;
@@ -263,6 +269,8 @@ int SUNLinSolSetup_PCG(SUNLinearSolver S, SUNMatrix nul)
 int SUNLinSolSolve_PCG(SUNLinearSolver S, SUNMatrix nul, N_Vector x, 
                        N_Vector b, realtype delta)
 {
+  UNUSED(nul);
+  
   /* local data and shortcut variables */
   realtype alpha, beta, r0_norm, rho, rz, rz_old;
   N_Vector r, p, z, Ap, w;

--- a/src/sunlinsol_spbcgs/sunlinsol_spbcgs.c
+++ b/src/sunlinsol_spbcgs/sunlinsol_spbcgs.c
@@ -186,6 +186,8 @@ SUNDIALS_EXPORT int SUNSPBCGSSetMaxl(SUNLinearSolver S, int maxl)
 
 SUNLinearSolver_Type SUNLinSolGetType_SPBCGS(SUNLinearSolver S)
 {
+  UNUSED(S);
+  
   return(SUNLINEARSOLVER_ITERATIVE);
 }
 
@@ -280,6 +282,8 @@ int SUNLinSolSetup_SPBCGS(SUNLinearSolver S, SUNMatrix A)
 int SUNLinSolSolve_SPBCGS(SUNLinearSolver S, SUNMatrix A, N_Vector x, 
                           N_Vector b, realtype delta)
 {
+  UNUSED(A);
+  
   /* local data and shortcut variables */
   realtype alpha, beta, omega, omega_denom, beta_num, beta_denom, r_norm, rho;
   N_Vector r_star, r, p, q, u, Ap, vtemp;

--- a/src/sunlinsol_spbcgs/sunlinsol_spbcgs.c
+++ b/src/sunlinsol_spbcgs/sunlinsol_spbcgs.c
@@ -254,6 +254,8 @@ int SUNLinSolSetScalingVectors_SPBCGS(SUNLinearSolver S, N_Vector s1,
 
 int SUNLinSolSetup_SPBCGS(SUNLinearSolver S, SUNMatrix A)
 {
+  UNUSED(A);
+  
   int ier;
   PSetupFn Psetup;
   void* PData;

--- a/src/sunlinsol_spbcgs/sunlinsol_spbcgs.c
+++ b/src/sunlinsol_spbcgs/sunlinsol_spbcgs.c
@@ -28,6 +28,7 @@
 
 #include <sunlinsol/sunlinsol_spbcgs.h>
 #include <sundials/sundials_math.h>
+#include <sundials/sundials_types.h>
 
 #define ZERO RCONST(0.0)
 #define ONE  RCONST(1.0)

--- a/src/sunlinsol_spfgmr/sunlinsol_spfgmr.c
+++ b/src/sunlinsol_spfgmr/sunlinsol_spfgmr.c
@@ -28,6 +28,7 @@
 
 #include <sunlinsol/sunlinsol_spfgmr.h>
 #include <sundials/sundials_math.h>
+#include <sundials/sundials_types.h>
 
 #define ZERO RCONST(0.0)
 #define ONE  RCONST(1.0)

--- a/src/sunlinsol_spfgmr/sunlinsol_spfgmr.c
+++ b/src/sunlinsol_spfgmr/sunlinsol_spfgmr.c
@@ -328,6 +328,8 @@ int SUNLinSolSetScalingVectors_SPFGMR(SUNLinearSolver S, N_Vector s1,
 
 int SUNLinSolSetup_SPFGMR(SUNLinearSolver S, SUNMatrix A)
 {
+  UNUNSED(A);
+  
   int ier;
   PSetupFn Psetup;
   void* PData;
@@ -356,6 +358,8 @@ int SUNLinSolSetup_SPFGMR(SUNLinearSolver S, SUNMatrix A)
 int SUNLinSolSolve_SPFGMR(SUNLinearSolver S, SUNMatrix A, N_Vector x, 
                          N_Vector b, realtype delta)
 {
+  UNUSED(A);
+  
   /* local data and shortcut variables */
   N_Vector *V, *Z, xcor, vtemp, s1, s2;
   realtype **Hes, *givens, *yg, *res_norm;

--- a/src/sunlinsol_spfgmr/sunlinsol_spfgmr.c
+++ b/src/sunlinsol_spfgmr/sunlinsol_spfgmr.c
@@ -329,7 +329,7 @@ int SUNLinSolSetScalingVectors_SPFGMR(SUNLinearSolver S, N_Vector s1,
 
 int SUNLinSolSetup_SPFGMR(SUNLinearSolver S, SUNMatrix A)
 {
-  UNUNSED(A);
+  UNUSED(A);
   
   int ier;
   PSetupFn Psetup;

--- a/src/sunlinsol_spfgmr/sunlinsol_spfgmr.c
+++ b/src/sunlinsol_spfgmr/sunlinsol_spfgmr.c
@@ -205,6 +205,8 @@ SUNDIALS_EXPORT int SUNSPFGMRSetMaxRestarts(SUNLinearSolver S, int maxrs)
 
 SUNLinearSolver_Type SUNLinSolGetType_SPFGMR(SUNLinearSolver S)
 {
+  UNUSED(S);
+  
   return(SUNLINEARSOLVER_ITERATIVE);
 }
 

--- a/src/sunlinsol_spgmr/sunlinsol_spgmr.c
+++ b/src/sunlinsol_spgmr/sunlinsol_spgmr.c
@@ -201,6 +201,8 @@ SUNDIALS_EXPORT int SUNSPGMRSetMaxRestarts(SUNLinearSolver S, int maxrs)
 
 SUNLinearSolver_Type SUNLinSolGetType_SPGMR(SUNLinearSolver S)
 {
+  UNUSED(S);
+  
   return(SUNLINEARSOLVER_ITERATIVE);
 }
 
@@ -317,6 +319,8 @@ int SUNLinSolSetScalingVectors_SPGMR(SUNLinearSolver S, N_Vector s1,
 
 int SUNLinSolSetup_SPGMR(SUNLinearSolver S, SUNMatrix A)
 {
+  UNUSED(A);
+  
   int ier;
   PSetupFn Psetup;
   void* PData;
@@ -345,6 +349,8 @@ int SUNLinSolSetup_SPGMR(SUNLinearSolver S, SUNMatrix A)
 int SUNLinSolSolve_SPGMR(SUNLinearSolver S, SUNMatrix A, N_Vector x, 
                          N_Vector b, realtype delta)
 {
+  UNUSED(A);
+  
   /* local data and shortcut variables */
   N_Vector *V, xcor, vtemp, s1, s2;
   realtype **Hes, *givens, *yg, *res_norm;

--- a/src/sunlinsol_sptfqmr/sunlinsol_sptfqmr.c
+++ b/src/sunlinsol_sptfqmr/sunlinsol_sptfqmr.c
@@ -193,6 +193,8 @@ SUNDIALS_EXPORT int SUNSPTFQMRSetMaxl(SUNLinearSolver S, int maxl)
 
 SUNLinearSolver_Type SUNLinSolGetType_SPTFQMR(SUNLinearSolver S)
 {
+  UNUSED(S);
+  
   return(SUNLINEARSOLVER_ITERATIVE);
 }
 

--- a/src/sunlinsol_sptfqmr/sunlinsol_sptfqmr.c
+++ b/src/sunlinsol_sptfqmr/sunlinsol_sptfqmr.c
@@ -263,6 +263,8 @@ int SUNLinSolSetScalingVectors_SPTFQMR(SUNLinearSolver S,
 
 int SUNLinSolSetup_SPTFQMR(SUNLinearSolver S, SUNMatrix A)
 {
+  UNUSED(A);
+  
   int ier;
   PSetupFn Psetup;
   void* PData;
@@ -291,6 +293,8 @@ int SUNLinSolSetup_SPTFQMR(SUNLinearSolver S, SUNMatrix A)
 int SUNLinSolSolve_SPTFQMR(SUNLinearSolver S, SUNMatrix A, N_Vector x, 
                            N_Vector b, realtype delta)
 {
+  UNUSED(A);
+  
   /* local data and shortcut variables */
   realtype alpha, tau, eta, beta, c, sigma, v_bar, omega;
   realtype rho[2];

--- a/src/sunlinsol_sptfqmr/sunlinsol_sptfqmr.c
+++ b/src/sunlinsol_sptfqmr/sunlinsol_sptfqmr.c
@@ -27,6 +27,7 @@
 
 #include <sunlinsol/sunlinsol_sptfqmr.h>
 #include <sundials/sundials_math.h>
+#include <sundials/sundials_types.h>
 
 #define ZERO RCONST(0.0)
 #define ONE  RCONST(1.0)

--- a/src/sunmat_band/sunmatrix_band.c
+++ b/src/sunmat_band/sunmatrix_band.c
@@ -234,6 +234,7 @@ realtype* SUNBandMatrix_Column(SUNMatrix A, sunindextype j)
 
 SUNMatrix_ID SUNMatGetID_Band(SUNMatrix A)
 {
+  UNUSED(A);
   return SUNMATRIX_BAND;
 }
 
@@ -424,6 +425,8 @@ static booleantype SMCompatible_Band(SUNMatrix A, SUNMatrix B)
 
 static booleantype SMCompatible2_Band(SUNMatrix A, N_Vector x, N_Vector y)
 {
+  UNUSED(y);
+  
   /*   matrix must be SUNMATRIX_BAND */
   if (SUNMatGetID(A) != SUNMATRIX_BAND)
     return SUNFALSE;

--- a/src/sunmat_dense/sunmatrix_dense.c
+++ b/src/sunmat_dense/sunmatrix_dense.c
@@ -202,6 +202,7 @@ realtype* SUNDenseMatrix_Column(SUNMatrix A, sunindextype j)
 
 SUNMatrix_ID SUNMatGetID_Dense(SUNMatrix A)
 {
+  UNUSED(A);
   return SUNMATRIX_DENSE;
 }
 
@@ -338,6 +339,9 @@ static booleantype SMCompatible_Dense(SUNMatrix A, SUNMatrix B)
 
 static booleantype SMCompatible2_Dense(SUNMatrix A, N_Vector x, N_Vector y)
 {
+  UNUSED(A);
+  UNUSED(y);
+  
   /*   vectors must be one of {SERIAL, OPENMP, PTHREADS} */ 
   if ( (N_VGetVectorID(x) != SUNDIALS_NVEC_SERIAL) &&
        (N_VGetVectorID(x) != SUNDIALS_NVEC_OPENMP) &&

--- a/src/sunmat_sparse/sunmatrix_sparse.c
+++ b/src/sunmat_sparse/sunmatrix_sparse.c
@@ -430,6 +430,7 @@ sunindextype* SUNSparseMatrix_IndexPointers(SUNMatrix A)
 
 SUNMatrix_ID SUNMatGetID_Sparse(SUNMatrix A)
 {
+  UNUSED(A);
   return SUNMATRIX_SPARSE;
 }
 
@@ -901,7 +902,9 @@ static booleantype SMCompatible_Sparse(SUNMatrix A, SUNMatrix B)
 
 static booleantype SMCompatible2_Sparse(SUNMatrix A, N_Vector x, N_Vector y)
 {
-
+  UNUSED(A);
+  UNUSED(y);
+  
   /*   vectors must be one of {SERIAL, OPENMP, PTHREADS} */ 
   if ( (N_VGetVectorID(x) != SUNDIALS_NVEC_SERIAL) &&
        (N_VGetVectorID(x) != SUNDIALS_NVEC_OPENMP) &&


### PR DESCRIPTION
We propose to fix all warnings in SUNDIALS.

The overwhelming majority of the warnings generated are due to unused variables. While these warnings tend to be harmless, they have three important negative consequences.

1. Encourage an *ignore the warnings* attitude, which can be dangerous.
2. Generate too much noise that may hide real issues. 
2. Break builds that treat warnings as errors.

We propose to add the `UNUSED` macro:

```
#define UNUSED(x) (void)(x)
```

to the `sundials_types.h` header file. It is used as follows:

```
void foo(int x) {
    UNUSED(x);
    /* do something */
}
```

The macro approach has the following advantages:

1. No performance penalty (it generates no code)
2. Self-documenting
3. Easy to `grep`

We also fixed a warning triggered by a signed/unsigned comparison.

There are still several warnings to fix (all related to unused variables), which we highlight below. We will complete them if this pull request is accepted.

```
/examples/arkode/C_serial/ark_KrylovDemo_prec.c:730:55: warning: unused parameter 't' [-Wunused-parameter]
/examples/arkode/C_serial/ark_KrylovDemo_prec.c:766:69: warning: unused parameter 'jok' [-Wunused-parameter]
/examples/arkode/C_serial/ark_KrylovDemo_prec.c:877:28: warning: unused parameter 'tn' [-Wunused-parameter]
/examples/arkode/C_serial/ark_KrylovDemo_prec.c:877:41: warning: unused parameter 'c' [-Wunused-parameter]
/examples/arkode/C_serial/ark_KrylovDemo_prec.c:877:53: warning: unused parameter 'fc' [-Wunused-parameter]
/examples/arkode/C_serial/ark_KrylovDemo_prec.c:878:44: warning: unused parameter 'delta' [-Wunused-parameter]
/examples/arkode/C_serial/ark_KrylovDemo_prec.c:878:55: warning: unused parameter 'lr' [-Wunused-parameter]
/examples/arkode/C_serial/ark_analytic.c:223:25: warning: unused parameter 't' [-Wunused-parameter]
/examples/arkode/C_serial/ark_analytic.c:223:37: warning: unused parameter 'y' [-Wunused-parameter]
/examples/arkode/C_serial/ark_analytic.c:223:49: warning: unused parameter 'fy' [-Wunused-parameter]
/examples/arkode/C_serial/ark_analytic.c:224:42: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/arkode/C_serial/ark_analytic.c:224:57: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/arkode/C_serial/ark_analytic.c:224:72: warning: unused parameter 'tmp3' [-Wunused-parameter]
/examples/arkode/C_serial/ark_analytic_nonlin.c:154:59: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/arkode/C_serial/ark_brusselator.c:257:23: warning: unused parameter 't' [-Wunused-parameter]
/examples/arkode/C_serial/ark_brusselator.c:276:25: warning: unused parameter 't' [-Wunused-parameter]
/examples/arkode/C_serial/ark_brusselator.c:276:49: warning: unused parameter 'fy' [-Wunused-parameter]
/examples/arkode/C_serial/ark_brusselator.c:277:25: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/arkode/C_serial/ark_brusselator.c:277:40: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/arkode/C_serial/ark_brusselator.c:277:55: warning: unused parameter 'tmp3' [-Wunused-parameter]
/examples/arkode/C_serial/ark_brusselator1D.c:330:23: warning: unused parameter 't' [-Wunused-parameter]
/examples/arkode/C_serial/ark_brusselator1D.c:379:25: warning: unused parameter 't' [-Wunused-parameter]
/examples/arkode/C_serial/ark_brusselator1D.c:379:49: warning: unused parameter 'fy' [-Wunused-parameter]
/examples/arkode/C_serial/ark_brusselator1D.c:380:42: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/arkode/C_serial/ark_brusselator1D.c:380:57: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/arkode/C_serial/ark_brusselator1D.c:380:72: warning: unused parameter 'tmp3' [-Wunused-parameter]
/examples/arkode/C_serial/ark_brusselator_fp.c:232:24: warning: unused parameter 't' [-Wunused-parameter]
/examples/arkode/C_serial/ark_brusselator_fp.c:248:24: warning: unused parameter 't' [-Wunused-parameter]
/examples/arkode/C_serial/ark_heat1D.c:239:23: warning: unused parameter 't' [-Wunused-parameter]
/examples/arkode/C_serial/ark_heat1D.c:269:50: warning: unused parameter 't' [-Wunused-parameter]
/examples/arkode/C_serial/ark_heat1D.c:269:62: warning: unused parameter 'y' [-Wunused-parameter]
/examples/arkode/C_serial/ark_heat1D.c:270:18: warning: unused parameter 'fy' [-Wunused-parameter]
/examples/arkode/C_serial/ark_heat1D.c:270:48: warning: unused parameter 'tmp' [-Wunused-parameter]
/examples/arkode/C_serial/ark_heat1D_adapt.c:293:23: warning: unused parameter 't' [-Wunused-parameter]
/examples/arkode/C_serial/ark_heat1D_adapt.c:331:50: warning: unused parameter 't' [-Wunused-parameter]
/examples/arkode/C_serial/ark_heat1D_adapt.c:331:62: warning: unused parameter 'y' [-Wunused-parameter]
/examples/arkode/C_serial/ark_heat1D_adapt.c:332:25: warning: unused parameter 'fy' [-Wunused-parameter]
/examples/arkode/C_serial/ark_heat1D_adapt.c:332:55: warning: unused parameter 'tmp' [-Wunused-parameter]
/examples/arkode/C_serial/ark_robertson.c:230:23: warning: unused parameter 't' [-Wunused-parameter]
/examples/arkode/C_serial/ark_robertson.c:230:59: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/arkode/C_serial/ark_robertson.c:245:25: warning: unused parameter 't' [-Wunused-parameter]
/examples/arkode/C_serial/ark_robertson.c:245:49: warning: unused parameter 'fy' [-Wunused-parameter]
/examples/arkode/C_serial/ark_robertson.c:246:22: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/arkode/C_serial/ark_robertson.c:246:42: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/arkode/C_serial/ark_robertson.c:246:57: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/arkode/C_serial/ark_robertson.c:246:72: warning: unused parameter 'tmp3' [-Wunused-parameter]
/examples/arkode/C_serial/ark_robertson.c:307:43: warning: unused parameter 't' [-Wunused-parameter]
/examples/arkode/C_serial/ark_robertson_root.c:249:23: warning: unused parameter 't' [-Wunused-parameter]
/examples/arkode/C_serial/ark_robertson_root.c:249:59: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/arkode/C_serial/ark_robertson_root.c:264:25: warning: unused parameter 't' [-Wunused-parameter]
/examples/arkode/C_serial/ark_robertson_root.c:264:49: warning: unused parameter 'fy' [-Wunused-parameter]
/examples/arkode/C_serial/ark_robertson_root.c:265:22: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/arkode/C_serial/ark_robertson_root.c:265:42: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/arkode/C_serial/ark_robertson_root.c:265:57: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/arkode/C_serial/ark_robertson_root.c:265:72: warning: unused parameter 'tmp3' [-Wunused-parameter]
/examples/arkode/C_serial/ark_robertson_root.c:286:23: warning: unused parameter 't' [-Wunused-parameter]
/examples/arkode/C_serial/ark_robertson_root.c:286:60: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvode/serial/cvAdvDiff_bnd.c:205:23: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvode/serial/cvAdvDiff_bnd.c:250:25: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvode/serial/cvAdvDiff_bnd.c:250:37: warning: unused parameter 'u' [-Wunused-parameter]
/examples/cvode/serial/cvAdvDiff_bnd.c:250:49: warning: unused parameter 'fu' [-Wunused-parameter]
/examples/cvode/serial/cvAdvDiff_bnd.c:252:25: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/cvode/serial/cvAdvDiff_bnd.c:252:40: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/cvode/serial/cvAdvDiff_bnd.c:252:55: warning: unused parameter 'tmp3' [-Wunused-parameter]
/examples/cvode/serial/cvDirectDemo_ls.c:320:24: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvode/serial/cvDirectDemo_ls.c:320:60: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvode/serial/cvDirectDemo_ls.c:333:26: warning: unused parameter 'tn' [-Wunused-parameter]
/examples/cvode/serial/cvDirectDemo_ls.c:333:51: warning: unused parameter 'fy' [-Wunused-parameter]
/examples/cvode/serial/cvDirectDemo_ls.c:334:23: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvode/serial/cvDirectDemo_ls.c:334:43: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/cvode/serial/cvDirectDemo_ls.c:334:58: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/cvode/serial/cvDirectDemo_ls.c:334:73: warning: unused parameter 'tmp3' [-Wunused-parameter]
/examples/cvode/serial/cvDirectDemo_ls.c:516:24: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvode/serial/cvDirectDemo_ls.c:516:60: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvode/serial/cvDirectDemo_ls.c:544:26: warning: unused parameter 'tn' [-Wunused-parameter]
/examples/cvode/serial/cvDirectDemo_ls.c:544:39: warning: unused parameter 'y' [-Wunused-parameter]
/examples/cvode/serial/cvDirectDemo_ls.c:544:51: warning: unused parameter 'fy' [-Wunused-parameter]
/examples/cvode/serial/cvDirectDemo_ls.c:545:23: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvode/serial/cvDirectDemo_ls.c:545:43: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/cvode/serial/cvDirectDemo_ls.c:545:58: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/cvode/serial/cvDirectDemo_ls.c:545:73: warning: unused parameter 'tmp3' [-Wunused-parameter]
/examples/cvode/serial/cvDiurnal_kry.c:542:37: warning: unused parameter 'fu' [-Wunused-parameter]
/examples/cvode/serial/cvDiurnal_kry.c:543:42: warning: unused parameter 'tmp' [-Wunused-parameter]
/examples/cvode/serial/cvDiurnal_kry.c:688:29: warning: unused parameter 'tn' [-Wunused-parameter]
/examples/cvode/serial/cvDiurnal_kry.c:688:54: warning: unused parameter 'fu' [-Wunused-parameter]
/examples/cvode/serial/cvDiurnal_kry.c:775:28: warning: unused parameter 'tn' [-Wunused-parameter]
/examples/cvode/serial/cvDiurnal_kry.c:775:41: warning: unused parameter 'u' [-Wunused-parameter]
/examples/cvode/serial/cvDiurnal_kry.c:775:53: warning: unused parameter 'fu' [-Wunused-parameter]
/examples/cvode/serial/cvDiurnal_kry.c:776:28: warning: unused parameter 'gamma' [-Wunused-parameter]
/examples/cvode/serial/cvDiurnal_kry.c:776:44: warning: unused parameter 'delta' [-Wunused-parameter]
/examples/cvode/serial/cvDiurnal_kry.c:776:55: warning: unused parameter 'lr' [-Wunused-parameter]
/examples/cvode/serial/cvKrylovDemo_ls.c:616:29: warning: unused parameter 'tn' [-Wunused-parameter]
/examples/cvode/serial/cvKrylovDemo_ls.c:616:54: warning: unused parameter 'fu' [-Wunused-parameter]
/examples/cvode/serial/cvKrylovDemo_ls.c:703:28: warning: unused parameter 'tn' [-Wunused-parameter]
/examples/cvode/serial/cvKrylovDemo_ls.c:703:41: warning: unused parameter 'u' [-Wunused-parameter]
/examples/cvode/serial/cvKrylovDemo_ls.c:703:53: warning: unused parameter 'fu' [-Wunused-parameter]
/examples/cvode/serial/cvKrylovDemo_ls.c:705:28: warning: unused parameter 'gamma' [-Wunused-parameter]
/examples/cvode/serial/cvKrylovDemo_ls.c:705:44: warning: unused parameter 'delta' [-Wunused-parameter]
/examples/cvode/serial/cvKrylovDemo_ls.c:706:23: warning: unused parameter 'lr' [-Wunused-parameter]
/examples/cvode/serial/cvKrylovDemo_prec.c:712:55: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvode/serial/cvKrylovDemo_prec.c:748:69: warning: unused parameter 'jok' [-Wunused-parameter]
/examples/cvode/serial/cvKrylovDemo_prec.c:859:28: warning: unused parameter 'tn' [-Wunused-parameter]
/examples/cvode/serial/cvKrylovDemo_prec.c:859:41: warning: unused parameter 'c' [-Wunused-parameter]
/examples/cvode/serial/cvKrylovDemo_prec.c:859:53: warning: unused parameter 'fc' [-Wunused-parameter]
/examples/cvode/serial/cvKrylovDemo_prec.c:860:44: warning: unused parameter 'delta' [-Wunused-parameter]
/examples/cvode/serial/cvKrylovDemo_prec.c:860:55: warning: unused parameter 'lr' [-Wunused-parameter]
/examples/cvode/serial/cvRoberts_dns.c:230:23: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvode/serial/cvRoberts_dns.c:230:59: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvode/serial/cvRoberts_dns.c:247:23: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvode/serial/cvRoberts_dns.c:247:60: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvode/serial/cvRoberts_dns.c:262:25: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvode/serial/cvRoberts_dns.c:262:49: warning: unused parameter 'fy' [-Wunused-parameter]
/examples/cvode/serial/cvRoberts_dns.c:263:22: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvode/serial/cvRoberts_dns.c:263:42: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/cvode/serial/cvRoberts_dns.c:263:57: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/cvode/serial/cvRoberts_dns.c:263:72: warning: unused parameter 'tmp3' [-Wunused-parameter]
/examples/cvode/serial/cvRoberts_dns.c:386:43: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvode/serial/cvRoberts_dns_uw.c:216:23: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvode/serial/cvRoberts_dns_uw.c:216:59: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvode/serial/cvRoberts_dns_uw.c:233:23: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvode/serial/cvRoberts_dns_uw.c:233:60: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvode/serial/cvRoberts_dns_uw.c:248:25: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvode/serial/cvRoberts_dns_uw.c:248:49: warning: unused parameter 'fy' [-Wunused-parameter]
/examples/cvode/serial/cvRoberts_dns_uw.c:249:22: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvode/serial/cvRoberts_dns_uw.c:249:42: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/cvode/serial/cvRoberts_dns_uw.c:249:57: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/cvode/serial/cvRoberts_dns_uw.c:249:72: warning: unused parameter 'tmp3' [-Wunused-parameter]
/examples/cvode/serial/cvRoberts_dns_uw.c:274:46: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_ASAi_bnd.c:116:14: warning: unused parameter 'argc' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_ASAi_bnd.c:116:26: warning: unused parameter 'argv' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_ASAi_bnd.c:283:23: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_ASAi_bnd.c:330:25: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_ASAi_bnd.c:330:37: warning: unused parameter 'u' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_ASAi_bnd.c:330:49: warning: unused parameter 'fu' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_ASAi_bnd.c:331:42: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_ASAi_bnd.c:331:57: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_ASAi_bnd.c:331:72: warning: unused parameter 'tmp3' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_ASAi_bnd.c:374:24: warning: unused parameter 'tB' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_ASAi_bnd.c:374:37: warning: unused parameter 'u' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_ASAi_bnd.c:424:26: warning: unused parameter 'tB' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_ASAi_bnd.c:424:39: warning: unused parameter 'u' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_ASAi_bnd.c:424:51: warning: unused parameter 'uB' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_ASAi_bnd.c:424:64: warning: unused parameter 'fuB' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_ASAi_bnd.c:425:44: warning: unused parameter 'tmp1B' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_ASAi_bnd.c:425:60: warning: unused parameter 'tmp2B' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_ASAi_bnd.c:425:76: warning: unused parameter 'tmp3B' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_FSA_non.c:246:23: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_bnd.c:205:23: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_bnd.c:250:25: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_bnd.c:250:37: warning: unused parameter 'u' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_bnd.c:250:49: warning: unused parameter 'fu' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_bnd.c:251:42: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_bnd.c:251:57: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/cvodes/serial/cvsAdvDiff_bnd.c:251:72: warning: unused parameter 'tmp3' [-Wunused-parameter]
/examples/cvodes/serial/cvsDirectDemo_ls.c:321:24: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsDirectDemo_ls.c:321:60: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvodes/serial/cvsDirectDemo_ls.c:334:26: warning: unused parameter 'tn' [-Wunused-parameter]
/examples/cvodes/serial/cvsDirectDemo_ls.c:334:51: warning: unused parameter 'fy' [-Wunused-parameter]
/examples/cvodes/serial/cvsDirectDemo_ls.c:335:23: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvodes/serial/cvsDirectDemo_ls.c:335:43: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/cvodes/serial/cvsDirectDemo_ls.c:335:58: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/cvodes/serial/cvsDirectDemo_ls.c:335:73: warning: unused parameter 'tmp3' [-Wunused-parameter]
/examples/cvodes/serial/cvsDirectDemo_ls.c:518:24: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsDirectDemo_ls.c:518:60: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvodes/serial/cvsDirectDemo_ls.c:546:26: warning: unused parameter 'tn' [-Wunused-parameter]
/examples/cvodes/serial/cvsDirectDemo_ls.c:546:39: warning: unused parameter 'y' [-Wunused-parameter]
/examples/cvodes/serial/cvsDirectDemo_ls.c:546:51: warning: unused parameter 'fy' [-Wunused-parameter]
/examples/cvodes/serial/cvsDirectDemo_ls.c:547:23: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvodes/serial/cvsDirectDemo_ls.c:547:43: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/cvodes/serial/cvsDirectDemo_ls.c:547:58: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/cvodes/serial/cvsDirectDemo_ls.c:547:73: warning: unused parameter 'tmp3' [-Wunused-parameter]
/examples/cvodes/serial/cvsDiurnal_FSA_kry.c:435:29: warning: unused parameter 'tn' [-Wunused-parameter]
/examples/cvodes/serial/cvsDiurnal_FSA_kry.c:435:54: warning: unused parameter 'fy' [-Wunused-parameter]
/examples/cvodes/serial/cvsDiurnal_FSA_kry.c:534:28: warning: unused parameter 'tn' [-Wunused-parameter]
/examples/cvodes/serial/cvsDiurnal_FSA_kry.c:534:41: warning: unused parameter 'y' [-Wunused-parameter]
/examples/cvodes/serial/cvsDiurnal_FSA_kry.c:534:53: warning: unused parameter 'fy' [-Wunused-parameter]
/examples/cvodes/serial/cvsDiurnal_FSA_kry.c:536:28: warning: unused parameter 'gamma' [-Wunused-parameter]
/examples/cvodes/serial/cvsDiurnal_FSA_kry.c:536:44: warning: unused parameter 'delta' [-Wunused-parameter]
/examples/cvodes/serial/cvsDiurnal_FSA_kry.c:537:23: warning: unused parameter 'lr' [-Wunused-parameter]
/examples/cvodes/serial/cvsDiurnal_kry.c:543:37: warning: unused parameter 'fu' [-Wunused-parameter]
/examples/cvodes/serial/cvsDiurnal_kry.c:544:42: warning: unused parameter 'tmp' [-Wunused-parameter]
/examples/cvodes/serial/cvsDiurnal_kry.c:689:29: warning: unused parameter 'tn' [-Wunused-parameter]
/examples/cvodes/serial/cvsDiurnal_kry.c:689:54: warning: unused parameter 'fu' [-Wunused-parameter]
/examples/cvodes/serial/cvsDiurnal_kry.c:777:28: warning: unused parameter 'tn' [-Wunused-parameter]
/examples/cvodes/serial/cvsDiurnal_kry.c:777:41: warning: unused parameter 'u' [-Wunused-parameter]
/examples/cvodes/serial/cvsDiurnal_kry.c:777:53: warning: unused parameter 'fu' [-Wunused-parameter]
/examples/cvodes/serial/cvsDiurnal_kry.c:779:28: warning: unused parameter 'gamma' [-Wunused-parameter]
/examples/cvodes/serial/cvsDiurnal_kry.c:779:44: warning: unused parameter 'delta' [-Wunused-parameter]
/examples/cvodes/serial/cvsDiurnal_kry.c:780:23: warning: unused parameter 'lr' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAi_kry.c:222:14: warning: unused parameter 'argc' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAi_kry.c:222:26: warning: unused parameter 'argv' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAi_kry.c:443:32: warning: unused parameter 'jok' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAi_kry.c:539:28: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAi_kry.c:539:40: warning: unused parameter 'c' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAi_kry.c:539:52: warning: unused parameter 'fc' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAi_kry.c:541:44: warning: unused parameter 'delta' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAi_kry.c:542:23: warning: unused parameter 'lr' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAi_kry.c:658:30: warning: unused parameter 'cB' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAi_kry.c:658:60: warning: unused parameter 'jok' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAi_kry.c:748:29: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAi_kry.c:748:41: warning: unused parameter 'c' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAi_kry.c:749:29: warning: unused parameter 'cB' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAi_kry.c:749:42: warning: unused parameter 'fcB' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAi_kry.c:751:45: warning: unused parameter 'delta' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAi_kry.c:752:24: warning: unused parameter 'lr' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAi_kry.c:949:55: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAi_kry.c:976:56: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAp_kry.c:217:14: warning: unused parameter 'argc' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAp_kry.c:217:26: warning: unused parameter 'argv' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAp_kry.c:432:32: warning: unused parameter 'jok' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAp_kry.c:524:28: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAp_kry.c:524:40: warning: unused parameter 'c' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAp_kry.c:524:52: warning: unused parameter 'fc' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAp_kry.c:526:44: warning: unused parameter 'delta' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAp_kry.c:527:23: warning: unused parameter 'lr' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAp_kry.c:633:30: warning: unused parameter 'cB' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAp_kry.c:633:60: warning: unused parameter 'jok' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAp_kry.c:721:29: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAp_kry.c:721:41: warning: unused parameter 'c' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAp_kry.c:722:29: warning: unused parameter 'cB' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAp_kry.c:722:42: warning: unused parameter 'fcB' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAp_kry.c:724:45: warning: unused parameter 'delta' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAp_kry.c:725:24: warning: unused parameter 'lr' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAp_kry.c:915:36: warning: unused parameter 'is' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAp_kry.c:947:55: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsFoodWeb_ASAp_kry.c:974:56: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsHessian_ASA_FSA.c:626:23: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsHessian_ASA_FSA.c:647:24: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsHessian_ASA_FSA.c:647:60: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvodes/serial/cvsHessian_ASA_FSA.c:660:19: warning: unused parameter 'Ns' [-Wunused-parameter]
/examples/cvodes/serial/cvsHessian_ASA_FSA.c:660:32: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsHessian_ASA_FSA.c:661:36: warning: unused parameter 'ydot' [-Wunused-parameter]
/examples/cvodes/serial/cvsHessian_ASA_FSA.c:664:24: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/cvodes/serial/cvsHessian_ASA_FSA.c:664:39: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/cvodes/serial/cvsHessian_ASA_FSA.c:711:20: warning: unused parameter 'Ns' [-Wunused-parameter]
/examples/cvodes/serial/cvsHessian_ASA_FSA.c:711:33: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsHessian_ASA_FSA.c:713:25: warning: unused parameter 'yQdot' [-Wunused-parameter]
/examples/cvodes/serial/cvsHessian_ASA_FSA.c:714:22: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvodes/serial/cvsHessian_ASA_FSA.c:715:25: warning: unused parameter 'tmp' [-Wunused-parameter]
/examples/cvodes/serial/cvsHessian_ASA_FSA.c:715:39: warning: unused parameter 'tmpQ' [-Wunused-parameter]
/examples/cvodes/serial/cvsHessian_ASA_FSA.c:745:25: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsHessian_ASA_FSA.c:787:26: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsHessian_ASA_FSA.c:829:25: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsHessian_ASA_FSA.c:872:26: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsHessian_ASA_FSA.c:92:14: warning: unused parameter 'argc' [-Wunused-parameter]
/examples/cvodes/serial/cvsHessian_ASA_FSA.c:92:26: warning: unused parameter 'argv' [-Wunused-parameter]
/examples/cvodes/serial/cvsKrylovDemo_ls.c:616:29: warning: unused parameter 'tn' [-Wunused-parameter]
/examples/cvodes/serial/cvsKrylovDemo_ls.c:616:54: warning: unused parameter 'fu' [-Wunused-parameter]
/examples/cvodes/serial/cvsKrylovDemo_ls.c:703:28: warning: unused parameter 'tn' [-Wunused-parameter]
/examples/cvodes/serial/cvsKrylovDemo_ls.c:703:41: warning: unused parameter 'u' [-Wunused-parameter]
/examples/cvodes/serial/cvsKrylovDemo_ls.c:703:53: warning: unused parameter 'fu' [-Wunused-parameter]
/examples/cvodes/serial/cvsKrylovDemo_ls.c:705:28: warning: unused parameter 'gamma' [-Wunused-parameter]
/examples/cvodes/serial/cvsKrylovDemo_ls.c:705:44: warning: unused parameter 'delta' [-Wunused-parameter]
/examples/cvodes/serial/cvsKrylovDemo_ls.c:706:23: warning: unused parameter 'lr' [-Wunused-parameter]
/examples/cvodes/serial/cvsKrylovDemo_prec.c:713:55: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsKrylovDemo_prec.c:749:69: warning: unused parameter 'jok' [-Wunused-parameter]
/examples/cvodes/serial/cvsKrylovDemo_prec.c:860:28: warning: unused parameter 'tn' [-Wunused-parameter]
/examples/cvodes/serial/cvsKrylovDemo_prec.c:860:41: warning: unused parameter 'c' [-Wunused-parameter]
/examples/cvodes/serial/cvsKrylovDemo_prec.c:860:53: warning: unused parameter 'fc' [-Wunused-parameter]
/examples/cvodes/serial/cvsKrylovDemo_prec.c:861:44: warning: unused parameter 'delta' [-Wunused-parameter]
/examples/cvodes/serial/cvsKrylovDemo_prec.c:861:55: warning: unused parameter 'lr' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_ASAi_dns.c:133:14: warning: unused parameter 'argc' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_ASAi_dns.c:133:26: warning: unused parameter 'argv' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_ASAi_dns.c:513:23: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_ASAi_dns.c:534:25: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_ASAi_dns.c:534:49: warning: unused parameter 'fy' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_ASAi_dns.c:535:42: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_ASAi_dns.c:535:57: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_ASAi_dns.c:535:72: warning: unused parameter 'tmp3' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_ASAi_dns.c:556:24: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_ASAi_dns.c:556:60: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_ASAi_dns.c:567:46: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_ASAi_dns.c:591:24: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_ASAi_dns.c:627:26: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_ASAi_dns.c:627:50: warning: unused parameter 'yB' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_ASAi_dns.c:627:63: warning: unused parameter 'fyB' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_ASAi_dns.c:628:44: warning: unused parameter 'tmp1B' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_ASAi_dns.c:628:60: warning: unused parameter 'tmp2B' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_ASAi_dns.c:628:76: warning: unused parameter 'tmp3B' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_ASAi_dns.c:654:25: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_ASAi_dns.c:655:38: warning: unused parameter 'user_dataB' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_FSA_dns.c:300:23: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_FSA_dns.c:322:25: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_FSA_dns.c:322:49: warning: unused parameter 'fy' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_FSA_dns.c:323:42: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_FSA_dns.c:323:57: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_FSA_dns.c:323:72: warning: unused parameter 'tmp3' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_FSA_dns.c:344:19: warning: unused parameter 'Ns' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_FSA_dns.c:344:32: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_FSA_dns.c:344:56: warning: unused parameter 'ydot' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_FSA_dns.c:346:41: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_FSA_dns.c:346:56: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_FSA_dns.c:390:46: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_dns.c:230:23: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_dns.c:230:59: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_dns.c:247:23: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_dns.c:247:60: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_dns.c:262:25: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_dns.c:262:49: warning: unused parameter 'fy' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_dns.c:263:22: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_dns.c:263:42: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_dns.c:263:57: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_dns.c:263:72: warning: unused parameter 'tmp3' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_dns.c:386:43: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_dns_uw.c:216:23: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_dns_uw.c:216:59: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_dns_uw.c:233:23: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_dns_uw.c:233:60: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_dns_uw.c:248:25: warning: unused parameter 't' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_dns_uw.c:248:49: warning: unused parameter 'fy' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_dns_uw.c:249:22: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_dns_uw.c:249:42: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_dns_uw.c:249:57: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_dns_uw.c:249:72: warning: unused parameter 'tmp3' [-Wunused-parameter]
/examples/cvodes/serial/cvsRoberts_dns_uw.c:274:46: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/ida/serial/idaFoodWeb_bnd.c:562:27: warning: unused parameter 'tcalc' [-Wunused-parameter]
/examples/ida/serial/idaFoodWeb_kry.c:375:29: warning: unused parameter 'tt' [-Wunused-parameter]
/examples/ida/serial/idaFoodWeb_kry.c:376:41: warning: unused parameter 'rr' [-Wunused-parameter]
/examples/ida/serial/idaFoodWeb_kry.c:443:28: warning: unused parameter 'tt' [-Wunused-parameter]
/examples/ida/serial/idaFoodWeb_kry.c:444:14: warning: unused parameter 'cc' [-Wunused-parameter]
/examples/ida/serial/idaFoodWeb_kry.c:444:27: warning: unused parameter 'cp' [-Wunused-parameter]
/examples/ida/serial/idaFoodWeb_kry.c:444:40: warning: unused parameter 'rr' [-Wunused-parameter]
/examples/ida/serial/idaFoodWeb_kry.c:446:14: warning: unused parameter 'cj' [-Wunused-parameter]
/examples/ida/serial/idaFoodWeb_kry.c:446:27: warning: unused parameter 'dalta' [-Wunused-parameter]
/examples/ida/serial/idaFoodWeb_kry.c:693:27: warning: unused parameter 'tcalc' [-Wunused-parameter]
/examples/ida/serial/idaHeat2D_bnd.c:216:22: warning: unused parameter 'tres' [-Wunused-parameter]
/examples/ida/serial/idaHeat2D_kry.c:294:22: warning: unused parameter 'tt' [-Wunused-parameter]
/examples/ida/serial/idaHeat2D_kry.c:345:25: warning: unused parameter 'tt' [-Wunused-parameter]
/examples/ida/serial/idaHeat2D_kry.c:346:25: warning: unused parameter 'uu' [-Wunused-parameter]
/examples/ida/serial/idaHeat2D_kry.c:346:38: warning: unused parameter 'up' [-Wunused-parameter]
/examples/ida/serial/idaHeat2D_kry.c:346:51: warning: unused parameter 'rr' [-Wunused-parameter]
/examples/ida/serial/idaHeat2D_kry.c:383:25: warning: unused parameter 'tt' [-Wunused-parameter]
/examples/ida/serial/idaHeat2D_kry.c:384:25: warning: unused parameter 'uu' [-Wunused-parameter]
/examples/ida/serial/idaHeat2D_kry.c:384:38: warning: unused parameter 'up' [-Wunused-parameter]
/examples/ida/serial/idaHeat2D_kry.c:384:51: warning: unused parameter 'rr' [-Wunused-parameter]
/examples/ida/serial/idaHeat2D_kry.c:386:25: warning: unused parameter 'c_j' [-Wunused-parameter]
/examples/ida/serial/idaHeat2D_kry.c:386:39: warning: unused parameter 'delta' [-Wunused-parameter]
/examples/ida/serial/idaKrylovDemo_ls.c:317:22: warning: unused parameter 'tt' [-Wunused-parameter]
/examples/ida/serial/idaKrylovDemo_ls.c:368:25: warning: unused parameter 'tt' [-Wunused-parameter]
/examples/ida/serial/idaKrylovDemo_ls.c:369:25: warning: unused parameter 'uu' [-Wunused-parameter]
/examples/ida/serial/idaKrylovDemo_ls.c:369:38: warning: unused parameter 'up' [-Wunused-parameter]
/examples/ida/serial/idaKrylovDemo_ls.c:369:51: warning: unused parameter 'rr' [-Wunused-parameter]
/examples/ida/serial/idaKrylovDemo_ls.c:406:25: warning: unused parameter 'tt' [-Wunused-parameter]
/examples/ida/serial/idaKrylovDemo_ls.c:407:25: warning: unused parameter 'uu' [-Wunused-parameter]
/examples/ida/serial/idaKrylovDemo_ls.c:407:38: warning: unused parameter 'up' [-Wunused-parameter]
/examples/ida/serial/idaKrylovDemo_ls.c:407:51: warning: unused parameter 'rr' [-Wunused-parameter]
/examples/ida/serial/idaKrylovDemo_ls.c:409:25: warning: unused parameter 'c_j' [-Wunused-parameter]
/examples/ida/serial/idaKrylovDemo_ls.c:409:39: warning: unused parameter 'delta' [-Wunused-parameter]
/examples/ida/serial/idaKrylovDemo_ls.c:512:65: warning: unused parameter 'linsolver' [-Wunused-parameter]
/examples/ida/serial/idaRoberts_dns.c:206:21: warning: unused parameter 'tres' [-Wunused-parameter]
/examples/ida/serial/idaRoberts_dns.c:206:72: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/ida/serial/idaRoberts_dns.c:226:26: warning: unused parameter 't' [-Wunused-parameter]
/examples/ida/serial/idaRoberts_dns.c:226:51: warning: unused parameter 'yp' [-Wunused-parameter]
/examples/ida/serial/idaRoberts_dns.c:227:23: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/ida/serial/idaRoberts_dns.c:243:21: warning: unused parameter 'tt' [-Wunused-parameter]
/examples/ida/serial/idaRoberts_dns.c:244:34: warning: unused parameter 'yp' [-Wunused-parameter]
/examples/ida/serial/idaRoberts_dns.c:244:47: warning: unused parameter 'resvec' [-Wunused-parameter]
/examples/ida/serial/idaRoberts_dns.c:245:32: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/ida/serial/idaRoberts_dns.c:246:21: warning: unused parameter 'tempv1' [-Wunused-parameter]
/examples/ida/serial/idaRoberts_dns.c:246:38: warning: unused parameter 'tempv2' [-Wunused-parameter]
/examples/ida/serial/idaRoberts_dns.c:246:55: warning: unused parameter 'tempv3' [-Wunused-parameter]
/examples/ida/serial/idaRoberts_dns.c:422:43: warning: unused parameter 't' [-Wunused-parameter]
/examples/ida/serial/idaSlCrank_dns.c:246:20: warning: unused parameter 'tres' [-Wunused-parameter]
/examples/ida/serial/idaSlCrank_dns.c:306:64: warning: unused parameter 'y' [-Wunused-parameter]
/examples/idas/serial/idasAkzoNob_ASAi_dns.c:282:25: warning: unused parameter 't' [-Wunused-parameter]
/examples/idas/serial/idasAkzoNob_ASAi_dns.c:338:26: warning: unused parameter 't' [-Wunused-parameter]
/examples/idas/serial/idasAkzoNob_ASAi_dns.c:338:51: warning: unused parameter 'yp' [-Wunused-parameter]
/examples/idas/serial/idasAkzoNob_ASAi_dns.c:338:76: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/idas/serial/idasAkzoNob_ASAi_dns.c:352:26: warning: unused parameter 'tt' [-Wunused-parameter]
/examples/idas/serial/idasAkzoNob_ASAi_dns.c:353:39: warning: unused parameter 'yp' [-Wunused-parameter]
/examples/idas/serial/idasAkzoNob_ASAi_dns.c:431:34: warning: unused parameter 'tfinal' [-Wunused-parameter]
/examples/idas/serial/idasAkzoNob_ASAi_dns.c:431:64: warning: unused parameter 'ypB' [-Wunused-parameter]
/examples/idas/serial/idasAkzoNob_dns.c:221:25: warning: unused parameter 't' [-Wunused-parameter]
/examples/idas/serial/idasAkzoNob_dns.c:277:26: warning: unused parameter 't' [-Wunused-parameter]
/examples/idas/serial/idasAkzoNob_dns.c:277:51: warning: unused parameter 'yp' [-Wunused-parameter]
/examples/idas/serial/idasAkzoNob_dns.c:277:76: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/idas/serial/idasAkzoNob_dns.c:284:65: warning: unused parameter 'y' [-Wunused-parameter]
/examples/idas/serial/idasFoodWeb_bnd.c:563:27: warning: unused parameter 'tcalc' [-Wunused-parameter]
/examples/idas/serial/idasHeat2D_bnd.c:216:22: warning: unused parameter 'tres' [-Wunused-parameter]
/examples/idas/serial/idasHeat2D_kry.c:294:22: warning: unused parameter 'tt' [-Wunused-parameter]
/examples/idas/serial/idasHeat2D_kry.c:345:25: warning: unused parameter 'tt' [-Wunused-parameter]
/examples/idas/serial/idasHeat2D_kry.c:346:25: warning: unused parameter 'uu' [-Wunused-parameter]
/examples/idas/serial/idasHeat2D_kry.c:346:38: warning: unused parameter 'up' [-Wunused-parameter]
/examples/idas/serial/idasHeat2D_kry.c:346:51: warning: unused parameter 'rr' [-Wunused-parameter]
/examples/idas/serial/idasHeat2D_kry.c:383:25: warning: unused parameter 'tt' [-Wunused-parameter]
/examples/idas/serial/idasHeat2D_kry.c:384:25: warning: unused parameter 'uu' [-Wunused-parameter]
/examples/idas/serial/idasHeat2D_kry.c:384:38: warning: unused parameter 'up' [-Wunused-parameter]
/examples/idas/serial/idasHeat2D_kry.c:384:51: warning: unused parameter 'rr' [-Wunused-parameter]
/examples/idas/serial/idasHeat2D_kry.c:386:25: warning: unused parameter 'c_j' [-Wunused-parameter]
/examples/idas/serial/idasHeat2D_kry.c:386:39: warning: unused parameter 'delta' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:121:14: warning: unused parameter 'argc' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:121:26: warning: unused parameter 'argv' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:524:25: warning: unused parameter 'tres' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:545:21: warning: unused parameter 'Ns' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:545:34: warning: unused parameter 't' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:546:52: warning: unused parameter 'resval' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:549:26: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:549:41: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:549:56: warning: unused parameter 'tmp3' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:607:26: warning: unused parameter 't' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:607:51: warning: unused parameter 'yp' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:607:76: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:618:22: warning: unused parameter 'Ns' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:618:35: warning: unused parameter 't' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:619:40: warning: unused parameter 'yp' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:620:43: warning: unused parameter 'ypS' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:621:27: warning: unused parameter 'rrQ' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:622:24: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:623:27: warning: unused parameter 'yytmp' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:623:43: warning: unused parameter 'yptmp' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:623:59: warning: unused parameter 'tmpQS' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:649:28: warning: unused parameter 'tt' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:650:41: warning: unused parameter 'yp' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:651:44: warning: unused parameter 'ypS' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:699:29: warning: unused parameter 'tt' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:700:40: warning: unused parameter 'yp' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:701:43: warning: unused parameter 'ypS' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:702:41: warning: unused parameter 'ypB' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:740:28: warning: unused parameter 'tt' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:741:41: warning: unused parameter 'yp' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:742:44: warning: unused parameter 'ypS' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:790:29: warning: unused parameter 'tt' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:791:40: warning: unused parameter 'yp' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:792:43: warning: unused parameter 'ypS' [-Wunused-parameter]
/examples/idas/serial/idasHessian_ASA_FSA.c:793:41: warning: unused parameter 'ypB' [-Wunused-parameter]
/examples/idas/serial/idasKrylovDemo_ls.c:317:22: warning: unused parameter 'tt' [-Wunused-parameter]
/examples/idas/serial/idasKrylovDemo_ls.c:368:25: warning: unused parameter 'tt' [-Wunused-parameter]
/examples/idas/serial/idasKrylovDemo_ls.c:369:25: warning: unused parameter 'uu' [-Wunused-parameter]
/examples/idas/serial/idasKrylovDemo_ls.c:369:38: warning: unused parameter 'up' [-Wunused-parameter]
/examples/idas/serial/idasKrylovDemo_ls.c:369:51: warning: unused parameter 'rr' [-Wunused-parameter]
/examples/idas/serial/idasKrylovDemo_ls.c:406:25: warning: unused parameter 'tt' [-Wunused-parameter]
/examples/idas/serial/idasKrylovDemo_ls.c:407:25: warning: unused parameter 'uu' [-Wunused-parameter]
/examples/idas/serial/idasKrylovDemo_ls.c:407:38: warning: unused parameter 'up' [-Wunused-parameter]
/examples/idas/serial/idasKrylovDemo_ls.c:407:51: warning: unused parameter 'rr' [-Wunused-parameter]
/examples/idas/serial/idasKrylovDemo_ls.c:409:25: warning: unused parameter 'c_j' [-Wunused-parameter]
/examples/idas/serial/idasKrylovDemo_ls.c:409:39: warning: unused parameter 'delta' [-Wunused-parameter]
/examples/idas/serial/idasKrylovDemo_ls.c:512:65: warning: unused parameter 'linsolver' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:141:14: warning: unused parameter 'argc' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:141:26: warning: unused parameter 'argv' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:518:25: warning: unused parameter 't' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:543:25: warning: unused parameter 't' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:544:38: warning: unused parameter 'yp' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:544:51: warning: unused parameter 'resvec' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:546:25: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:546:40: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:546:55: warning: unused parameter 'tmp3' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:576:26: warning: unused parameter 't' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:576:51: warning: unused parameter 'yp' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:576:76: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:586:46: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:611:26: warning: unused parameter 'tt' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:612:40: warning: unused parameter 'yp' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:649:26: warning: unused parameter 'tt' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:650:39: warning: unused parameter 'yp' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:651:26: warning: unused parameter 'yyB' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:651:40: warning: unused parameter 'ypB' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:651:54: warning: unused parameter 'rrB' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:653:26: warning: unused parameter 'tmp1B' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:653:42: warning: unused parameter 'tmp2B' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:653:58: warning: unused parameter 'tmp3B' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:680:27: warning: unused parameter 'tt' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:681:40: warning: unused parameter 'yp' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:682:41: warning: unused parameter 'ypB' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:683:39: warning: unused parameter 'user_dataB' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_ASAi_dns.c:716:64: warning: unused parameter 'ypB' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_FSA_dns.c:360:25: warning: unused parameter 't' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_FSA_dns.c:392:21: warning: unused parameter 'Ns' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_FSA_dns.c:392:34: warning: unused parameter 't' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_FSA_dns.c:393:52: warning: unused parameter 'resval' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_FSA_dns.c:396:26: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_FSA_dns.c:396:41: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_FSA_dns.c:396:56: warning: unused parameter 'tmp3' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_FSA_dns.c:457:26: warning: unused parameter 't' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_FSA_dns.c:457:50: warning: unused parameter 'yp' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_FSA_dns.c:558:34: warning: unused parameter 'y' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_FSA_dns.c:558:46: warning: unused parameter 'yp' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_dns.c:206:21: warning: unused parameter 'tres' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_dns.c:206:72: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_dns.c:226:26: warning: unused parameter 't' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_dns.c:226:51: warning: unused parameter 'yp' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_dns.c:227:23: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_dns.c:243:21: warning: unused parameter 'tt' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_dns.c:244:34: warning: unused parameter 'yp' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_dns.c:244:47: warning: unused parameter 'resvec' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_dns.c:245:32: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_dns.c:246:21: warning: unused parameter 'tempv1' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_dns.c:246:38: warning: unused parameter 'tempv2' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_dns.c:246:55: warning: unused parameter 'tempv3' [-Wunused-parameter]
/examples/idas/serial/idasRoberts_dns.c:422:43: warning: unused parameter 't' [-Wunused-parameter]
/examples/idas/serial/idasSlCrank_FSA_dns.c:428:27: warning: unused parameter 'tres' [-Wunused-parameter]
/examples/idas/serial/idasSlCrank_FSA_dns.c:488:26: warning: unused parameter 't' [-Wunused-parameter]
/examples/idas/serial/idasSlCrank_FSA_dns.c:488:51: warning: unused parameter 'yp' [-Wunused-parameter]
/examples/idas/serial/idasSlCrank_FSA_dns.c:510:22: warning: unused parameter 'Ns' [-Wunused-parameter]
/examples/idas/serial/idasSlCrank_FSA_dns.c:510:35: warning: unused parameter 't' [-Wunused-parameter]
/examples/idas/serial/idasSlCrank_FSA_dns.c:510:60: warning: unused parameter 'yp' [-Wunused-parameter]
/examples/idas/serial/idasSlCrank_FSA_dns.c:511:43: warning: unused parameter 'ypS' [-Wunused-parameter]
/examples/idas/serial/idasSlCrank_FSA_dns.c:511:57: warning: unused parameter 'rrQ' [-Wunused-parameter]
/examples/idas/serial/idasSlCrank_FSA_dns.c:512:45: warning: unused parameter 'yytmp' [-Wunused-parameter]
/examples/idas/serial/idasSlCrank_FSA_dns.c:512:61: warning: unused parameter 'yptmp' [-Wunused-parameter]
/examples/idas/serial/idasSlCrank_FSA_dns.c:512:77: warning: unused parameter 'tmpQS' [-Wunused-parameter]
/examples/idas/serial/idasSlCrank_dns.c:273:27: warning: unused parameter 'tres' [-Wunused-parameter]
/examples/idas/serial/idasSlCrank_dns.c:333:26: warning: unused parameter 't' [-Wunused-parameter]
/examples/idas/serial/idasSlCrank_dns.c:333:51: warning: unused parameter 'yp' [-Wunused-parameter]
/examples/idas/serial/idasSlCrank_dns.c:355:65: warning: unused parameter 'y' [-Wunused-parameter]
/examples/kinsol/serial/kinFoodWeb_kry.c:424:33: warning: unused parameter 'cc' [-Wunused-parameter]
/examples/kinsol/serial/kinFoodWeb_kry.c:424:46: warning: unused parameter 'cscale' [-Wunused-parameter]
/examples/kinsol/serial/kinFoodWeb_kry.c:425:33: warning: unused parameter 'fval' [-Wunused-parameter]
/examples/kinsol/serial/kinFoodWeb_kry.c:425:48: warning: unused parameter 'fscale' [-Wunused-parameter]
/examples/kinsol/serial/kinKrylovDemo_ls.c:521:33: warning: unused parameter 'cc' [-Wunused-parameter]
/examples/kinsol/serial/kinKrylovDemo_ls.c:521:46: warning: unused parameter 'cscale' [-Wunused-parameter]
/examples/kinsol/serial/kinKrylovDemo_ls.c:522:33: warning: unused parameter 'fval' [-Wunused-parameter]
/examples/kinsol/serial/kinKrylovDemo_ls.c:522:48: warning: unused parameter 'fscale' [-Wunused-parameter]
/examples/kinsol/serial/kinLaplace_bnd.c:222:47: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/kinsol/serial/kinLaplace_picard_bnd.c:224:47: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/kinsol/serial/kinLaplace_picard_bnd.c:278:25: warning: unused parameter 'u' [-Wunused-parameter]
/examples/kinsol/serial/kinLaplace_picard_bnd.c:278:37: warning: unused parameter 'f' [-Wunused-parameter]
/examples/kinsol/serial/kinLaplace_picard_bnd.c:279:22: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/kinsol/serial/kinLaplace_picard_bnd.c:279:42: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/kinsol/serial/kinLaplace_picard_bnd.c:279:57: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/kinsol/serial/kinRoberts_fp.c:196:54: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/kinsol/serial/kinRoboKin_dns.c:173:47: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/kinsol/serial/kinRoboKin_dns.c:248:37: warning: unused parameter 'f' [-Wunused-parameter]
/examples/kinsol/serial/kinRoboKin_dns.c:249:22: warning: unused parameter 'user_data' [-Wunused-parameter]
/examples/kinsol/serial/kinRoboKin_dns.c:249:42: warning: unused parameter 'tmp1' [-Wunused-parameter]
/examples/kinsol/serial/kinRoboKin_dns.c:249:57: warning: unused parameter 'tmp2' [-Wunused-parameter]
/examples/nvector/test_nvector.c:1127:34: warning: unused parameter 'local_length' [-Wunused-parameter]
/examples/nvector/test_nvector.c:1195:59: warning: unused parameter 'local_length' [-Wunused-parameter]
/examples/nvector/test_nvector.c:1230:18: warning: unused parameter 'local_length' [-Wunused-parameter]
/examples/nvector/test_nvector.c:1230:45: warning: unused parameter 'global_length' [-Wunused-parameter]
/examples/nvector/test_nvector.c:1333:34: warning: unused parameter 'local_length' [-Wunused-parameter]
/examples/nvector/test_nvector.c:1367:45: warning: unused parameter 'local_length' [-Wunused-parameter]
/examples/sunlinsol/pcg/serial/test_sunlinsol_pcg_serial.c:358:18: warning: unused parameter 'Data' [-Wunused-parameter]
/examples/sunlinsol/pcg/serial/test_sunlinsol_pcg_serial.c:361:65: warning: unused parameter 'tol' [-Wunused-parameter]
/examples/sunlinsol/pcg/serial/test_sunlinsol_pcg_serial.c:361:74: warning: unused parameter 'lr' [-Wunused-parameter]
/examples/sunlinsol/spbcgs/serial/test_sunlinsol_spbcgs_serial.c:433:18: warning: unused parameter 'Data' [-Wunused-parameter]
/examples/sunlinsol/spbcgs/serial/test_sunlinsol_spbcgs_serial.c:436:65: warning: unused parameter 'tol' [-Wunused-parameter]
/examples/sunlinsol/spbcgs/serial/test_sunlinsol_spbcgs_serial.c:436:74: warning: unused parameter 'lr' [-Wunused-parameter]
/examples/sunlinsol/spfgmr/serial/test_sunlinsol_spfgmr_serial.c:436:18: warning: unused parameter 'Data' [-Wunused-parameter]
/examples/sunlinsol/spfgmr/serial/test_sunlinsol_spfgmr_serial.c:439:65: warning: unused parameter 'tol' [-Wunused-parameter]
/examples/sunlinsol/spfgmr/serial/test_sunlinsol_spfgmr_serial.c:439:74: warning: unused parameter 'lr' [-Wunused-parameter]
/examples/sunlinsol/spgmr/serial/test_sunlinsol_spgmr_serial.c:443:18: warning: unused parameter 'Data' [-Wunused-parameter]
/examples/sunlinsol/spgmr/serial/test_sunlinsol_spgmr_serial.c:446:65: warning: unused parameter 'tol' [-Wunused-parameter]
/examples/sunlinsol/spgmr/serial/test_sunlinsol_spgmr_serial.c:446:74: warning: unused parameter 'lr' [-Wunused-parameter]
/examples/sunlinsol/sptfqmr/serial/test_sunlinsol_sptfqmr_serial.c:438:18: warning: unused parameter 'Data' [-Wunused-parameter]
/examples/sunlinsol/sptfqmr/serial/test_sunlinsol_sptfqmr_serial.c:441:65: warning: unused parameter 'tol' [-Wunused-parameter]
/examples/sunlinsol/sptfqmr/serial/test_sunlinsol_sptfqmr_serial.c:441:74: warning: unused parameter 'lr' [-Wunused-parameter]
/examples/sunmatrix/band/test_sunmatrix_band.c:260:33: warning: unused parameter 'A' [-Wunused-parameter]
/src/cvodes/cvodes.c:8644:43: warning: unused parameter 'cv_mem' [-Wunused-parameter]
/src/cvodes/cvodes.c:8644:43: warning: unused parameter 'cv_mem' [-Wunused-parameter]
/src/cvodes/cvodes.c:8858:30: warning: unused parameter 'Ns' [-Wunused-parameter]
/src/cvodes/cvodes.c:8858:30: warning: unused parameter 'Ns' [-Wunused-parameter]
/src/cvodes/cvodes_bandpre.c:435:37: warning: unused parameter 't' [-Wunused-parameter]
/src/cvodes/cvodes_bandpre.c:435:37: warning: unused parameter 't' [-Wunused-parameter]
/src/cvodes/cvodes_bandpre.c:435:49: warning: unused parameter 'y' [-Wunused-parameter]
/src/cvodes/cvodes_bandpre.c:435:49: warning: unused parameter 'y' [-Wunused-parameter]
/src/cvodes/cvodes_bandpre.c:435:61: warning: unused parameter 'fy' [-Wunused-parameter]
/src/cvodes/cvodes_bandpre.c:435:61: warning: unused parameter 'fy' [-Wunused-parameter]
/src/cvodes/cvodes_bandpre.c:436:61: warning: unused parameter 'gamma' [-Wunused-parameter]
/src/cvodes/cvodes_bandpre.c:436:61: warning: unused parameter 'gamma' [-Wunused-parameter]
/src/cvodes/cvodes_bandpre.c:437:37: warning: unused parameter 'delta' [-Wunused-parameter]
/src/cvodes/cvodes_bandpre.c:437:37: warning: unused parameter 'delta' [-Wunused-parameter]
/src/cvodes/cvodes_bandpre.c:437:48: warning: unused parameter 'lr' [-Wunused-parameter]
/src/cvodes/cvodes_bandpre.c:437:48: warning: unused parameter 'lr' [-Wunused-parameter]
/src/cvodes/cvodes_bbdpre.c:464:60: warning: unused parameter 'fy' [-Wunused-parameter]
/src/cvodes/cvodes_bbdpre.c:464:60: warning: unused parameter 'fy' [-Wunused-parameter]
/src/cvodes/cvodes_bbdpre.c:559:36: warning: unused parameter 't' [-Wunused-parameter]
/src/cvodes/cvodes_bbdpre.c:559:36: warning: unused parameter 't' [-Wunused-parameter]
/src/cvodes/cvodes_bbdpre.c:559:48: warning: unused parameter 'y' [-Wunused-parameter]
/src/cvodes/cvodes_bbdpre.c:559:48: warning: unused parameter 'y' [-Wunused-parameter]
/src/cvodes/cvodes_bbdpre.c:559:60: warning: unused parameter 'fy' [-Wunused-parameter]
/src/cvodes/cvodes_bbdpre.c:559:60: warning: unused parameter 'fy' [-Wunused-parameter]
/src/cvodes/cvodes_bbdpre.c:561:36: warning: unused parameter 'gamma' [-Wunused-parameter]
/src/cvodes/cvodes_bbdpre.c:561:36: warning: unused parameter 'gamma' [-Wunused-parameter]
/src/cvodes/cvodes_bbdpre.c:561:52: warning: unused parameter 'delta' [-Wunused-parameter]
/src/cvodes/cvodes_bbdpre.c:561:52: warning: unused parameter 'delta' [-Wunused-parameter]
/src/cvodes/cvodes_bbdpre.c:562:31: warning: unused parameter 'lr' [-Wunused-parameter]
/src/cvodes/cvodes_bbdpre.c:562:31: warning: unused parameter 'lr' [-Wunused-parameter]
/src/cvodes/cvodes_diag.c:326:45: warning: unused parameter 'convfail' [-Wunused-parameter]
/src/cvodes/cvodes_diag.c:326:45: warning: unused parameter 'convfail' [-Wunused-parameter]
/src/cvodes/cvodes_diag.c:328:50: warning: unused parameter 'vtemp3' [-Wunused-parameter]
/src/cvodes/cvodes_diag.c:328:50: warning: unused parameter 'vtemp3' [-Wunused-parameter]
/src/cvodes/cvodes_diag.c:396:62: warning: unused parameter 'weight' [-Wunused-parameter]
/src/cvodes/cvodes_diag.c:396:62: warning: unused parameter 'weight' [-Wunused-parameter]
/src/cvodes/cvodes_diag.c:397:33: warning: unused parameter 'ycur' [-Wunused-parameter]
/src/cvodes/cvodes_diag.c:397:33: warning: unused parameter 'ycur' [-Wunused-parameter]
/src/cvodes/cvodes_diag.c:397:48: warning: unused parameter 'fcur' [-Wunused-parameter]
/src/cvodes/cvodes_diag.c:397:48: warning: unused parameter 'fcur' [-Wunused-parameter]
/src/cvodes/cvodes_direct.c:383:40: warning: unused parameter 'tmp3' [-Wunused-parameter]
/src/cvodes/cvodes_direct.c:383:40: warning: unused parameter 'tmp3' [-Wunused-parameter]
/src/cvodes/cvodes_direct.c:500:29: warning: unused parameter 't' [-Wunused-parameter]
/src/cvodes/cvodes_direct.c:500:29: warning: unused parameter 't' [-Wunused-parameter]
/src/cvodes/cvodes_direct.c:725:54: warning: unused parameter 'weight' [-Wunused-parameter]
/src/cvodes/cvodes_direct.c:725:54: warning: unused parameter 'weight' [-Wunused-parameter]
/src/cvodes/cvodes_direct.c:726:25: warning: unused parameter 'ycur' [-Wunused-parameter]
/src/cvodes/cvodes_direct.c:726:25: warning: unused parameter 'ycur' [-Wunused-parameter]
/src/cvodes/cvodes_direct.c:726:40: warning: unused parameter 'fcur' [-Wunused-parameter]
/src/cvodes/cvodes_direct.c:726:40: warning: unused parameter 'fcur' [-Wunused-parameter]
/src/cvodes/cvodes_spils.c:881:27: warning: unused parameter 'tmp1' [-Wunused-parameter]
/src/cvodes/cvodes_spils.c:881:27: warning: unused parameter 'tmp1' [-Wunused-parameter]
/src/cvodes/cvodes_spils.c:881:42: warning: unused parameter 'tmp2' [-Wunused-parameter]
/src/cvodes/cvodes_spils.c:881:42: warning: unused parameter 'tmp2' [-Wunused-parameter]
/src/cvodes/cvodes_spils.c:881:57: warning: unused parameter 'tmp3' [-Wunused-parameter]
/src/cvodes/cvodes_spils.c:881:57: warning: unused parameter 'tmp3' [-Wunused-parameter]
/src/ida/ida_bbdpre.c:441:37: warning: unused parameter 'rr' [-Wunused-parameter]
/src/ida/ida_bbdpre.c:441:37: warning: unused parameter 'rr' [-Wunused-parameter]
/src/ida/ida_bbdpre.c:491:37: warning: unused parameter 'tt' [-Wunused-parameter]
/src/ida/ida_bbdpre.c:491:37: warning: unused parameter 'tt' [-Wunused-parameter]
/src/ida/ida_bbdpre.c:491:50: warning: unused parameter 'yy' [-Wunused-parameter]
/src/ida/ida_bbdpre.c:491:50: warning: unused parameter 'yy' [-Wunused-parameter]
/src/ida/ida_bbdpre.c:491:63: warning: unused parameter 'yp' [-Wunused-parameter]
/src/ida/ida_bbdpre.c:491:63: warning: unused parameter 'yp' [-Wunused-parameter]
/src/ida/ida_bbdpre.c:492:37: warning: unused parameter 'rr' [-Wunused-parameter]
/src/ida/ida_bbdpre.c:492:37: warning: unused parameter 'rr' [-Wunused-parameter]
/src/ida/ida_bbdpre.c:493:37: warning: unused parameter 'c_j' [-Wunused-parameter]
/src/ida/ida_bbdpre.c:493:37: warning: unused parameter 'c_j' [-Wunused-parameter]
/src/ida/ida_bbdpre.c:493:51: warning: unused parameter 'delta' [-Wunused-parameter]
/src/ida/ida_bbdpre.c:493:51: warning: unused parameter 'delta' [-Wunused-parameter]
/src/ida/ida_direct.c:506:43: warning: unused parameter 'c_j' [-Wunused-parameter]
/src/ida/ida_direct.c:506:43: warning: unused parameter 'c_j' [-Wunused-parameter]
/src/ida/ida_direct.c:726:54: warning: unused parameter 'weight' [-Wunused-parameter]
/src/ida/ida_direct.c:726:54: warning: unused parameter 'weight' [-Wunused-parameter]
/src/ida/ida_direct.c:727:26: warning: unused parameter 'ycur' [-Wunused-parameter]
/src/ida/ida_direct.c:727:26: warning: unused parameter 'ycur' [-Wunused-parameter]
/src/ida/ida_direct.c:727:41: warning: unused parameter 'ypcur' [-Wunused-parameter]
/src/ida/ida_direct.c:727:41: warning: unused parameter 'ypcur' [-Wunused-parameter]
/src/ida/ida_direct.c:727:57: warning: unused parameter 'rescur' [-Wunused-parameter]
/src/ida/ida_direct.c:727:57: warning: unused parameter 'rescur' [-Wunused-parameter]
/src/ida/ida_spils.c:743:38: warning: unused parameter 'lr' [-Wunused-parameter]
/src/ida/ida_spils.c:743:38: warning: unused parameter 'lr' [-Wunused-parameter]
/src/ida/ida_spils.c:890:28: warning: unused parameter 'vt1' [-Wunused-parameter]
/src/ida/ida_spils.c:890:28: warning: unused parameter 'vt1' [-Wunused-parameter]
/src/ida/ida_spils.c:890:42: warning: unused parameter 'vt2' [-Wunused-parameter]
/src/ida/ida_spils.c:890:42: warning: unused parameter 'vt2' [-Wunused-parameter]
/src/ida/ida_spils.c:890:56: warning: unused parameter 'vt3' [-Wunused-parameter]
/src/ida/ida_spils.c:890:56: warning: unused parameter 'vt3' [-Wunused-parameter]
/src/idas/idas.c:6223:46: warning: unused parameter 'IDA_mem' [-Wunused-parameter]
/src/idas/idas.c:6223:46: warning: unused parameter 'IDA_mem' [-Wunused-parameter]
/src/idas/idas.c:6768:30: warning: unused parameter 'Ns' [-Wunused-parameter]
/src/idas/idas.c:6768:30: warning: unused parameter 'Ns' [-Wunused-parameter]
/src/idas/idas_bbdpre.c:458:37: warning: unused parameter 'rr' [-Wunused-parameter]
/src/idas/idas_bbdpre.c:458:37: warning: unused parameter 'rr' [-Wunused-parameter]
/src/idas/idas_bbdpre.c:508:37: warning: unused parameter 'tt' [-Wunused-parameter]
/src/idas/idas_bbdpre.c:508:37: warning: unused parameter 'tt' [-Wunused-parameter]
/src/idas/idas_bbdpre.c:508:50: warning: unused parameter 'yy' [-Wunused-parameter]
/src/idas/idas_bbdpre.c:508:50: warning: unused parameter 'yy' [-Wunused-parameter]
/src/idas/idas_bbdpre.c:508:63: warning: unused parameter 'yp' [-Wunused-parameter]
/src/idas/idas_bbdpre.c:508:63: warning: unused parameter 'yp' [-Wunused-parameter]
/src/idas/idas_bbdpre.c:509:37: warning: unused parameter 'rr' [-Wunused-parameter]
/src/idas/idas_bbdpre.c:509:37: warning: unused parameter 'rr' [-Wunused-parameter]
/src/idas/idas_bbdpre.c:510:37: warning: unused parameter 'c_j' [-Wunused-parameter]
/src/idas/idas_bbdpre.c:510:37: warning: unused parameter 'c_j' [-Wunused-parameter]
/src/idas/idas_bbdpre.c:510:51: warning: unused parameter 'delta' [-Wunused-parameter]
/src/idas/idas_bbdpre.c:510:51: warning: unused parameter 'delta' [-Wunused-parameter]
/src/idas/idas_direct.c:523:43: warning: unused parameter 'c_j' [-Wunused-parameter]
/src/idas/idas_direct.c:523:43: warning: unused parameter 'c_j' [-Wunused-parameter]
/src/idas/idas_direct.c:746:54: warning: unused parameter 'weight' [-Wunused-parameter]
/src/idas/idas_direct.c:746:54: warning: unused parameter 'weight' [-Wunused-parameter]
/src/idas/idas_direct.c:747:26: warning: unused parameter 'ycur' [-Wunused-parameter]
/src/idas/idas_direct.c:747:26: warning: unused parameter 'ycur' [-Wunused-parameter]
/src/idas/idas_direct.c:747:41: warning: unused parameter 'ypcur' [-Wunused-parameter]
/src/idas/idas_direct.c:747:41: warning: unused parameter 'ypcur' [-Wunused-parameter]
/src/idas/idas_direct.c:747:57: warning: unused parameter 'rescur' [-Wunused-parameter]
/src/idas/idas_direct.c:747:57: warning: unused parameter 'rescur' [-Wunused-parameter]
/src/idas/idas_spils.c:792:38: warning: unused parameter 'lr' [-Wunused-parameter]
/src/idas/idas_spils.c:792:38: warning: unused parameter 'lr' [-Wunused-parameter]
/src/idas/idas_spils.c:940:28: warning: unused parameter 'vt1' [-Wunused-parameter]
/src/idas/idas_spils.c:940:28: warning: unused parameter 'vt1' [-Wunused-parameter]
/src/idas/idas_spils.c:940:42: warning: unused parameter 'vt2' [-Wunused-parameter]
/src/idas/idas_spils.c:940:42: warning: unused parameter 'vt2' [-Wunused-parameter]
/src/idas/idas_spils.c:940:56: warning: unused parameter 'vt3' [-Wunused-parameter]
/src/idas/idas_spils.c:940:56: warning: unused parameter 'vt3' [-Wunused-parameter]
/src/kinsol/kinsol_bbdpre.c:385:37: warning: unused parameter 'fval' [-Wunused-parameter]
/src/kinsol/kinsol_bbdpre.c:385:37: warning: unused parameter 'fval' [-Wunused-parameter]
/src/kinsol/kinsol_bbdpre.c:385:52: warning: unused parameter 'fscale' [-Wunused-parameter]
/src/kinsol/kinsol_bbdpre.c:385:52: warning: unused parameter 'fscale' [-Wunused-parameter]
/src/kinsol/kinsol_bbdpre.c:447:37: warning: unused parameter 'uu' [-Wunused-parameter]
/src/kinsol/kinsol_bbdpre.c:447:37: warning: unused parameter 'uu' [-Wunused-parameter]
/src/kinsol/kinsol_bbdpre.c:447:50: warning: unused parameter 'uscale' [-Wunused-parameter]
/src/kinsol/kinsol_bbdpre.c:447:50: warning: unused parameter 'uscale' [-Wunused-parameter]
/src/kinsol/kinsol_bbdpre.c:448:37: warning: unused parameter 'fval' [-Wunused-parameter]
/src/kinsol/kinsol_bbdpre.c:448:37: warning: unused parameter 'fval' [-Wunused-parameter]
/src/kinsol/kinsol_bbdpre.c:448:52: warning: unused parameter 'fscale' [-Wunused-parameter]
/src/kinsol/kinsol_bbdpre.c:448:52: warning: unused parameter 'fscale' [-Wunused-parameter]
/src/kinsol/kinsol_direct.c:651:27: warning: unused parameter 'sJpnorm' [-Wunused-parameter]
/src/kinsol/kinsol_direct.c:651:27: warning: unused parameter 'sJpnorm' [-Wunused-parameter]
/src/kinsol/kinsol_spils.c:619:29: warning: unused parameter 'toldummy' [-Wunused-parameter]
/src/kinsol/kinsol_spils.c:619:29: warning: unused parameter 'toldummy' [-Wunused-parameter]
/src/kinsol/kinsol_spils.c:619:43: warning: unused parameter 'lrdummy' [-Wunused-parameter]
/src/kinsol/kinsol_spils.c:619:43: warning: unused parameter 'lrdummy' [-Wunused-parameter]
/src/kinsol/kinsol_spils.c:671:35: warning: unused parameter 'new_u' [-Wunused-parameter]
/src/kinsol/kinsol_spils.c:671:35: warning: unused parameter 'new_u' [-Wunused-parameter]
```