### PR TITLE
Fix floating-point underflow during root finding in cvode and arkode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # SUNDIALS Changelog
 
+## Changes to SUNDIALS in release 6.4.2
+
+Fixed an underflow bug during root finding in ARKODE, CVODE, CVODES, IDA and IDAS.
+
 ## Changes to SUNDIALS in release 6.4.1
 
 Fixed a bug with the Kokkos interfaces that would arise when using clang.

--- a/doc/arkode/guide/source/Introduction.rst
+++ b/doc/arkode/guide/source/Introduction.rst
@@ -118,6 +118,11 @@ provided with SUNDIALS, or again may utilize a user-supplied module.
 Changes from previous versions
 ==============================
 
+Changes in v5.4.2
+-----------------
+
+Fixed an underflow bug during root finding.
+
 Changes in v5.4.1
 -----------------
 

--- a/doc/cvode/guide/source/Introduction.rst
+++ b/doc/cvode/guide/source/Introduction.rst
@@ -111,6 +111,11 @@ implementations.
 Changes from previous versions
 ==============================
 
+Changes in v6.4.2
+-----------------
+
+Fixed an underflow bug during root finding.
+
 Changes in v6.4.1
 -----------------
 

--- a/doc/cvodes/guide/source/Introduction.rst
+++ b/doc/cvodes/guide/source/Introduction.rst
@@ -111,6 +111,11 @@ Fortran.
 Changes from previous versions
 ==============================
 
+Changes in v6.4.2
+-----------------
+
+Fixed an underflow bug during root finding.
+
 Changes in v6.4.1
 -----------------
 

--- a/doc/ida/guide/source/Introduction.rst
+++ b/doc/ida/guide/source/Introduction.rst
@@ -72,6 +72,11 @@ systems.
 Changes from previous versions
 ==============================
 
+Changes in v6.4.2
+-----------------
+
+Fixed an underflow bug during root finding.
+
 Changes in v6.4.1
 -----------------
 

--- a/doc/idas/guide/source/Introduction.rst
+++ b/doc/idas/guide/source/Introduction.rst
@@ -86,6 +86,11 @@ integrate any final-condition ODE dependent on the solution of the original IVP
 Changes from previous versions
 ==============================
 
+Changes in v5.4.2
+-----------------
+
+Fixed an underflow bug during root finding.
+
 Changes in v5.4.1
 -----------------
 

--- a/src/arkode/arkode_root.c
+++ b/src/arkode/arkode_root.c
@@ -526,6 +526,7 @@ int arkRootCheck3(void* arkode_mem)
   return(RTFOUND);
 }
 
