### PR TITLE
Fix multiple definition linking issue for the F77/F90 examples

### DIFF
--- a/examples/arkode/F77_serial/CMakeLists.txt
+++ b/examples/arkode/F77_serial/CMakeLists.txt
@@ -70,6 +70,11 @@ foreach(example_tuple ${FARKODE_examples})
 
   set_target_properties(${example} PROPERTIES FOLDER "Examples")
 
+  if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
+      # avoid linker errors like : '... libsundials_fcvode.a(fsunmatrix_sparse.c.o):(.bss+0x0): multiple definition of `F2C_CVODE_matrix' ...'
+      target_link_options(${example} PUBLIC "-Wl,--allow-multiple-definition")
+  endif()
+
   # add example to regression tests
   sundials_add_test(${example} ${example}
     ANSWER_DIR ${CMAKE_CURRENT_SOURCE_DIR}
@@ -111,6 +116,11 @@ if(BUILD_SUNLINSOL_LAPACKBAND AND BUILD_SUNLINSOL_LAPACKDENSE)
     add_executable(${example} ${example}.f)
 
     set_target_properties(${example} PROPERTIES FOLDER "Examples")
+
+    if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
+        # avoid linker errors like : '... libsundials_fcvode.a(fsunmatrix_sparse.c.o):(.bss+0x0): multiple definition of `F2C_CVODE_matrix' ...'
+        target_link_options(${example} PUBLIC "-Wl,--allow-multiple-definition")
+    endif()
 
     # add example to regression tests
     sundials_add_test(${example} ${example}

--- a/examples/arkode/F90_serial/CMakeLists.txt
+++ b/examples/arkode/F90_serial/CMakeLists.txt
@@ -73,6 +73,11 @@ foreach(example_tuple ${FARKODE_examples})
   set_target_properties(${example} PROPERTIES FOLDER "Examples")
   set_target_properties(${example} PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
+  if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
+      # avoid linker errors like : '... libsundials_fcvode.a(fsunmatrix_sparse.c.o):(.bss+0x0): multiple definition of `F2C_CVODE_matrix' ...'
+      target_link_options(${example} PUBLIC "-Wl,--allow-multiple-definition")
+  endif()
+
   # add example to regression tests
   sundials_add_test(${example} ${example}
     ANSWER_DIR ${CMAKE_CURRENT_SOURCE_DIR}
@@ -115,6 +120,11 @@ if(BUILD_SUNLINSOL_LAPACKBAND AND BUILD_SUNLINSOL_LAPACKDENSE)
 
     set_target_properties(${example} PROPERTIES FOLDER "Examples")
     set_target_properties(${example} PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+    if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
+        # avoid linker errors like : '... libsundials_fcvode.a(fsunmatrix_sparse.c.o):(.bss+0x0): multiple definition of `F2C_CVODE_matrix' ...'
+        target_link_options(${example} PUBLIC "-Wl,--allow-multiple-definition")
+    endif()
 
     # add example to regression tests
     sundials_add_test(${example} ${example}
@@ -159,6 +169,11 @@ if(BUILD_SUNLINSOL_KLU)
     set_target_properties(${example} PROPERTIES FOLDER "Examples")
     set_target_properties(${example} PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
+    if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
+        # avoid linker errors like : '... libsundials_fcvode.a(fsunmatrix_sparse.c.o):(.bss+0x0): multiple definition of `F2C_CVODE_matrix' ...'
+        target_link_options(${example} PUBLIC "-Wl,--allow-multiple-definition")
+    endif()
+
     # add example to regression tests
     sundials_add_test(${example} ${example}
       ANSWER_DIR ${CMAKE_CURRENT_SOURCE_DIR}
@@ -201,6 +216,11 @@ if(BUILD_SUNLINSOL_SUPERLUMT)
 
     set_target_properties(${example} PROPERTIES FOLDER "Examples")
     set_target_properties(${example} PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+    if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
+        # avoid linker errors like : '... libsundials_fcvode.a(fsunmatrix_sparse.c.o):(.bss+0x0): multiple definition of `F2C_CVODE_matrix' ...'
+        target_link_options(${example} PUBLIC "-Wl,--allow-multiple-definition")
+    endif()
 
     # add example to regression tests
     sundials_add_test(${example} ${example}

--- a/examples/cvode/fcmix_serial/CMakeLists.txt
+++ b/examples/cvode/fcmix_serial/CMakeLists.txt
@@ -73,6 +73,11 @@ foreach(example_tuple ${FCVODE_examples})
 
   set_target_properties(${example} PROPERTIES FOLDER "Examples")
 
+  if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
+      # avoid linker errors like : '... libsundials_fcvode.a(fsunmatrix_sparse.c.o):(.bss+0x0): multiple definition of `F2C_CVODE_matrix' ...'
+      target_link_options(${example} PUBLIC "-Wl,--allow-multiple-definition")
+  endif()
+
   # add example to regression tests
   sundials_add_test(${example} ${example}
     ANSWER_DIR ${CMAKE_CURRENT_SOURCE_DIR}
@@ -113,6 +118,11 @@ if(BUILD_SUNLINSOL_LAPACKBAND AND BUILD_SUNLINSOL_LAPACKDENSE)
     add_executable(${example} ${example}.f)
 
     set_target_properties(${example} PROPERTIES FOLDER "Examples")
+
+    if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
+        # avoid linker errors like : '... libsundials_fcvode.a(fsunmatrix_sparse.c.o):(.bss+0x0): multiple definition of `F2C_CVODE_matrix' ...'
+        target_link_options(${example} PUBLIC "-Wl,--allow-multiple-definition")
+    endif()
 
     # add example to regression tests
     sundials_add_test(${example} ${example}
@@ -155,6 +165,11 @@ if(BUILD_SUNLINSOL_KLU)
 
     set_target_properties(${example} PROPERTIES FOLDER "Examples")
 
+    if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
+        # avoid linker errors like : '... libsundials_fcvode.a(fsunmatrix_sparse.c.o):(.bss+0x0): multiple definition of `F2C_CVODE_matrix' ...'
+        target_link_options(${example} PUBLIC "-Wl,--allow-multiple-definition")
+    endif()
+
     # add example to regression tests
     sundials_add_test(${example} ${example}
       ANSWER_DIR ${CMAKE_CURRENT_SOURCE_DIR}
@@ -192,6 +207,11 @@ if(BUILD_SUNLINSOL_SUPERLUMT)
     add_executable(${example} ${example}.f)
 
     set_target_properties(${example} PROPERTIES FOLDER "Examples")
+
+    if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
+        # avoid linker errors like : '... libsundials_fcvode.a(fsunmatrix_sparse.c.o):(.bss+0x0): multiple definition of `F2C_CVODE_matrix' ...'
+        target_link_options(${example} PUBLIC "-Wl,--allow-multiple-definition")
+    endif()
 
     # add example to regression tests
     sundials_add_test(${example} ${example}

--- a/examples/ida/fcmix_serial/CMakeLists.txt
+++ b/examples/ida/fcmix_serial/CMakeLists.txt
@@ -43,6 +43,11 @@ foreach(example_tuple ${FIDA_examples})
 
   set_target_properties(${example} PROPERTIES FOLDER "Examples")
 
+  if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
+    # avoid linker errors like : '... libsundials_fcvode.a(fsunmatrix_sparse.c.o):(.bss+0x0): multiple definition of `F2C_CVODE_matrix' ...'
+    target_link_options(${example} PUBLIC "-Wl,--allow-multiple-definition")
+  endif()
+
   # add example to regression tests
   sundials_add_test(${example} ${example}
     ANSWER_DIR ${CMAKE_CURRENT_SOURCE_DIR}

--- a/examples/kinsol/fcmix_serial/CMakeLists.txt
+++ b/examples/kinsol/fcmix_serial/CMakeLists.txt
@@ -44,6 +44,11 @@ foreach(example_tuple ${FKINSOL_examples})
 
   set_target_properties(${example} PROPERTIES FOLDER "Examples")
 
+  if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
+    # avoid linker errors like : '... libsundials_fcvode.a(fsunmatrix_sparse.c.o):(.bss+0x0): multiple definition of `F2C_CVODE_matrix' ...'
+    target_link_options(${example} PUBLIC "-Wl,--allow-multiple-definition")
+  endif()
+
   # add example to regression tests
   sundials_add_test(${example} ${example}
     ANSWER_DIR ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
Signed-off-by: MPo <>

The F77 and F90 examples fail to build with gcc an clang (both version 11) on a Debian machine with a linker error due to multiple defined identical global variables.
e.g.:
[ 62%] Building Fortran object examples/arkode/F77_serial/CMakeFiles/fark_diurnal_kry_bp.dir/fark_diurnal_kry_bp.f.o
[ 62%] Linking Fortran executable fark_diurnal_kry_bp
/usr/bin/ld: ../../../src/arkode/fcmix/libsundials_farkode.a(fsunlinsol_spgmr.c.o):(.bss+0x18): multiple definition of 'F2C_ARKODE_linsol'; ../../../src/arkode/fcmix/libsundials_farkode.a(fsunlinsol_band.c.o):(.bss+0x18): first defined here
/usr/bin/ld: ../../../src/arkode/fcmix/libsundials_farkode.a(fsunlinsol_spgmr.c.o):(.bss+0x20): multiple definition of 'F2C_ARKODE_mass_sol'; ../../../src/arkode/fcmix/libsundials_farkode.a(fsunlinsol_band.c.o):(.bss+0x20): first defined here
/usr/bin/ld: ../../../src/arkode/fcmix/libsundials_farkode.a(fsunlinsol_spgmr.c.o):(.bss+0x0): multiple definition of 'F2C_CVODE_linsol'; ../../../src/arkode/fcmix/libsundials_farkode.a(fsunlinsol_band.c.o):(.bss+0x0): first defined here
/usr/bin/ld: ../../../src/arkode/fcmix/libsundials_farkode.a(fsunlinsol_spgmr.c.o):(.bss+0x8): multiple definition of 'F2C_IDA_linsol'; ../../../src/arkode/fcmix/libsundials_farkode.a(fsunlinsol_band.c.o):(.bss+0x8): first defined here
/usr/bin/ld: ../../../src/arkode/fcmix/libsundials_farkode.a(fsunlinsol_spgmr.c.o):(.bss+0x10): multiple definition of 'F2C_KINSOL_linsol'; ../../../src/arkode/fcmix/libsundials_farkode.a(fsunlinsol_band.c.o):(.bss+0x10): first defined here
/usr/bin/ld: ../../../src/arkode/fcmix/libsundials_farkode.a(farknullnonlinsol.c.o):(.bss+0x0): multiple definition of 'F2C_ARKODE_nonlinsol'; ../../../src/arkode/fcmix/libsundials_farkode.a(fsunnonlinsol_newton.c.o):(.bss+0x10): first defined here
/usr/bin/ld: ../../../src/arkode/fcmix/libsundials_farkode.a(farknulllinsol.c.o):(.bss+0x0): multiple definition of 'F2C_ARKODE_linsol'; ../../../src/arkode/fcmix/libsundials_farkode.a(fsunlinsol_band.c.o):(.bss+0x18): first defined here
/usr/bin/ld: ../../../src/arkode/fcmix/libsundials_farkode.a(farknulllinsol.c.o):(.bss+0x8): multiple definition of 'F2C_ARKODE_mass_sol'; ../../../src/arkode/fcmix/libsundials_farkode.a(fsunlinsol_band.c.o):(.bss+0x20): first defined here
/usr/bin/ld: ../../../src/arkode/fcmix/libsundials_farkode.a(farknullmatrix.c.o):(.bss+0x8): multiple definition of 'F2C_ARKODE_mass_matrix'; ../../../src/arkode/fcmix/libsundials_farkode.a(fsunmatrix_band.c.o):(.bss+0x20): first defined here
/usr/bin/ld: ../../../src/arkode/fcmix/libsundials_farkode.a(farknullmatrix.c.o):(.bss+0x0): multiple definition of 'F2C_ARKODE_matrix'; ../../../src/arkode/fcmix/libsundials_farkode.a(fsunmatrix_band.c.o):(.bss+0x18): first defined here
collect2: error: ld returned 1 exit status
`

I have addressed it by explicitly allowing such cases for the F77 and F90 examples 
by setting the linker option `-Wl,--allow-multiple-definition"` for the gcc and the clang compiler


regards

Martin