### PR TITLE
Bugfix: memory leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 Fixed a bug in the CUDA and HIP vectors where `N_VMaxNorm` would return the
 minimum positive floating-point value for the zero vector.
 
+Fixed memory leaks/out of bounds memory accesses in the ARKODE MRIStep module
+that could occur when attaching a coupling table after reinitialization with a
+different number of stages than originally selected.
+
+Fixed a memory leak in CVODE and CVODES where the projection memory would not be
+deallocated when calling `CVodeFree`.
+
 ## Changes to SUNDIALS in release 6.3.0
 
 Added `GetUserData` functions in each package to retrieve the user data pointer

--- a/doc/arkode/guide/source/Introduction.rst
+++ b/doc/arkode/guide/source/Introduction.rst
@@ -124,6 +124,10 @@ Changes in v5.4.0
 Fixed a bug in the CUDA and HIP vectors where :c:func:`N_VMaxNorm` would return
 the minimum positive floating-point value for the zero vector.
 
+Fixed memory leaks/out of bounds memory accesses in the ARKODE MRIStep module
+that could occur when attaching a coupling table after reinitialization with a
+different number of stages than originally selected.
+
 Changes in v5.3.0
 -----------------
 

--- a/doc/cvode/guide/source/Introduction.rst
+++ b/doc/cvode/guide/source/Introduction.rst
@@ -117,6 +117,9 @@ Changes in v6.4.0
 Fixed a bug in the CUDA and HIP vectors where :c:func:`N_VMaxNorm` would return
 the minimum positive floating-point value for the zero vector.
 
+Fixed a memory leak where the projection memory would not be deallocated when
+calling :c:func:`CVodeFree`.
+
 Changes in v6.3.0
 -----------------
 

--- a/doc/cvodes/guide/source/Introduction.rst
+++ b/doc/cvodes/guide/source/Introduction.rst
@@ -117,6 +117,9 @@ Changes in v6.4.0
 Fixed a bug in the CUDA and HIP vectors where :c:func:`N_VMaxNorm` would return
 the minimum positive floating-point value for the zero vector.
 
+Fixed a memory leak where the projection memory would not be deallocated when
+calling :c:func:`CVodeFree`.
+
 Changes in v6.3.0
 -----------------
 

--- a/examples/arkode/C_serial/ark_kpr_mri.c
+++ b/examples/arkode/C_serial/ark_kpr_mri.c
@@ -306,6 +306,7 @@ int main(int argc, char *argv[])
     B->p=2;
     retval = ARKStepSetTables(inner_arkode_mem, 3, 2, NULL, B);
     if (check_retval(&retval, "ARKStepSetTables", 1)) return 1;
+    ARKodeButcherTable_Free(B);
     break;
   case(1):  /* erk-3-3 fast solver (full problem) */
     inner_arkode_mem = ARKStepCreate(fn, NULL, T0, y, ctx);
@@ -325,6 +326,7 @@ int main(int argc, char *argv[])
     B->p=2;
     retval = ARKStepSetTables(inner_arkode_mem, 3, 2, NULL, B);
     if (check_retval(&retval, "ARKStepSetTables", 1)) return 1;
+    ARKodeButcherTable_Free(B);
     break;
   case(9):
   case(5):  /* erk-4-4 fast solver */
@@ -345,6 +347,7 @@ int main(int argc, char *argv[])
     B->q=4;
     retval = ARKStepSetTables(inner_arkode_mem, 4, 0, NULL, B);
     if (check_retval(&retval, "ARKStepSetTables", 1)) return 1;
+    ARKodeButcherTable_Free(B);
     break;
   case(2):  /* esdirk-3-3 fast solver (full problem) */
     inner_arkode_mem = ARKStepCreate(NULL, fn, T0, y, ctx);
@@ -376,6 +379,7 @@ int main(int argc, char *argv[])
     if (check_retval(&retval, "ARKStepSetJacFn", 1)) return 1;
     retval = ARKStepSStolerances(inner_arkode_mem, reltol, abstol);
     if (check_retval(&retval, "ARKStepSStolerances", 1)) return 1;
