### PR TITLE
Allow for skipping fused operation benchmarks

### DIFF
--- a/benchmarks/nvector/cuda/test_nvector_performance_cuda.cu
+++ b/benchmarks/nvector/cuda/test_nvector_performance_cuda.cu
@@ -100,15 +100,13 @@ int main(int argc, char *argv[])
   }
 
   nvecs = atol(argv[2]);
-  if (nvecs <= 0) {
-    printf("ERROR: number of vectors must be a positive integer \n");
-    return(-1);
+  if (nvecs < 1) {
+    printf("WARNING: Fused operation tests disabled\n");
   }
 
   nsums = atol(argv[3]);
-  if (nsums <= 0) {
-    printf("ERROR: number of sums must be a positive integer \n");
-    return(-1);
+  if (nsums < 1) {
+    printf("WARNING: Some fused operation tests disabled\n");
   }
 
   ntests = atol(argv[4]);
@@ -163,21 +161,27 @@ int main(int argc, char *argv[])
   flag = Test_N_VConstrMask(X, veclen, ntests);
   flag = Test_N_VMinQuotient(X, veclen, ntests);
 
-  if (print_timing) printf("\n\n fused operations 1: nvecs= %d\n", nvecs);
-  if (print_timing) PrintTableHeader(2);
-  flag = Test_N_VLinearCombination(X, veclen, nvecs, ntests);
-  flag = Test_N_VScaleAddMulti(X, veclen, nvecs, ntests);
-  flag = Test_N_VDotProdMulti(X, veclen, nvecs, ntests);
-  flag = Test_N_VLinearSumVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VScaleVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VConstVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VWrmsNormVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VWrmsNormMaskVectorArray(X, veclen, nvecs, ntests);
+  if (nvecs > 0)
+  {
+    if (print_timing) printf("\n\n fused operations 1: nvecs= %d\n", nvecs);
+    if (print_timing) PrintTableHeader(2);
+    flag = Test_N_VLinearCombination(X, veclen, nvecs, ntests);
+    flag = Test_N_VScaleAddMulti(X, veclen, nvecs, ntests);
+    flag = Test_N_VDotProdMulti(X, veclen, nvecs, ntests);
+    flag = Test_N_VLinearSumVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VScaleVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VConstVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VWrmsNormVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VWrmsNormMaskVectorArray(X, veclen, nvecs, ntests);
 
-  if (print_timing) printf("\n\n fused operations 2: nvecs= %d nsums= %d\n", nvecs, nsums);
-  if (print_timing) PrintTableHeader(2);
-  flag = Test_N_VScaleAddMultiVectorArray(X, veclen, nvecs, nsums, ntests);
-  flag = Test_N_VLinearCombinationVectorArray(X, veclen, nvecs, nsums, ntests);
+    if (nsums > 0)
+    {
+      if (print_timing) printf("\n\n fused operations 2: nvecs= %d nsums= %d\n", nvecs, nsums);
+      if (print_timing) PrintTableHeader(2);
+      flag = Test_N_VScaleAddMultiVectorArray(X, veclen, nvecs, nsums, ntests);
+      flag = Test_N_VLinearCombinationVectorArray(X, veclen, nvecs, nsums, ntests);
+    }
+  }
 
   /* Free vectors */
   N_VDestroy(X);

--- a/benchmarks/nvector/mpiplusx/test_nvector_performance_mpiplusx.c
+++ b/benchmarks/nvector/mpiplusx/test_nvector_performance_mpiplusx.c
@@ -81,15 +81,13 @@ int main(int argc, char *argv[])
   }
 
   nvecs = (int) atol(argv[2]);
-  if (nvecs <= 0) {
-    printf("ERROR: number of vectors must be a positive integer \n");
-    return(-1);
+  if (nvecs < 1) {
+    printf("WARNING: Fused operation tests disabled\n");
   }
 
   nsums = (int) atol(argv[3]);
-  if (nsums <= 0) {
-    printf("ERROR: number of sums must be a positive integer \n");
-    return(-1);
+  if (nsums < 1) {
+    printf("WARNING: Some fused operation tests disabled\n");
   }
 
   ntests = (int) atol(argv[4]);
@@ -149,25 +147,31 @@ int main(int argc, char *argv[])
   flag = Test_N_VConstrMask(X, veclen, ntests);
   flag = Test_N_VMinQuotient(X, veclen, ntests);
 
-  if (myid == 0 && print_timing) {
-    printf("\n\n fused operations 1: nvecs= %d\n", nvecs);
-    PrintTableHeader(2);
-  }
-  flag = Test_N_VLinearCombination(X, veclen, nvecs, ntests);
-  flag = Test_N_VScaleAddMulti(X, veclen, nvecs, ntests);
-  flag = Test_N_VDotProdMulti(X, veclen, nvecs, ntests);
-  flag = Test_N_VLinearSumVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VScaleVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VConstVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VWrmsNormVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VWrmsNormMaskVectorArray(X, veclen, nvecs, ntests);
+  if (nvecs > 0)
+  {
+    if (myid == 0 && print_timing) {
+      printf("\n\n fused operations 1: nvecs= %d\n", nvecs);
+      PrintTableHeader(2);
+    }
+    flag = Test_N_VLinearCombination(X, veclen, nvecs, ntests);
+    flag = Test_N_VScaleAddMulti(X, veclen, nvecs, ntests);
+    flag = Test_N_VDotProdMulti(X, veclen, nvecs, ntests);
+    flag = Test_N_VLinearSumVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VScaleVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VConstVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VWrmsNormVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VWrmsNormMaskVectorArray(X, veclen, nvecs, ntests);
 
-  if (myid == 0 && print_timing) {
-    printf("\n\n fused operations 2: nvecs= %d nsums= %d\n", nvecs, nsums);
-    PrintTableHeader(2);
+    if (nsums > 0)
+    {
+      if (myid == 0 && print_timing) {
+        printf("\n\n fused operations 2: nvecs= %d nsums= %d\n", nvecs, nsums);
+        PrintTableHeader(2);
+      }
+      flag = Test_N_VScaleAddMultiVectorArray(X, veclen, nvecs, nsums, ntests);
+      flag = Test_N_VLinearCombinationVectorArray(X, veclen, nvecs, nsums, ntests);
+    }
   }
-  flag = Test_N_VScaleAddMultiVectorArray(X, veclen, nvecs, nsums, ntests);
-  flag = Test_N_VLinearCombinationVectorArray(X, veclen, nvecs, nsums, ntests);
 
   /* Free vectors */
   N_VDestroy(N_VGetLocalVector_MPIPlusX(X));

--- a/benchmarks/nvector/openmp/test_nvector_performance_openmp.c
+++ b/benchmarks/nvector/openmp/test_nvector_performance_openmp.c
@@ -69,15 +69,13 @@ int main(int argc, char *argv[])
   }
 
   nvecs = (int) atol(argv[2]);
-  if (nvecs <= 0) {
-    printf("ERROR: number of vectors must be a positive integer \n");
-    return(-1);
+  if (nvecs < 1) {
+    printf("WARNING: Fused operation tests disabled\n");
   }
 
   nsums = (int) atol(argv[3]);
-  if (nsums <= 0) {
-    printf("ERROR: number of sums must be a positive integer \n");
-    return(-1);
+  if (nsums < 1) {
+    printf("WARNING: Some fused operation tests disabled\n");
   }
 
   ntests = (int) atol(argv[4]);
@@ -139,22 +137,28 @@ int main(int argc, char *argv[])
   flag = Test_N_VConstrMask(X, veclen, ntests);
   flag = Test_N_VMinQuotient(X, veclen, ntests);
 
-  if (print_timing) printf("\n\n fused operations 1: nvecs= %d\n", nvecs);
-  if (print_timing) PrintTableHeader(2);
-  flag = Test_N_VLinearCombination(X, veclen, nvecs, ntests);
-  flag = Test_N_VScaleAddMulti(X, veclen, nvecs, ntests);
-  flag = Test_N_VDotProdMulti(X, veclen, nvecs, ntests);
-  flag = Test_N_VLinearSumVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VScaleVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VConstVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VWrmsNormVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VWrmsNormMaskVectorArray(X, veclen, nvecs, ntests);
+  if (nvecs > 0)
+  {
+    if (print_timing) printf("\n\n fused operations 1: nvecs= %d\n", nvecs);
+    if (print_timing) PrintTableHeader(2);
+    flag = Test_N_VLinearCombination(X, veclen, nvecs, ntests);
+    flag = Test_N_VScaleAddMulti(X, veclen, nvecs, ntests);
+    flag = Test_N_VDotProdMulti(X, veclen, nvecs, ntests);
+    flag = Test_N_VLinearSumVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VScaleVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VConstVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VWrmsNormVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VWrmsNormMaskVectorArray(X, veclen, nvecs, ntests);
 
-  if (print_timing) printf("\n\n fused operations 2: nvecs= %d nsums= %d\n",
-                           nvecs, nsums);
-  if (print_timing) PrintTableHeader(2);
-  flag = Test_N_VScaleAddMultiVectorArray(X, veclen, nvecs, nsums, ntests);
-  flag = Test_N_VLinearCombinationVectorArray(X, veclen, nvecs, nsums, ntests);
+    if (nsums > 0)
+    {
+      if (print_timing) printf("\n\n fused operations 2: nvecs= %d nsums= %d\n",
+                               nvecs, nsums);
+      if (print_timing) PrintTableHeader(2);
+      flag = Test_N_VScaleAddMultiVectorArray(X, veclen, nvecs, nsums, ntests);
+      flag = Test_N_VLinearCombinationVectorArray(X, veclen, nvecs, nsums, ntests);
+    }
+  }
 
   /* Free vectors */
   N_VDestroy(X);

--- a/benchmarks/nvector/openmpdev/test_nvector_performance_openmpdev.c
+++ b/benchmarks/nvector/openmpdev/test_nvector_performance_openmpdev.c
@@ -62,15 +62,13 @@ int main(int argc, char *argv[])
   }
 
   nvecs = atol(argv[2]);
-  if (nvecs <= 0) {
-    printf("ERROR: number of vectors must be a positive integer \n");
-    return(-1);
+  if (nvecs < 1) {
+    printf("WARNING: Fused operation tests disabled\n");
   }
 
   nsums = atol(argv[3]);
-  if (nsums <= 0) {
-    printf("ERROR: number of sums must be a positive integer \n");
-    return(-1);
+  if (nsums < 1) {
+    printf("WARNING: Some fused operation tests disabled\n");
   }
 
   ntests = atol(argv[4]);
@@ -123,21 +121,27 @@ int main(int argc, char *argv[])
   flag = Test_N_VConstrMask(X, veclen, ntests);
   flag = Test_N_VMinQuotient(X, veclen, ntests);
 
-  if (print_timing) printf("\n\n fused operations 1: nvecs= %d\n", nvecs);
-  if (print_timing) PrintTableHeader(2);
-  flag = Test_N_VLinearCombination(X, veclen, nvecs, ntests);
-  flag = Test_N_VScaleAddMulti(X, veclen, nvecs, ntests);
-  flag = Test_N_VDotProdMulti(X, veclen, nvecs, ntests);
-  flag = Test_N_VLinearSumVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VScaleVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VConstVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VWrmsNormVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VWrmsNormMaskVectorArray(X, veclen, nvecs, ntests);
+  if (nvecs > 0)
+  {
+    if (print_timing) printf("\n\n fused operations 1: nvecs= %d\n", nvecs);
+    if (print_timing) PrintTableHeader(2);
+    flag = Test_N_VLinearCombination(X, veclen, nvecs, ntests);
+    flag = Test_N_VScaleAddMulti(X, veclen, nvecs, ntests);
+    flag = Test_N_VDotProdMulti(X, veclen, nvecs, ntests);
+    flag = Test_N_VLinearSumVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VScaleVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VConstVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VWrmsNormVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VWrmsNormMaskVectorArray(X, veclen, nvecs, ntests);
 
-  if (print_timing) printf("\n\n fused operations 2: nvecs= %d nsums= %d\n", nvecs, nsums);
-  if (print_timing) PrintTableHeader(2);
-  flag = Test_N_VScaleAddMultiVectorArray(X, veclen, nvecs, nsums, ntests);
-  flag = Test_N_VLinearCombinationVectorArray(X, veclen, nvecs, nsums, ntests);
+    if (nsums > 0)
+    {
+      if (print_timing) printf("\n\n fused operations 2: nvecs= %d nsums= %d\n", nvecs, nsums);
+      if (print_timing) PrintTableHeader(2);
+      flag = Test_N_VScaleAddMultiVectorArray(X, veclen, nvecs, nsums, ntests);
+      flag = Test_N_VLinearCombinationVectorArray(X, veclen, nvecs, nsums, ntests);
+    }
+  }
 
   /* Free vectors */
   N_VDestroy(X);

--- a/benchmarks/nvector/parallel/test_nvector_performance_parallel.c
+++ b/benchmarks/nvector/parallel/test_nvector_performance_parallel.c
@@ -79,15 +79,13 @@ int main(int argc, char *argv[])
   }
 
   nvecs = (int) atol(argv[2]);
-  if (nvecs <= 0) {
-    printf("ERROR: number of vectors must be a positive integer \n");
-    return(-1);
+  if (nvecs < 1) {
+    printf("WARNING: Fused operation tests disabled\n");
   }
 
   nsums = (int) atol(argv[3]);
-  if (nsums <= 0) {
-    printf("ERROR: number of sums must be a positive integer \n");
-    return(-1);
+  if (nsums < 1) {
+    printf("WARNING: Some fused operation tests disabled\n");
   }
 
   ntests = (int) atol(argv[4]);
@@ -147,25 +145,31 @@ int main(int argc, char *argv[])
   flag = Test_N_VConstrMask(X, veclen, ntests);
   flag = Test_N_VMinQuotient(X, veclen, ntests);
 
-  if (myid == 0 && print_timing) {
-    printf("\n\n fused operations 1: nvecs= %d\n", nvecs);
-    PrintTableHeader(2);
-  }
-  flag = Test_N_VLinearCombination(X, veclen, nvecs, ntests);
-  flag = Test_N_VScaleAddMulti(X, veclen, nvecs, ntests);
-  flag = Test_N_VDotProdMulti(X, veclen, nvecs, ntests);
-  flag = Test_N_VLinearSumVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VScaleVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VConstVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VWrmsNormVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VWrmsNormMaskVectorArray(X, veclen, nvecs, ntests);
+  if (nvecs > 0)
+  {
+    if (myid == 0 && print_timing) {
+      printf("\n\n fused operations 1: nvecs= %d\n", nvecs);
+      PrintTableHeader(2);
+    }
+    flag = Test_N_VLinearCombination(X, veclen, nvecs, ntests);
+    flag = Test_N_VScaleAddMulti(X, veclen, nvecs, ntests);
+    flag = Test_N_VDotProdMulti(X, veclen, nvecs, ntests);
+    flag = Test_N_VLinearSumVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VScaleVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VConstVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VWrmsNormVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VWrmsNormMaskVectorArray(X, veclen, nvecs, ntests);
 
-  if (myid == 0 && print_timing) {
-    printf("\n\n fused operations 2: nvecs= %d nsums= %d\n", nvecs, nsums);
-    PrintTableHeader(2);
+    if (nsums > 0)
+    {
+      if (myid == 0 && print_timing) {
+        printf("\n\n fused operations 2: nvecs= %d nsums= %d\n", nvecs, nsums);
+        PrintTableHeader(2);
+      }
+      flag = Test_N_VScaleAddMultiVectorArray(X, veclen, nvecs, nsums, ntests);
+      flag = Test_N_VLinearCombinationVectorArray(X, veclen, nvecs, nsums, ntests);
+    }
   }
-  flag = Test_N_VScaleAddMultiVectorArray(X, veclen, nvecs, nsums, ntests);
-  flag = Test_N_VLinearCombinationVectorArray(X, veclen, nvecs, nsums, ntests);
 
   /* Free vectors */
   N_VDestroy(X);

--- a/benchmarks/nvector/parhyp/test_nvector_performance_parhyp.c
+++ b/benchmarks/nvector/parhyp/test_nvector_performance_parhyp.c
@@ -79,15 +79,13 @@ int main(int argc, char *argv[])
   }
 
   nvecs = (int) atol(argv[2]);
-  if (nvecs <= 0) {
-    printf("ERROR: number of vectors must be a positive integer \n");
-    return(-1);
+  if (nvecs < 1) {
+    printf("WARNING: Fused operation tests disabled\n");
   }
 
   nsums = (int) atol(argv[3]);
-  if (nsums <= 0) {
-    printf("ERROR: number of sums must be a positive integer \n");
-    return(-1);
+  if (nsums < 1) {
+    printf("WARNING: Some fused operation tests disabled\n");
   }
 
   ntests = (int) atol(argv[4]);
@@ -161,25 +159,31 @@ int main(int argc, char *argv[])
   flag = Test_N_VConstrMask(X, veclen, ntests);
   flag = Test_N_VMinQuotient(X, veclen, ntests);
 
-  if (myid == 0 && print_timing) {
-    printf("\n\n fused operations 1: nvecs= %d\n", nvecs);
-    PrintTableHeader(2);
-  }
-  flag = Test_N_VLinearCombination(X, veclen, nvecs, ntests);
-  flag = Test_N_VScaleAddMulti(X, veclen, nvecs, ntests);
-  flag = Test_N_VDotProdMulti(X, veclen, nvecs, ntests);
-  flag = Test_N_VLinearSumVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VScaleVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VConstVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VWrmsNormVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VWrmsNormMaskVectorArray(X, veclen, nvecs, ntests);
+  if (nvecs > 0)
+  {
+    if (myid == 0 && print_timing) {
+      printf("\n\n fused operations 1: nvecs= %d\n", nvecs);
+      PrintTableHeader(2);
+    }
+    flag = Test_N_VLinearCombination(X, veclen, nvecs, ntests);
+    flag = Test_N_VScaleAddMulti(X, veclen, nvecs, ntests);
+    flag = Test_N_VDotProdMulti(X, veclen, nvecs, ntests);
+    flag = Test_N_VLinearSumVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VScaleVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VConstVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VWrmsNormVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VWrmsNormMaskVectorArray(X, veclen, nvecs, ntests);
 
-  if (myid == 0 && print_timing) {
-    printf("\n\n fused operations 2: nvecs= %d nsums= %d\n", nvecs, nsums);
-    PrintTableHeader(2);
+    if (nsums > 0)
+    {
+      if (myid == 0 && print_timing) {
+        printf("\n\n fused operations 2: nvecs= %d nsums= %d\n", nvecs, nsums);
+        PrintTableHeader(2);
+      }
+      flag = Test_N_VScaleAddMultiVectorArray(X, veclen, nvecs, nsums, ntests);
+      flag = Test_N_VLinearCombinationVectorArray(X, veclen, nvecs, nsums, ntests);
+    }
   }
-  flag = Test_N_VScaleAddMultiVectorArray(X, veclen, nvecs, nsums, ntests);
-  flag = Test_N_VLinearCombinationVectorArray(X, veclen, nvecs, nsums, ntests);
 
   /* Free vectors */
   N_VDestroy(X);

--- a/benchmarks/nvector/petsc/test_nvector_performance_petsc.c
+++ b/benchmarks/nvector/petsc/test_nvector_performance_petsc.c
@@ -90,15 +90,13 @@ int main(int argc, char *argv[])
   }
 
   nvecs = (int) atol(argv[2]);
-  if (nvecs <= 0) {
-    printf("ERROR: number of vectors must be a positive integer \n");
-    return(-1);
+  if (nvecs < 1) {
+    printf("WARNING: Fused operation tests disabled\n");
   }
 
   nsums = (int) atol(argv[3]);
-  if (nsums <= 0) {
-    printf("ERROR: number of sums must be a positive integer \n");
-    return(-1);
+  if (nsums < 1) {
+    printf("WARNING: Some fused operation tests disabled\n");
   }
 
   ntests = (int) atol(argv[4]);
@@ -158,25 +156,31 @@ int main(int argc, char *argv[])
   flag = Test_N_VConstrMask(X, veclen, ntests);
   flag = Test_N_VMinQuotient(X, veclen, ntests);
 
-  if (myid == 0 && print_timing) {
-    printf("\n\n fused operations 1: nvecs= %d\n", nvecs);
-    PrintTableHeader(2);
-  }
-  flag = Test_N_VLinearCombination(X, veclen, nvecs, ntests);
-  flag = Test_N_VScaleAddMulti(X, veclen, nvecs, ntests);
-  flag = Test_N_VDotProdMulti(X, veclen, nvecs, ntests);
-  flag = Test_N_VLinearSumVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VScaleVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VConstVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VWrmsNormVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VWrmsNormMaskVectorArray(X, veclen, nvecs, ntests);
+  if (nvecs > 0)
+  {
+    if (myid == 0 && print_timing) {
+      printf("\n\n fused operations 1: nvecs= %d\n", nvecs);
+      PrintTableHeader(2);
+    }
+    flag = Test_N_VLinearCombination(X, veclen, nvecs, ntests);
+    flag = Test_N_VScaleAddMulti(X, veclen, nvecs, ntests);
+    flag = Test_N_VDotProdMulti(X, veclen, nvecs, ntests);
+    flag = Test_N_VLinearSumVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VScaleVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VConstVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VWrmsNormVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VWrmsNormMaskVectorArray(X, veclen, nvecs, ntests);
 
-  if (myid == 0 && print_timing) {
-    printf("\n\n fused operations 2: nvecs= %d nsums= %d\n", nvecs, nsums);
-    PrintTableHeader(2);
+    if (nsums > 0)
+    {
+      if (myid == 0 && print_timing) {
+        printf("\n\n fused operations 2: nvecs= %d nsums= %d\n", nvecs, nsums);
+        PrintTableHeader(2);
+      }
+      flag = Test_N_VScaleAddMultiVectorArray(X, veclen, nvecs, nsums, ntests);
+      flag = Test_N_VLinearCombinationVectorArray(X, veclen, nvecs, nsums, ntests);
+    }
   }
-  flag = Test_N_VScaleAddMultiVectorArray(X, veclen, nvecs, nsums, ntests);
-  flag = Test_N_VLinearCombinationVectorArray(X, veclen, nvecs, nsums, ntests);
 
   /* Free vectors */
   N_VDestroy(X);

--- a/benchmarks/nvector/pthreads/test_nvector_performance_pthreads.c
+++ b/benchmarks/nvector/pthreads/test_nvector_performance_pthreads.c
@@ -67,15 +67,13 @@ int main(int argc, char *argv[])
   }
 
   nvecs = (int) atol(argv[2]);
-  if (nvecs <= 0) {
-    printf("ERROR: number of vectors must be a positive integer \n");
-    return(-1);
+  if (nvecs < 1) {
+    printf("WARNING: Fused operation tests disabled\n");
   }
 
   nsums = (int) atol(argv[3]);
-  if (nsums <= 0) {
-    printf("ERROR: number of sums must be a positive integer \n");
-    return(-1);
+  if (nsums < 1) {
+    printf("WARNING: Some fused operation tests disabled\n");
   }
 
   ntests = (int) atol(argv[4]);
@@ -137,21 +135,27 @@ int main(int argc, char *argv[])
   flag = Test_N_VConstrMask(X, veclen, ntests);
   flag = Test_N_VMinQuotient(X, veclen, ntests);
 
-  if (print_timing) printf("\n\n fused operations 1: nvecs= %d\n", nvecs);
-  if (print_timing) PrintTableHeader(2);
-  flag = Test_N_VLinearCombination(X, veclen, nvecs, ntests);
-  flag = Test_N_VScaleAddMulti(X, veclen, nvecs, ntests);
-  flag = Test_N_VDotProdMulti(X, veclen, nvecs, ntests);
-  flag = Test_N_VLinearSumVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VScaleVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VConstVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VWrmsNormVectorArray(X, veclen, nvecs, ntests);
-  flag = Test_N_VWrmsNormMaskVectorArray(X, veclen, nvecs, ntests);
+  if (nvecs > 0)
+  {
+    if (print_timing) printf("\n\n fused operations 1: nvecs= %d\n", nvecs);
+    if (print_timing) PrintTableHeader(2);
+    flag = Test_N_VLinearCombination(X, veclen, nvecs, ntests);
+    flag = Test_N_VScaleAddMulti(X, veclen, nvecs, ntests);
+    flag = Test_N_VDotProdMulti(X, veclen, nvecs, ntests);
+    flag = Test_N_VLinearSumVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VScaleVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VConstVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VWrmsNormVectorArray(X, veclen, nvecs, ntests);
+    flag = Test_N_VWrmsNormMaskVectorArray(X, veclen, nvecs, ntests);
 
-  if (print_timing) printf("\n\n fused operations 2: nvecs= %d nsums= %d\n", nvecs, nsums);
-  if (print_timing) PrintTableHeader(2);
-  flag = Test_N_VScaleAddMultiVectorArray(X, veclen, nvecs, nsums, ntests);
-  flag = Test_N_VLinearCombinationVectorArray(X, veclen, nvecs, nsums, ntests);
+    if (nsums > 0)
+    {
+      if (print_timing) printf("\n\n fused operations 2: nvecs= %d nsums= %d\n", nvecs, nsums);
+      if (print_timing) PrintTableHeader(2);
+      flag = Test_N_VScaleAddMultiVectorArray(X, veclen, nvecs, nsums, ntests);
+      flag = Test_N_VLinearCombinationVectorArray(X, veclen, nvecs, nsums, ntests);
+    }
+  }
 
   /* Free vectors */
   N_VDestroy(X);


### PR DESCRIPTION
Some benchmarks already allowed for skipping these tests, this update makes the behavior consistent for all the vector benchmarks.
* If `nvecs < 1` skip all fused operation benchmarks
* If `nsums < 1` skip fused vector array operation benchmarks
