### PR TITLE
CMake: Fix exported targets so that build dir can be used directly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,3 +262,10 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/SUNDIALSConfig.cmake"
               "${CMAKE_CURRENT_BINARY_DIR}/SUNDIALSConfigVersion.cmake"
         DESTINATION "${SUNDIALS_INSTALL_CMAKEDIR}"
 )
+
+# Export targets so build directory can be used directly
+export(
+  EXPORT sundials-targets
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/SUNDIALSTargets.cmake"
+  NAMESPACE SUNDIALS::
+)

--- a/cmake/macros/SundialsAddLibrary.cmake
+++ b/cmake/macros/SundialsAddLibrary.cmake
@@ -348,12 +348,20 @@ macro(sundials_add_library target)
     if(NOT sundials_add_library_OBJECT_LIB_ONLY)
       add_library(${target} ALIAS ${target}${_SHARED_LIB_SUFFIX})
       set(_SUNDIALS_ALIAS_TARGETS "${target}->${target}${_SHARED_LIB_SUFFIX};${_SUNDIALS_ALIAS_TARGETS}" CACHE INTERNAL "" FORCE)
+
+      # Namespaced alias for using build directory directly
+      string(REPLACE "sundials_" "" _export_name "${target}")
+      add_library(SUNDIALS::${_export_name} ALIAS ${target}${_SHARED_LIB_SUFFIX})
     endif()
   else()
     add_library(${target}_obj ALIAS ${target}_obj${_STATIC_LIB_SUFFIX})
     if(NOT sundials_add_library_OBJECT_LIB_ONLY)
       add_library(${target} ALIAS ${target}${_STATIC_LIB_SUFFIX})
       set(_SUNDIALS_ALIAS_TARGETS "${target}->${target}${_STATIC_LIB_SUFFIX};${_SUNDIALS_ALIAS_TARGETS}" CACHE INTERNAL "" FORCE)
+
+      # Namespaced alias for using build directory directly
+      string(REPLACE "sundials_" "" _export_name "${target}")
+      add_library(SUNDIALS::${_export_name} ALIAS ${target}${_STATIC_LIB_SUFFIX})
     endif()
   endif()
 


### PR DESCRIPTION
Two small fixes that allow more complete parity between installed versions and using the build directory directly.

The call to `export(EXPORT)` is the main fix -- without this, `add_subdirectory`/`FetchContent` didn't work properly.

The other change is to add aliases without the `_shared/static` suffix -- without this change, using `add_subdirectory`/`FetchContent` would only have e.g. `SUNDIALS::arkode_shared`, while the installed version would have `SUNDIALS::arkode` too.