+    ARKodeButcherTable_Free(B);
     break;
   case(3):  /* no fast dynamics ('evolve' explicitly w/ erk-3-3) */
   case(4):
@@ -396,6 +400,7 @@ int main(int argc, char *argv[])
     B->p=2;
     retval = ARKStepSetTables(inner_arkode_mem, 3, 2, NULL, B);
     if (check_retval(&retval, "ARKStepSetTables", 1)) return 1;
+    ARKodeButcherTable_Free(B);
   }
 
   /* Set the user data pointer */
@@ -459,6 +464,7 @@ int main(int argc, char *argv[])
     if (check_retval((void *)C, "MRIStepCoupling_MIStoMRI", 0)) return 1;
     retval = MRIStepSetCoupling(arkode_mem, C);
     if (check_retval(&retval, "MRIStepSetCoupling", 1)) return 1;
+    ARKodeButcherTable_Free(B);
     break;
   case(4):  /* dirk-2 (trapezoidal), solve-decoupled slow solver */
     arkode_mem = MRIStepCreate(NULL, fn, T0, y, inner_stepper, ctx);
@@ -656,7 +662,6 @@ int main(int argc, char *argv[])
 
   /* Clean up and return */
   N_VDestroy(y);                             /* Free y vector */
-  ARKodeButcherTable_Free(B);                /* Butcher table */
   MRIStepCoupling_Free(C);                   /* free coupling coefficients */
   SUNMatDestroy(Af);                         /* free fast matrix */
   SUNLinSolFree(LSf);                        /* free fast linear solver */

--- a/examples/cvode/F2003_serial/cv_analytic_sys_dns_jac_f2003.f90
+++ b/examples/cvode/F2003_serial/cv_analytic_sys_dns_jac_f2003.f90
@@ -208,7 +208,6 @@ program main
   real(c_double) :: yvec(neq)
 
   !======= Internals ============
-  ierr = FSUNContext_Create(c_null_ptr, ctx)
 
   ! initialize ODE
   tstart = 0.0d0

--- a/examples/cvode/serial/cvKrylovDemo_ls.c
+++ b/examples/cvode/serial/cvKrylovDemo_ls.c
@@ -459,6 +459,7 @@ int main(int argc, char* argv[])
   FreeUserData(data);
   CVodeFree(&cvode_mem);
   SUNLinSolFree(LS);
+  SUNNonlinSolFree(NLS);
   SUNContext_Free(&sunctx);
 
   return(0);

--- a/examples/cvode/serial/cvParticle_dns.c
+++ b/examples/cvode/serial/cvParticle_dns.c
@@ -294,7 +294,9 @@ int main(int argc, char* argv[])
   PrintStats(cvode_mem);
 
   /* Free memory */
+  free(udata);
   N_VDestroy(y);
+  N_VDestroy(e);
   SUNMatDestroy(A);
   SUNLinSolFree(LS);
   CVodeFree(&cvode_mem);

--- a/examples/cvodes/serial/cvsKrylovDemo_ls.c
+++ b/examples/cvodes/serial/cvsKrylovDemo_ls.c
@@ -444,6 +444,7 @@ int main(int argc, char* argv[])
   FreeUserData(data);
   CVodeFree(&cvode_mem);
   SUNLinSolFree(LS);
+  SUNNonlinSolFree(NLS);
   SUNContext_Free(&sunctx);
 
   return(0);

--- a/examples/cvodes/serial/cvsParticle_dns.c
+++ b/examples/cvodes/serial/cvsParticle_dns.c
@@ -294,7 +294,9 @@ int main(int argc, char* argv[])
   PrintStats(cvode_mem);
 
   /* Free memory */
+  free(udata);
   N_VDestroy(y);
+  N_VDestroy(e);
   SUNMatDestroy(A);
   SUNLinSolFree(LS);
   CVodeFree(&cvode_mem);

