### PR TITLE
Add missing break

### DIFF
--- a/src/arkode/arkode_arkstep.c
+++ b/src/arkode/arkode_arkstep.c
@@ -1926,6 +1926,7 @@ int arkStep_SetButcherTables(ARKodeMem ark_mem)
     case(2):
       etable = ARKSTEP_DEFAULT_ARK_ETABLE_2;
       itable = ARKSTEP_DEFAULT_ARK_ITABLE_2;
+      break;
     case(3):
       etable = ARKSTEP_DEFAULT_ARK_ETABLE_3;
       itable = ARKSTEP_DEFAULT_ARK_ITABLE_3;


### PR DESCRIPTION
Missing break when selecting ARKODE second order IMEX method