### PR TITLE
Fix link on non-Linux

### DIFF
--- a/src/nvector/pthreads/CMakeLists.txt
+++ b/src/nvector/pthreads/CMakeLists.txt
@@ -26,6 +26,8 @@ sundials_add_library(sundials_nvecpthreads
     nvector
   OBJECT_LIBRARIES
     sundials_generic_obj
+  LINK_LIBRARIES
+    PRIVATE Threads::Threads
   OUTPUT_NAME
     sundials_nvecpthreads
   VERSION


### PR DESCRIPTION
With at least version 3.25.1 of cmake, the link line of the test_nvector_pthreads ends up so:

```
/usr/bin/cc -fcommon -Wl,-z,relro -Wl,-z,now CMakeFiles/test_nvector_pthreads.dir/test_nvector_pthreads.c.o ../CMakeFiles/test_nvector_obj.dir/test_nvector.c.o -o test_nvector_pthreads  -Wl,-rpath,/<<PKGBUILDDIR>>/debian/build/src/nvector/pthreads/fmod:/<<PKGBUILDDIR>>/debian/build/src/nvector/serial:/<<PKGBUILDDIR>>/debian/build/src/nvector/pthreads ../../../src/nvector/pthreads/fmod/libsundials_fnvecpthreads_mod.so.6.4.1 -lm -lpthread ../../../src/nvector/serial/libsundials_nvecserial.so.6.4.1 ../../../src/nvector/pthreads/libsundials_nvecpthreads.so.6.4.1
```

but that fails to link with:

```
/usr/bin/ld: ../../../src/nvector/pthreads/libsundials_nvecpthreads.so.6.4.1: undefined reference to `pthread_create' /usr/bin/ld: ../../../src/nvector/pthreads/libsundials_nvecpthreads.so.6.4.1: undefined reference to `pthread_join'
```

because since -lpthread is before libsundials_nvecpthreads.so.6.4.1 in the link line, the "as-needed" link optimization ignores -lpthread.

Anyway, libsundials_nvecpthreads should be already linking against libpthread, and not have its user have to determine that they should use -lpthread. This is what this commit does, thus fixing building sundials on non-Linux entirely (on Linux, glibc has moved all pthread symbols into libc so the problem doesn't appear there any more)