### PR TITLE
Group CMake Options in index and Show index in left navigation pane

### DIFF
--- a/doc/arkode/guide/source/conf.py
+++ b/doc/arkode/guide/source/conf.py
@@ -34,7 +34,7 @@ extensions = ['sphinx_rtd_theme', 'sphinx.ext.ifconfig', 'sphinx.ext.mathjax',
 bibtex_bibfiles = ['../../../shared/sundials.bib']
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ['../../../shared/_templates']
 
 # The suffix of source filenames.
 source_suffix = '.rst'

--- a/doc/arkode/guide/source/conf.py
+++ b/doc/arkode/guide/source/conf.py
@@ -13,14 +13,7 @@
 import sys, os
 sys.path.append(os.path.dirname(os.path.abspath('../../../shared/versions.py')))
 from versions import *
-
-# -- Create new object types --------------------------------------------------
-
-from sphinx.application import Sphinx
-
-def setup(app: Sphinx):
-    app.add_object_type('cmakeoption', 'cmakeop', 'single: %s (CMake option)')
-    app.add_config_value('package_name', '', 'env', types=[str])
+sys.path.append(os.path.dirname(os.path.abspath('../../../shared')))
 
 # -- General configuration ----------------------------------------------------
 
@@ -34,7 +27,8 @@ needs_sphinx = '4.0'
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx_rtd_theme', 'sphinx.ext.ifconfig', 'sphinx.ext.mathjax',
-              'sphinxfortran.fortran_domain', 'sphinxcontrib.bibtex', 'sphinx_copybutton']
+              'sphinxfortran.fortran_domain', 'sphinxcontrib.bibtex',
+              'sphinx_copybutton', 'sphinx_sundials']
 
 # References
 bibtex_bibfiles = ['../../../shared/sundials.bib']

--- a/doc/cvode/guide/source/conf.py
+++ b/doc/cvode/guide/source/conf.py
@@ -34,7 +34,7 @@ extensions = ['sphinx_rtd_theme', 'sphinx.ext.ifconfig', 'sphinx.ext.mathjax',
 bibtex_bibfiles = ['../../../shared/sundials.bib']
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ['../../../shared/_templates']
 
 # The suffix of source filenames.
 source_suffix = '.rst'

--- a/doc/cvode/guide/source/conf.py
+++ b/doc/cvode/guide/source/conf.py
@@ -13,14 +13,7 @@
 import sys, os
 sys.path.append(os.path.dirname(os.path.abspath('../../../shared/versions.py')))
 from versions import *
-
-# -- Create new object types --------------------------------------------------
-
-from sphinx.application import Sphinx
-
-def setup(app: Sphinx):
-    app.add_object_type('cmakeoption', 'cmakeop', 'single: %s (CMake option)')
-    app.add_config_value('package_name', '', 'env', types=[str])
+sys.path.append(os.path.dirname(os.path.abspath('../../../shared')))
 
 # -- General configuration ----------------------------------------------------
 
@@ -34,7 +27,8 @@ needs_sphinx = '4.0'
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx_rtd_theme', 'sphinx.ext.ifconfig', 'sphinx.ext.mathjax',
-              'sphinxfortran.fortran_domain', 'sphinxcontrib.bibtex', 'sphinx_copybutton']
+              'sphinxfortran.fortran_domain', 'sphinxcontrib.bibtex',
+              'sphinx_copybutton', 'sphinx_sundials']
 
 # References
 bibtex_bibfiles = ['../../../shared/sundials.bib']

--- a/doc/cvodes/guide/source/conf.py
+++ b/doc/cvodes/guide/source/conf.py
@@ -34,7 +34,7 @@ extensions = ['sphinx_rtd_theme', 'sphinx.ext.ifconfig', 'sphinx.ext.mathjax',
 bibtex_bibfiles = ['../../../shared/sundials.bib']
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ['../../../shared/_templates']
 
 # The suffix of source filenames.
 source_suffix = '.rst'

--- a/doc/cvodes/guide/source/conf.py
+++ b/doc/cvodes/guide/source/conf.py
@@ -13,14 +13,7 @@
 import sys, os
 sys.path.append(os.path.dirname(os.path.abspath('../../../shared/versions.py')))
 from versions import *
-
-# -- Create new object types --------------------------------------------------
-
-from sphinx.application import Sphinx
-
-def setup(app: Sphinx):
-    app.add_object_type('cmakeoption', 'cmakeop', 'single: %s (CMake option)')
-    app.add_config_value('package_name', '', 'env', types=[str])
+sys.path.append(os.path.dirname(os.path.abspath('../../../shared')))
 
 # -- General configuration ----------------------------------------------------
 
@@ -34,7 +27,8 @@ needs_sphinx = '4.0'
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx_rtd_theme', 'sphinx.ext.ifconfig', 'sphinx.ext.mathjax',
-              'sphinxfortran.fortran_domain', 'sphinxcontrib.bibtex', 'sphinx_copybutton']
+              'sphinxfortran.fortran_domain', 'sphinxcontrib.bibtex',
+              'sphinx_copybutton', 'sphinx_sundials']
 
 # References
 bibtex_bibfiles = ['../../../shared/sundials.bib']

