### PR TITLE
Bugfix: Intel oneAPI 2022.2 Fortran

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Fixed a bug with the Kokkos interfaces that would arise when using clang.
 
+Fixed a compilation error with the Intel oneAPI 2022.2 Fortran compiler in the
+Fortran 2003 interface test for the serial NVector.
+
 ## Changes to SUNDIALS in release 6.4.0
 
 CMake 3.18.0 or newer is now required for CUDA support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 Fixed a bug with the Kokkos interfaces that would arise when using clang.
 
 Fixed a compilation error with the Intel oneAPI 2022.2 Fortran compiler in the
-Fortran 2003 interface test for the serial NVector.
+Fortran 2003 interface test for the serial `N_Vector`.
 
 ## Changes to SUNDIALS in release 6.4.0
 

--- a/doc/arkode/guide/source/Introduction.rst
+++ b/doc/arkode/guide/source/Introduction.rst
@@ -124,7 +124,7 @@ Changes in v5.4.1
 Fixed a bug with the Kokkos interfaces that would arise when using clang.
 
 Fixed a compilation error with the Intel oneAPI 2022.2 Fortran compiler in the
-Fortran 2003 interface test for the serial NVector.
+Fortran 2003 interface test for the serial ``N_Vector``.
 
 Changes in v5.4.0
 -----------------

--- a/doc/arkode/guide/source/Introduction.rst
+++ b/doc/arkode/guide/source/Introduction.rst
@@ -123,6 +123,9 @@ Changes in v5.4.1
 
 Fixed a bug with the Kokkos interfaces that would arise when using clang.
 
+Fixed a compilation error with the Intel oneAPI 2022.2 Fortran compiler in the
+Fortran 2003 interface test for the serial NVector.
+
 Changes in v5.4.0
 -----------------
 

--- a/doc/cvode/guide/source/Introduction.rst
+++ b/doc/cvode/guide/source/Introduction.rst
@@ -117,7 +117,7 @@ Changes in v6.4.1
 Fixed a bug with the Kokkos interfaces that would arise when using clang.
 
 Fixed a compilation error with the Intel oneAPI 2022.2 Fortran compiler in the
-Fortran 2003 interface test for the serial NVector.
+Fortran 2003 interface test for the serial ``N_Vector``.
 
 Changes in v6.4.0
 -----------------

--- a/doc/cvode/guide/source/Introduction.rst
+++ b/doc/cvode/guide/source/Introduction.rst
@@ -116,6 +116,9 @@ Changes in v6.4.1
 
 Fixed a bug with the Kokkos interfaces that would arise when using clang.
 
+Fixed a compilation error with the Intel oneAPI 2022.2 Fortran compiler in the
+Fortran 2003 interface test for the serial NVector.
+
 Changes in v6.4.0
 -----------------
 

--- a/doc/cvodes/guide/source/Introduction.rst
+++ b/doc/cvodes/guide/source/Introduction.rst
@@ -117,7 +117,7 @@ Changes in v6.4.1
 Fixed a bug with the Kokkos interfaces that would arise when using clang.
 
 Fixed a compilation error with the Intel oneAPI 2022.2 Fortran compiler in the
-Fortran 2003 interface test for the serial NVector.
+Fortran 2003 interface test for the serial ``N_Vector``.
 
 Changes in v6.4.0
 -----------------

--- a/doc/cvodes/guide/source/Introduction.rst
+++ b/doc/cvodes/guide/source/Introduction.rst
@@ -116,6 +116,9 @@ Changes in v6.4.1
 
 Fixed a bug with the Kokkos interfaces that would arise when using clang.
 
+Fixed a compilation error with the Intel oneAPI 2022.2 Fortran compiler in the
+Fortran 2003 interface test for the serial NVector.
+
 Changes in v6.4.0
 -----------------
 

--- a/doc/ida/guide/source/Introduction.rst
+++ b/doc/ida/guide/source/Introduction.rst
@@ -78,7 +78,7 @@ Changes in v6.4.1
 Fixed a bug with the Kokkos interfaces that would arise when using clang.
 
 Fixed a compilation error with the Intel oneAPI 2022.2 Fortran compiler in the
-Fortran 2003 interface test for the serial NVector.
+Fortran 2003 interface test for the serial ``N_Vector``.
 
 Changes in v6.4.0
 -----------------

--- a/doc/ida/guide/source/Introduction.rst
+++ b/doc/ida/guide/source/Introduction.rst
@@ -77,6 +77,9 @@ Changes in v6.4.1
 
 Fixed a bug with the Kokkos interfaces that would arise when using clang.
 
+Fixed a compilation error with the Intel oneAPI 2022.2 Fortran compiler in the
+Fortran 2003 interface test for the serial NVector.
+
 Changes in v6.4.0
 -----------------
 

--- a/doc/idas/guide/source/Introduction.rst
+++ b/doc/idas/guide/source/Introduction.rst
@@ -91,6 +91,9 @@ Changes in v5.4.1
 
 Fixed a bug with the Kokkos interfaces that would arise when using clang.
 
+Fixed a compilation error with the Intel oneAPI 2022.2 Fortran compiler in the
+Fortran 2003 interface test for the serial NVector.
+
 Changes in v5.4.0
 -----------------
 

--- a/doc/idas/guide/source/Introduction.rst
+++ b/doc/idas/guide/source/Introduction.rst
@@ -92,7 +92,7 @@ Changes in v5.4.1
 Fixed a bug with the Kokkos interfaces that would arise when using clang.
 
 Fixed a compilation error with the Intel oneAPI 2022.2 Fortran compiler in the
-Fortran 2003 interface test for the serial NVector.
+Fortran 2003 interface test for the serial ``N_Vector``.
 
 Changes in v5.4.0
 -----------------

--- a/doc/kinsol/guide/source/Introduction.rst
+++ b/doc/kinsol/guide/source/Introduction.rst
@@ -93,6 +93,9 @@ Changes in v6.4.1
 
 Fixed a bug with the Kokkos interfaces that would arise when using clang.
 
+Fixed a compilation error with the Intel oneAPI 2022.2 Fortran compiler in the
+Fortran 2003 interface test for the serial NVector.
+
 Changes in v6.4.0
 -----------------
 

--- a/doc/kinsol/guide/source/Introduction.rst
+++ b/doc/kinsol/guide/source/Introduction.rst
@@ -94,7 +94,7 @@ Changes in v6.4.1
 Fixed a bug with the Kokkos interfaces that would arise when using clang.
 
 Fixed a compilation error with the Intel oneAPI 2022.2 Fortran compiler in the
-Fortran 2003 interface test for the serial NVector.
+Fortran 2003 interface test for the serial ``N_Vector``.
 
 Changes in v6.4.0
 -----------------

--- a/examples/nvector/test_nvector.f90
+++ b/examples/nvector/test_nvector.f90
@@ -113,7 +113,9 @@ integer(C_INT) function Test_FN_VLinearCombination(X, local_length, myid) &
   Y3 => FN_VClone(X)
 
   ! set vectors in vector array
-  V = (/c_loc(Y1), c_loc(Y2), c_loc(Y3)/)
+  V(1) = c_loc(Y1)
+  V(2) = c_loc(Y2)
+  V(3) = c_loc(Y3)
   Vptr = c_loc(V)
 
   ! initialize c values


### PR DESCRIPTION
Fix compilation error when building the serial NVector Fortran 2003 example with the Intel oneAPI 2022.2 Fortran compiler.