### PR TITLE
examples/cvode/CXX_serial/cv_Heat.cpp: Fix compilation problem with Visual Studio 2019

### DIFF
--- a/examples/cvode/CXX_serial/cv_heat2D.cpp
+++ b/examples/cvode/CXX_serial/cv_heat2D.cpp
@@ -51,6 +51,7 @@
 #include <limits>
 #include <chrono>
 #include <cmath>
+#include <string>
 
 #include "cvode/cvode.h"               // access to CVODE
 #include "nvector/nvector_serial.h"    // access to the serial N_Vector


### PR DESCRIPTION
`stod` and `stoi` were not defined because of missing `include <string>` (seems like gcc does not need this include)