--- a/examples/nvector/manyvector/test_fnvector_manyvector_mod.f90
+++ b/examples/nvector/manyvector/test_fnvector_manyvector_mod.f90
@@ -111,10 +111,7 @@ contains
     tmp  => FN_VGetSubvector_ManyVector(x, ival-1)
 
     !==== Cleanup =====
-    tmp => FN_VGetVecAtIndexVectorArray(subvecs, 0)
-    call FN_VDestroy(tmp)
-    tmp => FN_VGetVecAtIndexVectorArray(subvecs, 1)
-    call FN_VDestroy(tmp)
+    call FN_VDestroyVectorArray(subvecs, nsubvecs)
     call FN_VDestroy_ManyVector(x)
     call FN_VDestroy_ManyVector(y)
     call FN_VDestroy_ManyVector(z)
@@ -152,10 +149,7 @@ contains
     fails = Test_FN_VLinearCombination(x, N, 0)
 
     !=== cleanup ====
-    tmp => FN_VGetVecAtIndexVectorArray(subvecs, 0)
-    call FN_VDestroy(tmp)
-    tmp => FN_VGetVecAtIndexVectorArray(subvecs, 1)
-    call FN_VDestroy(tmp)
+    call FN_VDestroyVectorArray(subvecs, nsubvecs)
     call FN_VDestroy_ManyVector(x)
 
   end function unit_tests

--- a/examples/sunlinsol/pcg/serial/test_fsunlinsol_pcg_mod_serial.f90
+++ b/examples/sunlinsol/pcg/serial/test_fsunlinsol_pcg_mod_serial.f90
@@ -211,6 +211,7 @@ contains
     call FN_VDestroy(b)
     call FN_VDestroy(probdata%d)
     call FN_VDestroy(probdata%s)
+    deallocate(probdata)
 
   end function unit_tests
 

--- a/examples/sunlinsol/spbcgs/serial/test_fsunlinsol_spbcgs_mod_serial.f90
+++ b/examples/sunlinsol/spbcgs/serial/test_fsunlinsol_spbcgs_mod_serial.f90
@@ -202,6 +202,7 @@ contains
     call FN_VDestroy(probdata%d)
     call FN_VDestroy(probdata%s1)
     call FN_VDestroy(probdata%s2)
+    deallocate(probdata)
 
   end function unit_tests
 

--- a/examples/sunlinsol/spfgmr/serial/test_fsunlinsol_spfgmr_mod_serial.f90
+++ b/examples/sunlinsol/spfgmr/serial/test_fsunlinsol_spfgmr_mod_serial.f90
@@ -204,6 +204,7 @@ contains
     call FN_VDestroy(probdata%d)
     call FN_VDestroy(probdata%s1)
     call FN_VDestroy(probdata%s2)
+    deallocate(probdata)
 
   end function unit_tests
 

--- a/examples/sunlinsol/spgmr/serial/test_fsunlinsol_spgmr_mod_serial.f90
+++ b/examples/sunlinsol/spgmr/serial/test_fsunlinsol_spgmr_mod_serial.f90
@@ -204,6 +204,7 @@ contains
     call FN_VDestroy(probdata%d)
     call FN_VDestroy(probdata%s1)
     call FN_VDestroy(probdata%s2)
+    deallocate(probdata)
 
   end function unit_tests
 

--- a/examples/sunlinsol/sptfqmr/serial/test_fsunlinsol_sptfqmr_mod_serial.f90
+++ b/examples/sunlinsol/sptfqmr/serial/test_fsunlinsol_sptfqmr_mod_serial.f90
@@ -202,6 +202,7 @@ contains
     call FN_VDestroy(probdata%d)
     call FN_VDestroy(probdata%s1)
     call FN_VDestroy(probdata%s2)
+    deallocate(probdata)
 
   end function unit_tests
 

