### PR TITLE
Use FindLAPACK regardless of fortran compiler

### DIFF
--- a/config/SundialsLapack.cmake
+++ b/config/SundialsLapack.cmake
@@ -19,16 +19,8 @@ SET(LAPACK_FOUND FALSE)
 # a working Fortran compiler) or look for them in the most
 # obvious place...
 if(NOT LAPACK_LIBRARIES)
-  if(F77_FOUND)
-    include(FindLAPACK)
-  else(F77_FOUND)
-    find_library(LAPACK_LIBRARIES
-      NAMES lapack
-      PATHS /usr/lib /usr/local/lib
-      "$ENV{ProgramFiles}/LAPACK/Lib"
-      )
-  endif(F77_FOUND)
-
+  find_package (LAPACK)
+ 
   # If the xSDK flag is used, set it to what was found
   if(LAPACK_LIBRARIES AND TPL_ENABLE_LAPACK)
     SET(DOCSTR "Lapack library")


### PR DESCRIPTION
This was probably a work-around for a very old bug in FindLAPACK not supporting fortran compiler not to be available:
https://github.com/Kitware/CMake/commit/51253da8bb193cdac4ac45ac43b250cecc2c0e87#diff-dee6a9a7be2db456465046ba0515a211
Get rid of it as the minimum cmake version is 3.1>>2.8.4.
It causes an issue as the resulting LAPACK_LIBRARIES did not contain the blas library, and the try_compile uses dcopy, part of blas, which resulted in that test failing and LAPACK disabled.