### PR TITLE
Do not include klu.h if already included by user

### DIFF
--- a/include/sunlinsol/sunlinsol_klu.h
+++ b/include/sunlinsol/sunlinsol_klu.h
@@ -39,7 +39,9 @@
 #include <sundials/sundials_matrix.h>
 #include <sundials/sundials_nvector.h>
 #include <sunmatrix/sunmatrix_sparse.h>
-#include "klu.h"
+#ifndef _KLU_H
+#include <klu.h>
+#endif
 
 #ifdef __cplusplus  /* wrapper to enable C++ usage */
 extern "C" {


### PR DESCRIPTION
* include/sunlinsol/sunlinsol_klu.h : check whether klu.h was already included
  by user before including it

Signed-off-by: Carlo de Falco <carlo.defalco@polimi.it>