### PR TITLE
cvLsDenseDQJac: [Non-functional change] Use correct dimension getter

### DIFF
--- a/src/cvode/cvode_ls.c
+++ b/src/cvode/cvode_ls.c
@@ -979,7 +979,7 @@ int cvLsDenseDQJac(realtype t, N_Vector y, N_Vector fy,
   cvls_mem = (CVLsMem) cv_mem->cv_lmem;
 
   /* access matrix dimension */
-  N = SUNDenseMatrix_Rows(Jac);
+  N = SUNDenseMatrix_Columns(Jac);
 
   /* Rename work vector for readibility */
   ftemp = tmp1;


### PR DESCRIPTION
We clearly need to iterate over the columns as the function comment and
later code states. But the rows are queried here. Changing to columns
will not change anything as the matrix is square.

Signed-off-by: Thomas Braun <thomas.braun@byte-physics.de>