--- a/doc/ida/guide/source/conf.py
+++ b/doc/ida/guide/source/conf.py
@@ -34,7 +34,7 @@ extensions = ['sphinx_rtd_theme', 'sphinx.ext.ifconfig', 'sphinx.ext.mathjax',
 bibtex_bibfiles = ['../../../shared/sundials.bib']
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ['../../../shared/_templates']
 
 # The suffix of source filenames.
 source_suffix = '.rst'

--- a/doc/ida/guide/source/conf.py
+++ b/doc/ida/guide/source/conf.py
@@ -13,14 +13,7 @@
 import sys, os
 sys.path.append(os.path.dirname(os.path.abspath('../../../shared/versions.py')))
 from versions import *
-
-# -- Create new object types --------------------------------------------------
-
-from sphinx.application import Sphinx
-
-def setup(app: Sphinx):
-    app.add_object_type('cmakeoption', 'cmakeop', 'single: %s (CMake option)')
-    app.add_config_value('package_name', '', 'env', types=[str])
+sys.path.append(os.path.dirname(os.path.abspath('../../../shared')))
 
 # -- General configuration ----------------------------------------------------
 
@@ -34,7 +27,8 @@ needs_sphinx = '4.0'
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx_rtd_theme', 'sphinx.ext.ifconfig', 'sphinx.ext.mathjax',
-              'sphinxfortran.fortran_domain', 'sphinxcontrib.bibtex', 'sphinx_copybutton']
+              'sphinxfortran.fortran_domain', 'sphinxcontrib.bibtex',
+              'sphinx_copybutton', 'sphinx_sundials']
 
 # References
 bibtex_bibfiles = ['../../../shared/sundials.bib']

--- a/doc/idas/guide/source/conf.py
+++ b/doc/idas/guide/source/conf.py
@@ -34,7 +34,7 @@ extensions = ['sphinx_rtd_theme', 'sphinx.ext.ifconfig', 'sphinx.ext.mathjax',
 bibtex_bibfiles = ['../../../shared/sundials.bib']
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ['../../../shared/_templates']
 
 # The suffix of source filenames.
 source_suffix = '.rst'

--- a/doc/idas/guide/source/conf.py
+++ b/doc/idas/guide/source/conf.py
@@ -13,14 +13,7 @@
 import sys, os
 sys.path.append(os.path.dirname(os.path.abspath('../../../shared/versions.py')))
 from versions import *
-
-# -- Create new object types --------------------------------------------------
-
-from sphinx.application import Sphinx
-
-def setup(app: Sphinx):
-    app.add_object_type('cmakeoption', 'cmakeop', 'single: %s (CMake option)')
-    app.add_config_value('package_name', '', 'env', types=[str])
+sys.path.append(os.path.dirname(os.path.abspath('../../../shared')))
 
 # -- General configuration ----------------------------------------------------
 
@@ -34,7 +27,8 @@ needs_sphinx = '4.0'
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx_rtd_theme', 'sphinx.ext.ifconfig', 'sphinx.ext.mathjax',
-              'sphinxfortran.fortran_domain', 'sphinxcontrib.bibtex', 'sphinx_copybutton']
+              'sphinxfortran.fortran_domain', 'sphinxcontrib.bibtex',
+              'sphinx_copybutton', 'sphinx_sundials']
 
 # References
 bibtex_bibfiles = ['../../../shared/sundials.bib']

--- a/doc/install_guide/source/conf.py
+++ b/doc/install_guide/source/conf.py
@@ -35,7 +35,7 @@ extensions = ['sphinx_rtd_theme', 'sphinx.ext.ifconfig', 'sphinx.ext.mathjax',
 bibtex_bibfiles = ['../../shared/sundials.bib']
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ['../../shared/_templates']
 
 # The suffix of source filenames.
 source_suffix = '.rst'

--- a/doc/install_guide/source/conf.py
+++ b/doc/install_guide/source/conf.py
@@ -14,14 +14,7 @@ from posixpath import supports_unicode_filenames
 import sys, os
 sys.path.append(os.path.dirname(os.path.abspath('../../shared/versions.py')))
 from versions import *
-
-# -- Create new object types --------------------------------------------------
-
-from sphinx.application import Sphinx
-
-def setup(app: Sphinx):
-    app.add_object_type('cmakeoption', 'cmakeop', 'single: %s (CMake option)')
-    app.add_config_value('package_name', '', 'env', types=[str])
+sys.path.append(os.path.dirname(os.path.abspath('../../shared')))
 
 # -- General configuration ----------------------------------------------------
 
@@ -35,7 +28,8 @@ needs_sphinx = '4.0'
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx_rtd_theme', 'sphinx.ext.ifconfig', 'sphinx.ext.mathjax',
-              'sphinxfortran.fortran_domain', 'sphinxcontrib.bibtex', 'sphinx_copybutton']
+              'sphinxfortran.fortran_domain', 'sphinxcontrib.bibtex',
+              'sphinx_copybutton', 'sphinx_sundials']
 
 # References
 bibtex_bibfiles = ['../../shared/sundials.bib']

