### PR TITLE
Fix POSIX_TIMERS in nvector tests

### DIFF
--- a/examples/nvector/test_nvector.c
+++ b/examples/nvector/test_nvector.c
@@ -24,6 +24,8 @@
 #define _POSIX_C_SOURCE 199309L
 #endif
 
+#include <sundials/sundials_config.h>
+
 /* POSIX timers */
 #if defined(SUNDIALS_HAVE_POSIX_TIMERS)
 #include <time.h>


### PR DESCRIPTION
Signed-off-by: Timothy Bourke <tim@tbrk.org>

The SUNDIALS_HAVE_POSIX_TIMERS variable is set (or not) in
sundials/sundials_config.h.

This header was previously included via test_nvector.h ->
sundials/sundials_types.h -> sundials_config.h. In the latest release,
test_nvector.h is included after testing of SUNDIALS_HAVE_POSIX_TIMERS.