+#define DIFFERENT_SIGN(a,b) ( ( (a) < 0 && (b) > 0 ) || ( (a) > 0 && (b) < 0 ) )
 
 /*---------------------------------------------------------------
   arkRootfind
@@ -631,7 +632,7 @@ int arkRootfind(void* arkode_mem)
         zroot = SUNTRUE;
       }
     } else {
-      if ( (rootmem->glo[i]*rootmem->ghi[i] < ZERO) &&
+      if ( (DIFFERENT_SIGN(rootmem->glo[i], rootmem->ghi[i])) &&
            (rootmem->rootdir[i]*rootmem->glo[i] <= ZERO) ) {
         gfrac = SUNRabs(rootmem->ghi[i]/(rootmem->ghi[i] - rootmem->glo[i]));
         if (gfrac > maxfrac) {
@@ -719,7 +720,7 @@ int arkRootfind(void* arkode_mem)
           zroot = SUNTRUE;
         }
       } else {
-        if ( (rootmem->glo[i]*rootmem->grout[i] < ZERO) &&
+        if ( (DIFFERENT_SIGN(rootmem->glo[i], rootmem->grout[i])) &&
              (rootmem->rootdir[i]*rootmem->glo[i] <= ZERO) ) {
           gfrac = SUNRabs(rootmem->grout[i]/(rootmem->grout[i] - rootmem->glo[i]));
           if (gfrac > maxfrac) {
@@ -770,7 +771,7 @@ int arkRootfind(void* arkode_mem)
     if ( (SUNRabs(rootmem->ghi[i]) == ZERO) &&
          (rootmem->rootdir[i]*rootmem->glo[i] <= ZERO) )
       rootmem->iroots[i] = rootmem->glo[i] > 0 ? -1:1;
-    if ( (rootmem->glo[i]*rootmem->ghi[i] < ZERO) &&
+    if ( (DIFFERENT_SIGN(rootmem->glo[i], rootmem->ghi[i])) &&
          (rootmem->rootdir[i]*rootmem->glo[i] <= ZERO) )
       rootmem->iroots[i] = rootmem->glo[i] > 0 ? -1:1;
   }

--- a/src/cvode/cvode.c
+++ b/src/cvode/cvode.c
@@ -4078,6 +4078,8 @@ static int cvRcheck3(CVodeMem cv_mem)
   return(RTFOUND);
 }
 
+#define DIFFERENT_SIGN(a,b) ( ( (a) < 0 && (b) > 0 ) || ( (a) > 0 && (b) < 0 ) )
+
 /*
  * cvRootfind
  *
@@ -4174,7 +4176,7 @@ static int cvRootfind(CVodeMem cv_mem)
         zroot = SUNTRUE;
       }
     } else {
-      if ( (cv_mem->cv_glo[i]*cv_mem->cv_ghi[i] < ZERO) &&
+      if ( (DIFFERENT_SIGN(cv_mem->cv_glo[i], cv_mem->cv_ghi[i])) &&
            (cv_mem->cv_rootdir[i]*cv_mem->cv_glo[i] <= ZERO) ) {
         gfrac = SUNRabs(cv_mem->cv_ghi[i]/(cv_mem->cv_ghi[i] - cv_mem->cv_glo[i]));
         if (gfrac > maxfrac) {
@@ -4262,7 +4264,7 @@ static int cvRootfind(CVodeMem cv_mem)
       if (SUNRabs(cv_mem->cv_grout[i]) == ZERO) {
         if(cv_mem->cv_rootdir[i]*cv_mem->cv_glo[i] <= ZERO) zroot = SUNTRUE;
       } else {
-        if ( (cv_mem->cv_glo[i]*cv_mem->cv_grout[i] < ZERO) &&
+        if ( (DIFFERENT_SIGN(cv_mem->cv_glo[i],cv_mem->cv_grout[i])) &&
              (cv_mem->cv_rootdir[i]*cv_mem->cv_glo[i] <= ZERO) ) {
           gfrac = SUNRabs(cv_mem->cv_grout[i] /
                           (cv_mem->cv_grout[i] - cv_mem->cv_glo[i]));
@@ -4313,7 +4315,7 @@ static int cvRootfind(CVodeMem cv_mem)
     if ( (SUNRabs(cv_mem->cv_ghi[i]) == ZERO) &&
          (cv_mem->cv_rootdir[i]*cv_mem->cv_glo[i] <= ZERO) )
       cv_mem->cv_iroots[i] = cv_mem->cv_glo[i] > 0 ? -1 : 1;
-    if ( (cv_mem->cv_glo[i]*cv_mem->cv_ghi[i] < ZERO) &&
+    if ( (DIFFERENT_SIGN(cv_mem->cv_glo[i],cv_mem->cv_ghi[i])) &&
          (cv_mem->cv_rootdir[i]*cv_mem->cv_glo[i] <= ZERO) )
       cv_mem->cv_iroots[i] = cv_mem->cv_glo[i] > 0 ? -1 : 1;
   }

--- a/src/cvodes/cvodes.c
+++ b/src/cvodes/cvodes.c
@@ -8138,6 +8138,8 @@ static int cvRcheck3(CVodeMem cv_mem)
   return(RTFOUND);
 }
 
+#define DIFFERENT_SIGN(a,b) ( ( (a) < 0 && (b) > 0 ) || ( (a) > 0 && (b) < 0 ) )
+
 /*
  * cvRootfind
  *
@@ -8234,7 +8236,7 @@ static int cvRootfind(CVodeMem cv_mem)
         zroot = SUNTRUE;
       }
     } else {
-      if ( (cv_mem->cv_glo[i]*cv_mem->cv_ghi[i] < ZERO) &&
+      if ( (DIFFERENT_SIGN(cv_mem->cv_glo[i], cv_mem->cv_ghi[i])) &&
            (cv_mem->cv_rootdir[i]*cv_mem->cv_glo[i] <= ZERO) ) {
         gfrac = SUNRabs(cv_mem->cv_ghi[i]/(cv_mem->cv_ghi[i] - cv_mem->cv_glo[i]));
         if (gfrac > maxfrac) {
@@ -8322,7 +8324,7 @@ static int cvRootfind(CVodeMem cv_mem)
       if (SUNRabs(cv_mem->cv_grout[i]) == ZERO) {
         if(cv_mem->cv_rootdir[i]*cv_mem->cv_glo[i] <= ZERO) zroot = SUNTRUE;
       } else {
-        if ( (cv_mem->cv_glo[i]*cv_mem->cv_grout[i] < ZERO) &&
+        if ( (DIFFERENT_SIGN(cv_mem->cv_glo[i], cv_mem->cv_grout[i])) &&
              (cv_mem->cv_rootdir[i]*cv_mem->cv_glo[i] <= ZERO) ) {
           gfrac = SUNRabs(cv_mem->cv_grout[i] /
                           (cv_mem->cv_grout[i] - cv_mem->cv_glo[i]));
@@ -8373,7 +8375,7 @@ static int cvRootfind(CVodeMem cv_mem)
     if ( (SUNRabs(cv_mem->cv_ghi[i]) == ZERO) &&
          (cv_mem->cv_rootdir[i]*cv_mem->cv_glo[i] <= ZERO) )
       cv_mem->cv_iroots[i] = cv_mem->cv_glo[i] > 0 ? -1 : 1;
-    if ( (cv_mem->cv_glo[i]*cv_mem->cv_ghi[i] < ZERO) &&
+    if ( (DIFFERENT_SIGN(cv_mem->cv_glo[i], cv_mem->cv_ghi[i])) &&
          (cv_mem->cv_rootdir[i]*cv_mem->cv_glo[i] <= ZERO) )
       cv_mem->cv_iroots[i] = cv_mem->cv_glo[i] > 0 ? -1 : 1;
   }

--- a/src/ida/ida.c
+++ b/src/ida/ida.c
@@ -3436,6 +3436,8 @@ static int IDARcheck3(IDAMem IDA_mem)
   return(RTFOUND);
 }
 
+#define DIFFERENT_SIGN(a,b) ( ( (a) < 0 && (b) > 0 ) || ( (a) > 0 && (b) < 0 ) )
+
 /*
  * IDARootfind
  *
@@ -3533,7 +3535,7 @@ static int IDARootfind(IDAMem IDA_mem)
         zroot = SUNTRUE;
       }
     } else {
-      if ( (IDA_mem->ida_glo[i] * IDA_mem->ida_ghi[i] < ZERO) &&
+      if ( (DIFFERENT_SIGN(IDA_mem->ida_glo[i], IDA_mem->ida_ghi[i])) &&
            (IDA_mem->ida_rootdir[i] * IDA_mem->ida_glo[i] <= ZERO) ) {
         gfrac = SUNRabs(IDA_mem->ida_ghi[i] / (IDA_mem->ida_ghi[i] - IDA_mem->ida_glo[i]));
         if (gfrac > maxfrac) {
@@ -3624,7 +3626,7 @@ static int IDARootfind(IDAMem IDA_mem)
         if(IDA_mem->ida_rootdir[i] * IDA_mem->ida_glo[i] <= ZERO)
           zroot = SUNTRUE;
       } else {
-        if ( (IDA_mem->ida_glo[i] * IDA_mem->ida_grout[i] < ZERO) &&
+        if ( (DIFFERENT_SIGN(IDA_mem->ida_glo[i], IDA_mem->ida_grout[i])) &&
              (IDA_mem->ida_rootdir[i] * IDA_mem->ida_glo[i] <= ZERO) ) {
           gfrac = SUNRabs(IDA_mem->ida_grout[i] /
                           (IDA_mem->ida_grout[i] - IDA_mem->ida_glo[i]));
@@ -3677,7 +3679,7 @@ static int IDARootfind(IDAMem IDA_mem)
     if ( (SUNRabs(IDA_mem->ida_ghi[i]) == ZERO) &&
          (IDA_mem->ida_rootdir[i] * IDA_mem->ida_glo[i] <= ZERO) )
       IDA_mem->ida_iroots[i] = IDA_mem->ida_glo[i] > 0 ? -1:1;
-    if ( (IDA_mem->ida_glo[i] * IDA_mem->ida_ghi[i] < ZERO) &&
+    if ( (DIFFERENT_SIGN(IDA_mem->ida_glo[i], IDA_mem->ida_ghi[i])) &&
          (IDA_mem->ida_rootdir[i] * IDA_mem->ida_glo[i] <= ZERO) )
       IDA_mem->ida_iroots[i] = IDA_mem->ida_glo[i] > 0 ? -1:1;
   }

--- a/src/idas/idas.c
+++ b/src/idas/idas.c
@@ -7430,6 +7430,8 @@ static int IDARcheck3(IDAMem IDA_mem)
   return(RTFOUND);
 }
 
+#define DIFFERENT_SIGN(a,b) ( ( (a) < 0 && (b) > 0 ) || ( (a) > 0 && (b) < 0 ) )
+
 /*
  * IDARootfind
  *
@@ -7527,7 +7529,7 @@ static int IDARootfind(IDAMem IDA_mem)
         zroot = SUNTRUE;
       }
     } else {
-      if ( (IDA_mem->ida_glo[i] * IDA_mem->ida_ghi[i] < ZERO) &&
+      if ( (DIFFERENT_SIGN(IDA_mem->ida_glo[i], IDA_mem->ida_ghi[i])) &&
            (IDA_mem->ida_rootdir[i] * IDA_mem->ida_glo[i] <= ZERO) ) {
         gfrac = SUNRabs(IDA_mem->ida_ghi[i] / (IDA_mem->ida_ghi[i] - IDA_mem->ida_glo[i]));
         if (gfrac > maxfrac) {
@@ -7618,7 +7620,7 @@ static int IDARootfind(IDAMem IDA_mem)
         if(IDA_mem->ida_rootdir[i] * IDA_mem->ida_glo[i] <= ZERO)
           zroot = SUNTRUE;
       } else {
-        if ( (IDA_mem->ida_glo[i] * IDA_mem->ida_grout[i] < ZERO) &&
+        if ( (DIFFERENT_SIGN(IDA_mem->ida_glo[i], IDA_mem->ida_grout[i])) &&
              (IDA_mem->ida_rootdir[i] * IDA_mem->ida_glo[i] <= ZERO) ) {
           gfrac = SUNRabs(IDA_mem->ida_grout[i] /
                           (IDA_mem->ida_grout[i] - IDA_mem->ida_glo[i]));
@@ -7671,7 +7673,7 @@ static int IDARootfind(IDAMem IDA_mem)
     if ( (SUNRabs(IDA_mem->ida_ghi[i]) == ZERO) &&
          (IDA_mem->ida_rootdir[i] * IDA_mem->ida_glo[i] <= ZERO) )
       IDA_mem->ida_iroots[i] = IDA_mem->ida_glo[i] > 0 ? -1:1;
-    if ( (IDA_mem->ida_glo[i] * IDA_mem->ida_ghi[i] < ZERO) &&
+    if ( (DIFFERENT_SIGN(IDA_mem->ida_glo[i], IDA_mem->ida_ghi[i])) &&
          (IDA_mem->ida_rootdir[i] * IDA_mem->ida_glo[i] <= ZERO) )
       IDA_mem->ida_iroots[i] = IDA_mem->ida_glo[i] > 0 ? -1:1;
   }


### PR DESCRIPTION
This is a PR cherry picking https://github.com/novadiscovery/sundials/commit/f7a725e9964a4177b6055a972ff25fea48c404f0 to fix issue #57 