### PR TITLE
Check if NLS is owned by the cvode(s) struct before freeing it.

### DIFF
--- a/src/cvode/cvode_nls.c
+++ b/src/cvode/cvode_nls.c
@@ -75,7 +75,7 @@ int CVodeSetNonlinearSolver(void *cvode_mem, SUNNonlinearSolver NLS)
   }
 
   /* free any existing nonlinear solver */
-  if (cv_mem->NLS) retval = SUNNonlinSolFree(cv_mem->NLS);
+  if (cv_mem->ownNLS && cv_mem->NLS) retval = SUNNonlinSolFree(cv_mem->NLS);
 
   /* set SUNNonlinearSolver pointer */
   cv_mem->NLS = NLS;

--- a/src/cvodes/cvodes_nls.c
+++ b/src/cvodes/cvodes_nls.c
@@ -65,7 +65,7 @@ int CVodeSetNonlinearSolver(void *cvode_mem, SUNNonlinearSolver NLS)
   }
 
   /* free any existing nonlinear solver */
-  if (cv_mem->NLS) retval = SUNNonlinSolFree(cv_mem->NLS);
+  if (cv_mem->ownNLS && cv_mem->NLS) retval = SUNNonlinSolFree(cv_mem->NLS);
 
   /* set SUNNonlinearSolver pointer */
   cv_mem->NLS = NLS;


### PR DESCRIPTION
Check if NLS is owned by the cvode(s) struct before freeing it in CVodeSetNonlinearSolver. 
This avoids double freeing the non-linear solver in some contexts.

For example, if the following sequence is executed a double free occurs.

NLS1 = SUNNonlinSol_FixedPoint (...)
cvode_mem = CVodeInit (...)
CVodeSetNonlinearSolver (cvode_mem, NLS1)
...
NLS2 = SUNNonlinSol_Newton (...)
CVodeReInit (cvode_mem, ...)
CVodeSetNonlinearSolver (cvode_mem, NLS2) /* At this point NLS1 is freed */
...
SUNNonlinSolFree (NLS1) /* Second free of NLS1 */
SUNNonlinSolFree (NLS2)