--- a/src/arkode/arkode_mri_tables.c
+++ b/src/arkode/arkode_mri_tables.c
@@ -1011,13 +1011,13 @@ int mriStepCoupling_GetStageType(MRIStepCoupling MRIC, int is)
 /* ---------------------------------------------------------------------------
  * Computes the stage RHS vector storage maps. With repeated abscissae the
  * first stage of the pair generally corresponds to a column of zeros and so
- * does not need to be computed and stored. The stage_map indicate if the RHS
+ * does not need to be computed and stored. The stage_map indicates if the RHS
  * needs to be computed and where to store it i.e., stage_map[i] > -1.
  * ---------------------------------------------------------------------------*/
 
 int mriStepCoupling_GetStageMap(MRIStepCoupling MRIC,
                                 int* stage_map,
-                                int* nstages_stored)
+                                int* nstages_active)
 {
   int i, j, k, idx;
   realtype Wsum, Gsum;
@@ -1029,14 +1029,14 @@ int mriStepCoupling_GetStageMap(MRIStepCoupling MRIC,
 
   if (!MRIC) return(ARK_ILL_INPUT);
   if (!(MRIC->W) && !(MRIC->G)) return(ARK_ILL_INPUT);
-  if (!stage_map || !nstages_stored) return(ARK_ILL_INPUT);
+  if (!stage_map || !nstages_active) return(ARK_ILL_INPUT);
 
   /* -------------------
    * Compute storage map
    * ------------------- */
 
-  /* Number of stage RHS vectors stored */
-  *nstages_stored = 0;
+  /* Number of stage RHS vectors active */
+  *nstages_active = 0;
 
   /* Initial storage index */
   idx = 0;
@@ -1066,10 +1066,10 @@ int mriStepCoupling_GetStageMap(MRIStepCoupling MRIC,
     }
   }
 
-  /* Check and set number of stage RHS vectors stored */
+  /* Check and set number of stage RHS vectors active */
   if (idx < 1) return(ARK_ILL_INPUT);
 
-  *nstages_stored = idx;
+  *nstages_active = idx;
 
   return(ARK_SUCCESS);
 }

--- a/src/arkode/arkode_mristep.c
+++ b/src/arkode/arkode_mristep.c
@@ -2530,6 +2530,9 @@ int MRIStepInnerStepper_Free(MRIStepInnerStepper *stepper)
   /* free the inner forcing and fused op workspace vector */
   mriStepInnerStepper_FreeVecs(*stepper);
 
+  /* free operations structure */
+  free((*stepper)->ops);
+
   /* free inner stepper mem */
   free(*stepper);
   *stepper = NULL;

--- a/src/arkode/arkode_mristep_impl.h
+++ b/src/arkode/arkode_mristep_impl.h
@@ -74,7 +74,8 @@ typedef struct ARKodeMRIStepMemRec {
   int q;                         /* method order                             */
   int p;                         /* embedding order                          */
   int stages;                    /* total number of stages                   */
-  int nstages_stored;            /* total number of stage RHS vectors stored */
+  int nstages_active;            /* number of active stage RHS vectors       */
+  int nstages_allocated;         /* number of stage RHS vectors allocated    */
   int *stage_map;                /* index map for storing stage RHS vectors  */
   int *stagetypes;               /* type flags for stages                    */
   realtype *Ae_row;              /* equivalent explicit RK coeffs            */
@@ -163,11 +164,12 @@ struct _MRIStepInnerStepper
   SUNContext  sunctx;
 
   /* base class data */
-  N_Vector*  forcing;    /* array of forcing vectors   */
-  int        nforcing;   /* number of forcing vectors  */
-  int        last_flag;  /* last stepper return flag   */
-  realtype   tshift;     /* time normalization shift   */
-  realtype   tscale;     /* time normalization scaling */
+  N_Vector*  forcing;             /* array of forcing vectors            */
+  int        nforcing;            /* number of forcing vectors active    */
+  int        nforcing_allocated;  /* number of forcing vectors allocated */
+  int        last_flag;           /* last stepper return flag            */
+  realtype   tshift;              /* time normalization shift            */
+  realtype   tscale;              /* time normalization scaling          */
 
   /* fused op workspace */
   realtype* vals;

--- a/src/cvode/cvode.c
+++ b/src/cvode/cvode.c
@@ -1622,6 +1622,10 @@ void CVodeFree(void **cvode_mem)
     free(cv_mem->cv_gactive); cv_mem->cv_gactive = NULL;
   }
 
