### PR TITLE
Bugfix/arkode adaptivity

### DIFF
--- a/doc/arkode/guide/source/Mathematics.rst
+++ b/doc/arkode/guide/source/Mathematics.rst
@@ -918,8 +918,8 @@ ERKStep modules.  It derives from those found in :cite:p:`KenCarp:03`, :cite:p:`
 :math:`\varepsilon_{n-2}` in determination of a prospective step size,
 
 .. math::
-   h' \;=\; h_n\; \varepsilon_n^{-k_1/p}\; \varepsilon_{n-1}^{k_2/p}\;
-        \varepsilon_{n-2}^{-k_3/p},
+   h' \;=\; h_n\; \varepsilon_n^{-k_1/q}\; \varepsilon_{n-1}^{k_2/q}\;
+        \varepsilon_{n-2}^{-k_3/q},
 
 where the constants :math:`k_1`, :math:`k_2` and :math:`k_3` default
 to 0.58, 0.21 and 0.1, respectively, and may be modified by the user.
@@ -939,7 +939,7 @@ that it only uses the two most recent step sizes in its adaptivity
 algorithm,
 
 .. math::
-   h' \;=\; h_n\; \varepsilon_n^{-k_1/p}\; \varepsilon_{n-1}^{k_2/p}.
+   h' \;=\; h_n\; \varepsilon_n^{-k_1/q}\; \varepsilon_{n-1}^{k_2/q}.
 
 Here, the default values of :math:`k_1` and :math:`k_2` default
 to 0.8 and 0.31, respectively, though they may be changed by the user.
@@ -956,7 +956,7 @@ publicly-available ODE solver codes.  It bases the prospective time step
 estimate entirely off of the current local error estimate,
 
 .. math::
-   h' \;=\; h_n\; \varepsilon_n^{-k_1/p}.
+   h' \;=\; h_n\; \varepsilon_n^{-k_1/q}.
 
 By default, :math:`k_1=1`, but that may be modified by the user.
 
@@ -974,9 +974,9 @@ In the notation of our earlier controllers, it has the form
 
 .. math::
    h' \;=\; \begin{cases}
-      h_1\; \varepsilon_1^{-1/p}, &\quad\text{on the first step}, \\
-      h_n\; \varepsilon_n^{-k_1/p}\;
-        \left(\dfrac{\varepsilon_n}{\varepsilon_{n-1}}\right)^{k_2/p}, &
+      h_1\; \varepsilon_1^{-1/q}, &\quad\text{on the first step}, \\
+      h_n\; \varepsilon_n^{-k_1/q}\;
+        \left(\dfrac{\varepsilon_n}{\varepsilon_{n-1}}\right)^{k_2/q}, &
       \quad\text{on subsequent steps}.
    \end{cases}
    :label: ARKODE_expGus
@@ -997,9 +997,9 @@ methods was introduced in :cite:p:`Gust:94`, and has the form
 
 .. math::
    h' = \begin{cases}
-      h_1 \varepsilon_1^{-1/p}, &\quad\text{on the first step}, \\
-      h_n \left(\dfrac{h_n}{h_{n-1}}\right) \varepsilon_n^{-k_1/p}
-        \left(\dfrac{\varepsilon_n}{\varepsilon_{n-1}}\right)^{-k_2/p}, &
+      h_1 \varepsilon_1^{-1/q}, &\quad\text{on the first step}, \\
+      h_n \left(\dfrac{h_n}{h_{n-1}}\right) \varepsilon_n^{-k_1/q}
+        \left(\dfrac{\varepsilon_n}{\varepsilon_{n-1}}\right)^{-k_2/q}, &
       \quad\text{on subsequent steps}.
    \end{cases}
    :label: ARKODE_impGus

--- a/doc/arkode/guide/source/Mathematics.rst
+++ b/doc/arkode/guide/source/Mathematics.rst
@@ -895,7 +895,7 @@ step size :math:`h'` based on the asymptotic local error estimates
 :math:`\varepsilon_{n-1}` and :math:`\varepsilon_{n-2}` as
 
 .. math::
-   \varepsilon_k \ \equiv \ \|T_k\| \ = \ \beta \|y_k - \tilde{y}_k\|,
+   \varepsilon_n \ \equiv \ \|T_n\| \ = \ \beta \|y_n - \tilde{y}_n\|,
 
 corresponding to the local error estimates for three consecutive
 steps, :math:`t_{n-3} \to t_{n-2} \to t_{n-1} \to t_n`.  These local

--- a/src/arkode/arkode_adapt.c
+++ b/src/arkode/arkode_adapt.c
@@ -123,8 +123,8 @@ int arkAdapt(void* arkode_mem, ARKodeHAdaptMem hadapt_mem,
   /* Current error with bias factor */
   ecur = hadapt_mem->bias * dsm;
 
-  /* Set k as either p or q, based on pq flag */
-  k = (hadapt_mem->pq) ? hadapt_mem->q : hadapt_mem->p;
+  /* Set k as either p+1 or q+1, based on pq flag */
+  k = 1 + ((hadapt_mem->pq) ? hadapt_mem->q : hadapt_mem->p);
 
   /* Call algorithm-specific error adaptivity method */
   switch (hadapt_mem->imethod) {


### PR DESCRIPTION
Fixes an off by one error in exponents used by ARKODE's error controllers. There are a couple things to consider before merging:

- Will the parameters set in `ARKStepSetOptimalParams` still be optimal?
- Are the current bias and safety factors too conservative now? For example, for a second order method, the suggested step size effectively get scaled by the relatively small value `safety_factor*(bias)^(-1/2) = 0.78`.