### PR TITLE
Bugfix: Constraint Temporary Vector Usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ internal solution vector.  Users who wish to revert to interpolation may call a 
 routine `CVodeSetInterpolateStopTime`, `ARKStepSetInterpolateStopTime`,
 `ERKStepSetInterpolateStopTime`, or `MRIStepSetInterpolateStopTime`.
 
+A potential bug was fixed when using inequality constraint handling and
+calling `ARKStepGetEstLocalErrors` or `ERKStepGetEstLocalErrors` after a failed
+step in which an inequality constraint violation occurred. In this case, the
+values returned by `ARKStepGetEstLocalErrors` or `ERKStepGetEstLocalErrors` may
+be invalid.
+
 ## Changes to SUNDIALS in release 6.5.1
 
 Added the functions `ARKStepClearStopTime`, `ERKStepClearStopTime`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ A potential bug was fixed when using inequality constraint handling and
 calling `ARKStepGetEstLocalErrors` or `ERKStepGetEstLocalErrors` after a failed
 step in which an inequality constraint violation occurred. In this case, the
 values returned by `ARKStepGetEstLocalErrors` or `ERKStepGetEstLocalErrors` may
-be invalid.
+have been invalid.
 
 ## Changes to SUNDIALS in release 6.5.1
 

--- a/doc/arkode/guide/source/Introduction.rst
+++ b/doc/arkode/guide/source/Introduction.rst
@@ -141,7 +141,7 @@ A potential bug was fixed when using inequality constraint handling and
 calling :c:func:`ARKStepGetEstLocalErrors` or :c:func:`ERKStepGetEstLocalErrors`
 after a failed step in which an inequality constraint violation occurred. In
 this case, the values returned by :c:func:`ARKStepGetEstLocalErrors` or
-:c:func:`ERKStepGetEstLocalErrors` may be invalid.
+:c:func:`ERKStepGetEstLocalErrors` may have been invalid.
 
 Changes in v5.5.1
 -----------------

--- a/doc/arkode/guide/source/Introduction.rst
+++ b/doc/arkode/guide/source/Introduction.rst
@@ -137,6 +137,12 @@ internal solution vector.  Users who wish to revert to interpolation may call a 
 routine :c:func:`ARKStepSetInterpolateStopTime`,
 :c:func:`ERKStepSetInterpolateStopTime`, or :c:func:`MRIStepSetInterpolateStopTime`.
 
+A potential bug was fixed when using inequality constraint handling and
+calling :c:func:`ARKStepGetEstLocalErrors` or :c:func:`ERKStepGetEstLocalErrors`
+after a failed step in which an inequality constraint violation occurred. In
+this case, the values returned by :c:func:`ARKStepGetEstLocalErrors` or
+:c:func:`ERKStepGetEstLocalErrors` may be invalid.
+
 Changes in v5.5.1
 -----------------
 

--- a/examples/arkode/CXX_serial/ark_heat2D.cpp
+++ b/examples/arkode/CXX_serial/ark_heat2D.cpp
@@ -1061,11 +1061,14 @@ static int OpenOutput(UserData *udata)
 // Write output
 static int WriteOutput(realtype t, N_Vector u, UserData *udata)
 {
-  int      flag;
-  realtype max;
+  int flag;
 
   if (udata->output > 0)
   {
+    // Compute rms norm of the state
+    realtype urms = sqrt(N_VDotProd(u, u) / udata->nx / udata->ny);
+
+    // Output current status
     if (udata->forcing)
     {
       // Compute the error
@@ -1073,15 +1076,8 @@ static int WriteOutput(realtype t, N_Vector u, UserData *udata)
       if (check_flag(&flag, "SolutionError", 1)) return 1;
 
       // Compute max error
-      max = N_VMaxNorm(udata->e);
-    }
+      realtype max = N_VMaxNorm(udata->e);
 
-    // Compute rms norm of the state
-    realtype urms = sqrt(N_VDotProd(u, u) / udata->nx / udata->ny);
-
-    // Output current status
-    if (udata->forcing)
-    {
       cout << setw(22) << t << setw(25) << urms << setw(25) << max << endl;
     }
     else

--- a/src/arkode/arkode.c
+++ b/src/arkode/arkode.c
@@ -2903,7 +2903,7 @@ int arkCheckConstraints(ARKodeMem ark_mem, int *constrfails, int *nflag)
 {
   booleantype constraintsPassed;
   N_Vector mm  = ark_mem->tempv4;
-  N_Vector tmp = ark_mem->tempv1;
+  N_Vector tmp = ark_mem->tempv3;
 
   /* Check constraints and get mask vector mm for where constraints failed */
   constraintsPassed = N_VConstrMask(ark_mem->constraints, ark_mem->ycur, mm);


### PR DESCRIPTION
Fix a potential bug when constraint handling is enabled and `GetEstLocalErrors`is called in ARKODE