+  if (cv_mem->proj_mem) {
+    cvProjFree(&(cv_mem->proj_mem));
+  }
+
   free(*cvode_mem);
   *cvode_mem = NULL;
 }

--- a/src/cvodes/cvodes.c
+++ b/src/cvodes/cvodes.c
@@ -4078,6 +4078,10 @@ void CVodeFree(void **cvode_mem)
   free(cv_mem->cv_Xvecs); cv_mem->cv_Xvecs = NULL;
   free(cv_mem->cv_Zvecs); cv_mem->cv_Zvecs = NULL;
 
+  if (cv_mem->proj_mem) {
+    cvProjFree(&(cv_mem->proj_mem));
+  }
+
   free(*cvode_mem);
   *cvode_mem = NULL;
 }

--- a/test/unit_tests/arkode/C_serial/CMakeLists.txt
+++ b/test/unit_tests/arkode/C_serial/CMakeLists.txt
@@ -29,7 +29,7 @@ set(ARKODE_unit_tests
   "ark_interp_check\;-100"
   "ark_interp_check\;-10000"
   "ark_interp_check\;-1000000"
-  "ark_reset_check\;1"
+  "ark_reset_check\;"
   )
 
 # Add the build and install targets for each test

--- a/test/unit_tests/arkode/C_serial/ark_reset_check.c
+++ b/test/unit_tests/arkode/C_serial/ark_reset_check.c
@@ -389,9 +389,9 @@ int main()
 
   /* Free MRIStep and ARKStep memory structures */
   MRIStepFree(&mristep_mem);
+  MRIStepInnerStepper_Free(&inner_stepper);
   ARKStepFree(&arkode_mem);
   arkode_mem = NULL;
-
 
   /* Clean up and return with success */
   N_VDestroy(y);

--- a/test/unit_tests/ida/CXX_serial/ida_test_kpr.cpp
+++ b/test/unit_tests/ida/CXX_serial/ida_test_kpr.cpp
@@ -160,6 +160,7 @@ int main(int argc, char* argv[])
 
   // Clean up and return with successful completion
   N_VDestroy(y);
+  N_VDestroy(yp);
   SUNMatDestroy(A);
   SUNLinSolFree(LS);
   IDAFree(&ida_mem);

--- a/test/unit_tests/ida/C_serial/ida_test_getuserdata.c
+++ b/test/unit_tests/ida/C_serial/ida_test_getuserdata.c
@@ -112,6 +112,7 @@ int main(int argc, char *argv[])
   /* Clean up */
   IDAFree(&ida_mem);
   N_VDestroy(y);
+  N_VDestroy(yp);
   SUNContext_Free(&sunctx);
 
   printf("SUCCESS\n");

--- a/test/unit_tests/idas/CXX_serial/idas_test_kpr.cpp
+++ b/test/unit_tests/idas/CXX_serial/idas_test_kpr.cpp
@@ -160,6 +160,7 @@ int main(int argc, char* argv[])
 
   // Clean up and return with successful completion
   N_VDestroy(y);
+  N_VDestroy(yp);
   SUNMatDestroy(A);
   SUNLinSolFree(LS);
   IDAFree(&ida_mem);

--- a/test/unit_tests/idas/C_serial/idas_test_getuserdata.c
+++ b/test/unit_tests/idas/C_serial/idas_test_getuserdata.c
@@ -112,6 +112,7 @@ int main(int argc, char *argv[])
   /* Clean up */
   IDAFree(&ida_mem);
   N_VDestroy(y);
+  N_VDestroy(yp);
   SUNContext_Free(&sunctx);
 
   printf("SUCCESS\n");


### PR DESCRIPTION
* Fix memory leak in CVODE(S) when using projection
* Fix memory leak/out of bounds access in MRIStep when reinitializing and changing methods
* Fix memory leaks in various examples/tests 