### PR TITLE
Fix initialization warnings

### DIFF
--- a/benchmarks/nvector/test_nvector_performance.c
+++ b/benchmarks/nvector/test_nvector_performance.c
@@ -1301,7 +1301,8 @@ int Test_N_VLinearCombination(N_Vector X, sunindextype local_length, int nvecs, 
   double   favgtime, fsdevtime, fmintime, fmaxtime;
   double   uavgtime, usdevtime, umintime, umaxtime;
   double   *ftimes, *utimes;
-  int      i, j, ier;
+  int      i, j;
+  int      ier = 0;
   realtype *c;
   N_Vector *Y;
 
@@ -1513,7 +1514,8 @@ int Test_N_VScaleAddMulti(N_Vector X, sunindextype local_length, int nvecs, int 
   double   favgtime, fsdevtime, fmintime, fmaxtime;
   double   uavgtime, usdevtime, umintime, umaxtime;
   double   *ftimes, *utimes;
-  int      i, j, ier;
+  int      i, j;
+  int      ier = 0;
   realtype *c;
   N_Vector *Y, *Z;
 
@@ -1645,7 +1647,8 @@ int Test_N_VDotProdMulti(N_Vector X, sunindextype local_length, int nvecs, int n
   double   favgtime, fsdevtime, fmintime, fmaxtime;
   double   uavgtime, usdevtime, umintime, umaxtime;
   double   *ftimes, *utimes;
-  int      i, j, ier;
+  int      i, j;
+  int      ier = 0;
   realtype *c;
   N_Vector *Y;
 
@@ -1718,7 +1721,8 @@ int Test_N_VLinearSumVectorArray(N_Vector V, sunindextype local_length,
   double   favgtime, fsdevtime, fmintime, fmaxtime;
   double   uavgtime, usdevtime, umintime, umaxtime;
   double   *ftimes, *utimes;
-  int      i, j, ier;
+  int      i, j;
+  int      ier = 0;
   realtype a, b;
   N_Vector *X, *Y, *Z;
 
@@ -1803,7 +1807,8 @@ int Test_N_VScaleVectorArray(N_Vector X, sunindextype local_length,
   double   favgtime, fsdevtime, fmintime, fmaxtime;
   double   uavgtime, usdevtime, umintime, umaxtime;
   double   *ftimes, *utimes;
-  int      i, j, ier;
+  int      i, j;
+  int      ier = 0;
   realtype *c;
   N_Vector *Y, *Z;
 
@@ -1932,7 +1937,8 @@ int Test_N_VConstVectorArray(N_Vector X, sunindextype local_length,
   double   favgtime, fsdevtime, fmintime, fmaxtime;
   double   uavgtime, usdevtime, umintime, umaxtime;
   double   *ftimes, *utimes;
-  int      i, j, ier;
+  int      i, j;
+  int      ier = 0;
   realtype c;
   N_Vector *Y;
 
@@ -2007,7 +2013,8 @@ int Test_N_VWrmsNormVectorArray(N_Vector X, sunindextype local_length,
   double   favgtime, fsdevtime, fmintime, fmaxtime;
   double   uavgtime, usdevtime, umintime, umaxtime;
   double   *ftimes, *utimes;
-  int      i, j, ier;
+  int      i, j;
+  int      ier = 0;
   realtype *c;
   N_Vector *Z, *W;
 
@@ -2088,7 +2095,8 @@ int Test_N_VWrmsNormMaskVectorArray(N_Vector X, sunindextype local_length,
   double   favgtime, fsdevtime, fmintime, fmaxtime;
   double   uavgtime, usdevtime, umintime, umaxtime;
   double   *ftimes, *utimes;
-  int      i, j, ier;
+  int      i, j;
+  int      ier = 0;
   realtype *c;
   N_Vector *Z, *W, ID;
 
@@ -2173,7 +2181,8 @@ int Test_N_VScaleAddMultiVectorArray(N_Vector V, sunindextype local_length,
   double   favgtime, fsdevtime, fmintime, fmaxtime;
   double   uavgtime, usdevtime, umintime, umaxtime;
   double   *ftimes, *utimes;
-  int      i, j, k, ier;
+  int      i, j, k;
+  int      ier = 0;
   realtype *c;
   N_Vector *X, **Y, **Z;
 
@@ -2336,7 +2345,8 @@ int Test_N_VLinearCombinationVectorArray(N_Vector V, sunindextype local_length,
   double   favgtime, fsdevtime, fmintime, fmaxtime;
   double   uavgtime, usdevtime, umintime, umaxtime;
   double   *ftimes, *utimes;
-  int      i, j, k, ier;
+  int      i, j, k;
+  int      ier = 0;
   realtype *c;
   N_Vector **X, *Z;
 

--- a/src/arkode/arkode_arkstep.c
+++ b/src/arkode/arkode_arkstep.c
@@ -1595,6 +1595,9 @@ int arkStep_TakeStep_Z(void* arkode_mem, realtype *dsmPtr, int *nflagPtr)
       if (SUNRabs(step_mem->Bi->A[is][is]) > TINY)
         implicit_stage = SUNTRUE;
 
+    /* determine if the stage RHS will be deduced from the implicit solve */
+    deduce_stage = step_mem->deduce_rhs && implicit_stage;
+
     /* set current stage time(s) */
     if (step_mem->implicit)
       ark_mem->tcur = ark_mem->tn + step_mem->Bi->c[is]*ark_mem->h;
@@ -1711,7 +1714,6 @@ int arkStep_TakeStep_Z(void* arkode_mem, realtype *dsmPtr, int *nflagPtr)
     /* successful stage solve */
     /*    store implicit RHS (value in Fi[is] is from preceding nonlinear iteration) */
     if (step_mem->implicit) {
-      deduce_stage = step_mem->deduce_rhs && implicit_stage;
 
       if (!deduce_stage) {
         retval = step_mem->fi(ark_mem->tcur, ark_mem->ycur,


### PR DESCRIPTION
Fix uninitialized value warnings that show up in `Release` and `RelWithDebInfo` builds. 