--- a/doc/kinsol/guide/source/conf.py
+++ b/doc/kinsol/guide/source/conf.py
@@ -34,7 +34,7 @@ extensions = ['sphinx_rtd_theme', 'sphinx.ext.ifconfig', 'sphinx.ext.mathjax',
 bibtex_bibfiles = ['../../../shared/sundials.bib']
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ['../../../shared/_templates']
 
 # The suffix of source filenames.
 source_suffix = '.rst'

--- a/doc/kinsol/guide/source/conf.py
+++ b/doc/kinsol/guide/source/conf.py
@@ -13,14 +13,7 @@
 import sys, os
 sys.path.append(os.path.dirname(os.path.abspath('../../../shared/versions.py')))
 from versions import *
-
-# -- Create new object types --------------------------------------------------
-
-from sphinx.application import Sphinx
-
-def setup(app: Sphinx):
-    app.add_object_type('cmakeoption', 'cmakeop', 'single: %s (CMake option)')
-    app.add_config_value('package_name', '', 'env', types=[str])
+sys.path.append(os.path.dirname(os.path.abspath('../../../shared')))
 
 # -- General configuration ----------------------------------------------------
 
@@ -34,7 +27,8 @@ needs_sphinx = '4.0'
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx_rtd_theme', 'sphinx.ext.ifconfig', 'sphinx.ext.mathjax',
-              'sphinxfortran.fortran_domain', 'sphinxcontrib.bibtex', 'sphinx_copybutton']
+              'sphinxfortran.fortran_domain', 'sphinxcontrib.bibtex',
+              'sphinx_copybutton', 'sphinx_sundials']
 
 # References
 bibtex_bibfiles = ['../../../shared/sundials.bib']

--- a/doc/shared/_templates/layout.html
+++ b/doc/shared/_templates/layout.html
@@ -1,0 +1,6 @@
+{% extends "!layout.html" %}
+
+  {% block menu %}
+    {{ super() }}
+    <li class="toctree-l1"><a class="reference internal" href="{{pathto('genindex.html', 1)}}">Index</a></li>
+  {% endblock %}

--- a/doc/shared/sphinx_sundials.py
+++ b/doc/shared/sphinx_sundials.py
@@ -1,0 +1,21 @@
+# -----------------------------------------------------------------------------
+# SUNDIALS Copyright Start
+# Copyright (c) 2002-2023, Lawrence Livermore National Security
+# and Southern Methodist University.
+# All rights reserved.
+#
+# See the top-level LICENSE and NOTICE files for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# SUNDIALS Copyright End
+# -----------------------------------------------------------------------------
+# SUNDIALS Sphinx extension
+# -----------------------------------------------------------------------------
+
+from sphinx.application import Sphinx
+
+def setup(app: Sphinx):
+    # Create new object type for CMake options
+    app.add_object_type('cmakeoption', 'cmakeop', 'single: CMake options; %s')
+    # Create new configuration value set in conf.py
+    app.add_config_value('package_name', '', 'env', types=[str])

--- a/doc/superbuild/source/conf.py
+++ b/doc/superbuild/source/conf.py
@@ -34,7 +34,7 @@ extensions = ['sphinx_rtd_theme', 'sphinx.ext.ifconfig', 'sphinx.ext.mathjax',
 bibtex_bibfiles = ['../../shared/sundials.bib']
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ['../../shared/_templates']
 
 # The suffix of source filenames.
 source_suffix = '.rst'

--- a/doc/superbuild/source/conf.py
+++ b/doc/superbuild/source/conf.py
@@ -13,14 +13,7 @@
 import sys, os
 sys.path.append(os.path.dirname(os.path.abspath('../../shared/versions.py')))
 from versions import *
-
-# -- Create new object types --------------------------------------------------
-
-from sphinx.application import Sphinx
-
-def setup(app: Sphinx):
-    app.add_object_type('cmakeoption', 'cmakeop', 'single: %s (CMake option)')
-    app.add_config_value('package_name', '', 'env', types=[str])
+sys.path.append(os.path.dirname(os.path.abspath('../../shared')))
 
 # -- General configuration ----------------------------------------------------
 
@@ -34,7 +27,8 @@ needs_sphinx = '4.0'
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx_rtd_theme', 'sphinx.ext.ifconfig', 'sphinx.ext.mathjax',
-              'sphinxfortran.fortran_domain', 'sphinxcontrib.bibtex', 'sphinx_copybutton']
+              'sphinxfortran.fortran_domain', 'sphinxcontrib.bibtex',
+              'sphinx_copybutton', 'sphinx_sundials']
 
 # References
 bibtex_bibfiles = ['../../shared/sundials.bib']


### PR DESCRIPTION
* Move common extensions to shared file
* Updates index to group cmake options under "CMake options" category
* Update left navigation pane to include index link 