### PR TITLE
config/FindKLU.cmake: Also use debug library suffix

### DIFF
--- a/config/FindKLU.cmake
+++ b/config/FindKLU.cmake
@@ -17,6 +17,9 @@
 # Set library prefixes for Windows
 if(WIN32)
   set(CMAKE_FIND_LIBRARY_PREFIXES lib ${CMAKE_FIND_LIBRARY_PREFIXES})
+  set(CMAKE_FIND_LIBRARY_SUFFIXES d.lib ${CMAKE_FIND_LIBRARY_SUFFIXES})
+elseif(APPLE)
+  set(CMAKE_FIND_LIBRARY_SUFFIXES d.a ${CMAKE_FIND_LIBRARY_SUFFIXES})
 endif()
 
 ### Find include dir


### PR DESCRIPTION
It is common to add suffixes to the created libraries in
order to denote things like debug/release configurations.

Search that also for the KLU library.

Encountered with SuiteSparse cmake build from
https://github.com/jlblancoc/suitesparse-metis-for-windows.

Signed-off-by: Thomas Braun <thomas.braun@byte-physics.de>