### PR TITLE
Bugfix: NVector benchmark timing

### DIFF
--- a/benchmarks/nvector/CMakeLists.txt
+++ b/benchmarks/nvector/CMakeLists.txt
@@ -24,7 +24,7 @@ if(BUILD_NVECTOR_MPIPLUSX)
   add_subdirectory(mpiplusx)
 endif()
 
-if(BUILD_NVECTOR_HYPRE)
+if(BUILD_NVECTOR_PARHYP)
   add_subdirectory(parhyp)
 endif()
 

--- a/benchmarks/nvector/parhyp/test_nvector_performance_parhyp.c
+++ b/benchmarks/nvector/parhyp/test_nvector_performance_parhyp.c
@@ -39,8 +39,9 @@ static realtype* data;  /* host data   */
  * --------------------------------------------------------------------*/
 int main(int argc, char *argv[])
 {
-  N_Vector X;          /* test vector        */
-  sunindextype veclen; /* vector length      */
+  SUNContext   ctx = NULL;  /* SUNDIALS context */
+  N_Vector     X   = NULL;  /* test vector      */
+  sunindextype veclen;      /* vector length    */
 
   HYPRE_ParVector Xhyp;    /* hypre parallel vector */
   HYPRE_Int *partitioning; /* vector partitioning   */
@@ -116,6 +117,9 @@ int main(int argc, char *argv[])
     printf("  number of MPI procs   %d  \n", nprocs);
   }
 
+  flag = SUNContext_Create(&comm, &ctx);
+  if (flag) return flag;
+
   /* set partitioning */
   if(HYPRE_AssumedPartitionCheck()) {
     partitioning = (HYPRE_Int*) malloc(2*sizeof(HYPRE_Int));
@@ -134,7 +138,7 @@ int main(int argc, char *argv[])
   HYPRE_ParVectorInitialize(Xhyp);
 
   /* Create vectors */
-  X = N_VMake_ParHyp(Xhyp);
+  X = N_VMake_ParHyp(Xhyp, ctx);
 
   /* run tests */
   if (myid == 0 && print_timing) {
@@ -186,6 +190,9 @@ int main(int argc, char *argv[])
   HYPRE_ParVectorDestroy(Xhyp);
 
   FinalizeClearCache();
+
+  flag = SUNContext_Free(&ctx);
+  if (flag) return flag;
 
   if (myid == 0)
     printf("\nFinished Tests\n");

--- a/benchmarks/nvector/test_nvector_performance.c
+++ b/benchmarks/nvector/test_nvector_performance.c
@@ -22,6 +22,8 @@
 #define _POSIX_C_SOURCE 199309L
 #endif
 
+#include <sundials/sundials_config.h>
+
 /* POSIX timers */
 #if defined(SUNDIALS_HAVE_POSIX_TIMERS)
 #include <time.h>
@@ -29,7 +31,6 @@
 #include <unistd.h>
 #endif
 
-#include <sundials/sundials_config.h>
 #include <sundials/sundials_nvector.h>
 #include <sundials/sundials_types.h>
 #include <sundials/sundials_math.h>


### PR DESCRIPTION
* Include `sundials_config.h` before using `SUNDIALS_HAVE_POSIX_TIMERS`
* Fix typo that prevented building hypre vector benchmarks