### PR TITLE
NLS Solve: check for required callbacks

### DIFF
--- a/src/sunnonlinsol/fixedpoint/sunnonlinsol_fixedpoint.c
+++ b/src/sunnonlinsol/fixedpoint/sunnonlinsol_fixedpoint.c
@@ -200,6 +200,10 @@ int SUNNonlinSolSolve_FixedPoint(SUNNonlinearSolver NLS, N_Vector y0,
   if ( (NLS == NULL) || (y0 == NULL) || (y == NULL) || (w == NULL) || (mem == NULL) )
     return(SUN_NLS_MEM_NULL);
 
+  /* check that all required function pointers have been set */
+  if ( (FP_CONTENT(NLS)->Sys == NULL) || (FP_CONTENT(NLS)->CTest == NULL) )
+    return(SUN_NLS_MEM_NULL);
+
   /* set local shortcut variables */
   yprev = FP_CONTENT(NLS)->yprev;
   gy    = FP_CONTENT(NLS)->gy;

--- a/src/sunnonlinsol/newton/sunnonlinsol_newton.c
+++ b/src/sunnonlinsol/newton/sunnonlinsol_newton.c
@@ -200,6 +200,14 @@ int SUNNonlinSolSolve_Newton(SUNNonlinearSolver NLS,
        (mem == NULL) )
     return(SUN_NLS_MEM_NULL);
 
+  /* check that all required function pointers have been set */
+  if ( (NEWTON_CONTENT(NLS)->Sys    == NULL) ||
+       (NEWTON_CONTENT(NLS)->LSolve == NULL) ||
+       (callLSetup && (NEWTON_CONTENT(NLS)->LSetup == NULL)) ||
+       (NEWTON_CONTENT(NLS)->CTest  == NULL) ) {
+    return(SUN_NLS_MEM_NULL);
+  }
+
   /* set local shortcut variables */
   delta = NEWTON_CONTENT(NLS)->delta;
 


### PR DESCRIPTION
Avoid a NULL pointer exception on incorrect use of either SUNNonlinearSolver_Newton or SUNNonlinearSolver_FixedPoint from external code.

This allows proper detection of error conditions from managed languages (e.g., OCaml) and appropriate signalling (e.g., raising of exceptions) rather than crashing due to NULL-pointer dereference.