### PR TITLE
Bugfix: SYLC example builds with C soruce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # SUNDIALS Changelog
 
+## Changes to SUNDIALS in release 6.6.0
+
+Fixed compilation errors in some SYCL examples when using the `icx` compiler.
+
 ## Changes to SUNDIALS in release 6.5.0
 
 Added the functions `ARKStepGetJac`, `ARKStepGetJacTime`,

--- a/doc/arkode/guide/source/Introduction.rst
+++ b/doc/arkode/guide/source/Introduction.rst
@@ -118,6 +118,11 @@ provided with SUNDIALS, or again may utilize a user-supplied module.
 Changes from previous versions
 ==============================
 
+Changes in v5.6.0
+-----------------
+
+Fixed compilation errors in some SYCL examples when using the ``icx`` compiler.
+
 Changes in v5.5.0
 -----------------
 

--- a/doc/cvode/guide/source/Introduction.rst
+++ b/doc/cvode/guide/source/Introduction.rst
@@ -111,6 +111,11 @@ implementations.
 Changes from previous versions
 ==============================
 
+Changes in v6.6.0
+-----------------
+
+Fixed compilation errors in some SYCL examples when using the ``icx`` compiler.
+
 Changes in v6.5.0
 -----------------
 

--- a/doc/cvodes/guide/source/Introduction.rst
+++ b/doc/cvodes/guide/source/Introduction.rst
@@ -111,6 +111,11 @@ Fortran.
 Changes from previous versions
 ==============================
 
+Changes in v6.6.0
+-----------------
+
+Fixed compilation errors in some SYCL examples when using the ``icx`` compiler.
+
 Changes in v6.5.0
 -----------------
 

--- a/doc/ida/guide/source/Introduction.rst
+++ b/doc/ida/guide/source/Introduction.rst
@@ -72,6 +72,11 @@ systems.
 Changes from previous versions
 ==============================
 
+Changes in v6.6.0
+-----------------
+
+Fixed compilation errors in some SYCL examples when using the ``icx`` compiler.
+
 Changes in v6.5.0
 -----------------
 

--- a/doc/idas/guide/source/Introduction.rst
+++ b/doc/idas/guide/source/Introduction.rst
@@ -86,6 +86,11 @@ integrate any final-condition ODE dependent on the solution of the original IVP
 Changes from previous versions
 ==============================
 
+Changes in v5.6.0
+-----------------
+
+Fixed compilation errors in some SYCL examples when using the ``icx`` compiler.
+
 Changes in v5.5.0
 -----------------
 

--- a/doc/kinsol/guide/source/Introduction.rst
+++ b/doc/kinsol/guide/source/Introduction.rst
@@ -88,6 +88,11 @@ applications written in Fortran.
 Changes from previous versions
 ==============================
 
+Changes in v6.6.0
+-----------------
+
+Fixed compilation errors in some SYCL examples when using the ``icx`` compiler.
+
 Changes in v6.5.0
 -----------------
 

--- a/doc/shared/Install.rst
+++ b/doc/shared/Install.rst
@@ -938,10 +938,11 @@ illustration only.
 
    .. note::
 
-      At present the only supported SYCL compiler is the DPC++ (Intel oneAPI)
-      compiler. CMake does not currently support autodetection of SYCL compilers
-      and ``CMAKE_CXX_COMPILER`` must be set to a valid SYCL compiler i.e.,
-      ``dpcpp`` in order to build with SYCL support.
+      CMake does not currently support autodetection of SYCL compilers and
+      ``CMAKE_CXX_COMPILER`` must be set to a valid SYCL compiler. At present
+      the only supported SYCL compilers are the Intel oneAPI compilers i.e.,
+      ``dpcpp`` and ``icpx``. When using ``icpx`` the ``-fsycl`` flag and any
+      ahead of time compilation flags must be added to ``CMAKE_CXX_FLAGS``.
 
 
 .. cmakeoption:: SUNDIALS_LOGGING_LEVEL

--- a/examples/sunlinsol/CMakeLists.txt
+++ b/examples/sunlinsol/CMakeLists.txt
@@ -32,6 +32,10 @@ add_subdirectory(pcg/serial)
 
 # Build the sunlinsol test utilities
 add_library(test_sunlinsol_obj OBJECT test_sunlinsol.c test_sunlinsol.h)
+if(BUILD_SHARED_LIBS)
+  # need PIC when shared libs are used since the example executables will link to the shared lib
+  set_property(TARGET test_sunlinsol_obj PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+endif()
 target_link_libraries(test_sunlinsol_obj PRIVATE sundials_sunlinsoldense)
 
 if(ENABLE_MPI AND MPI_C_FOUND)

--- a/examples/sunlinsol/onemkldense/CMakeLists.txt
+++ b/examples/sunlinsol/onemkldense/CMakeLists.txt
@@ -40,7 +40,7 @@ foreach(example_tuple ${sunlinsols_onemkldense_examples})
   if (NOT TARGET ${example_target})
 
     # example source files
-    add_executable(${example_target} ${example} ../test_sunlinsol.c ../test_sunlinsol.h)
+    add_executable(${example_target} ${example})
 
     # folder for IDEs
     set_target_properties(${example_target} PROPERTIES FOLDER "Examples")
@@ -48,6 +48,7 @@ foreach(example_tuple ${sunlinsols_onemkldense_examples})
     # libraries to link against
     target_link_libraries(${example_target}
       PRIVATE
+      test_sunlinsol_obj
       sundials_nvecsycl
       sundials_sunlinsolonemkldense
       MKL::MKL_DPCPP

--- a/examples/sunmatrix/CMakeLists.txt
+++ b/examples/sunmatrix/CMakeLists.txt
@@ -27,6 +27,10 @@ add_subdirectory(sparse)
 
 # Build the sunmatrix test utilities
 add_library(test_sunmatrix_obj OBJECT test_sunmatrix.c test_sunmatrix.h)
+if(BUILD_SHARED_LIBS)
+  # need PIC when shared libs are used since the example executables will link to the shared lib
+  set_property(TARGET test_sunmatrix_obj PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+endif()
 target_link_libraries(test_sunmatrix_obj PRIVATE sundials_sunmatrixdense)
 
 if(BUILD_SUNMATRIX_CUSPARSE)

--- a/examples/sunmatrix/onemkldense/CMakeLists.txt
+++ b/examples/sunmatrix/onemkldense/CMakeLists.txt
@@ -42,7 +42,7 @@ foreach(example_tuple ${sunmatrix_onemkldense_examples})
   if (NOT TARGET ${example_target})
 
     # example source files
-    add_executable(${example_target} ${example} ../test_sunmatrix.c ../test_sunmatrix.h)
+    add_executable(${example_target} ${example})
 
     # folder for IDEs
     set_target_properties(${example_target} PROPERTIES FOLDER "Examples")
@@ -50,6 +50,7 @@ foreach(example_tuple ${sunmatrix_onemkldense_examples})
     # libraries to link against
     target_link_libraries(${example_target}
       PRIVATE
+      test_sunmatrix_obj
       sundials_nvecsycl
       sundials_sunmatrixonemkldense
       MKL::MKL_DPCPP


### PR DESCRIPTION
Fixes #251. The `icx` compiler will treat C files as C++ files when the `-fsycl` flag is present (the flag appears to be picked up when linking to oneMKL). This causes compilation failures due to C standard flags added by CMake. This only impacts the oneMKL matrix and linear solver examples and is addressed by using the separately compiled object library for the shared C test code. 