### PR TITLE
correct a variable name typo in cmake file

### DIFF
--- a/examples/idas/serial/CMakeLists.txt
+++ b/examples/idas/serial/CMakeLists.txt
@@ -320,7 +320,7 @@ if(EXAMPLES_INSTALL)
       set(THREAD_LIBRARY_SLUMT "")
     endif()
   else()
-    set(EXAMPLES_SLUMTU "")
+    set(EXAMPLES_SLUMT "")
     set(THREAD_LIBRARY_SLUMT "")
   endif()
 


### PR DESCRIPTION
Signed-off-by: MPo <>

Here is a fix for issue #92

regards Martin