### PR TITLE
Change typedefs names to allow simulateous use of idas and cvodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # SUNDIALS Changelog
 
+## Changes to SUNDIALS in release X.X.X
+
+Renamed some internal types in CVODES and IDAS to allow both packages to be built together in the same binary.
+
 ## Changes to SUNDIALS in release 6.6.1
 
 Updated the Tpetra NVector interface to support Trilinos 14.

--- a/doc/cvodes/guide/source/Introduction.rst
+++ b/doc/cvodes/guide/source/Introduction.rst
@@ -111,6 +111,11 @@ Fortran.
 Changes from previous versions
 ==============================
 
+Changes in vX.X.X
+-----------------
+
+Renamed some internal types in CVODES and IDAS to allow both packages to be built together in the same binary.
+
 Changes in v6.6.1
 -----------------
 

--- a/doc/idas/guide/source/Introduction.rst
+++ b/doc/idas/guide/source/Introduction.rst
@@ -86,6 +86,11 @@ integrate any final-condition ODE dependent on the solution of the original IVP
 Changes from previous versions
 ==============================
 
+Changes in vX.X.X
+-----------------
+
+Renamed some internal types in CVODES and IDAS to allow both packages to be built together in the same binary.
+
 Changes in v5.6.1
 -----------------
 

--- a/src/cvodes/cvodea.c
+++ b/src/cvodes/cvodea.c
@@ -69,12 +69,12 @@ static int CVAfindIndex(CVodeMem cv_mem, realtype t,
 static booleantype CVAhermiteMalloc(CVodeMem cv_mem);
 static void CVAhermiteFree(CVodeMem cv_mem);
 static int CVAhermiteGetY(CVodeMem cv_mem, realtype t, N_Vector y, N_Vector *yS);
-static int CVAhermiteStorePnt(CVodeMem cv_mem, DtpntMem d);
+static int CVAhermiteStorePnt(CVodeMem cv_mem, CVdtpntMem d);
 
 static booleantype CVApolynomialMalloc(CVodeMem cv_mem);
 static void CVApolynomialFree(CVodeMem cv_mem);
 static int CVApolynomialGetY(CVodeMem cv_mem, realtype t, N_Vector y, N_Vector *yS);
-static int CVApolynomialStorePnt(CVodeMem cv_mem, DtpntMem d);
+static int CVApolynomialStorePnt(CVodeMem cv_mem, CVdtpntMem d);
 
 /* Wrappers */
 
@@ -174,7 +174,7 @@ int CVodeAdjInit(void *cvode_mem, long int steps, int interp)
   /* Allocate space for the array of Data Point structures */
 
   ca_mem->dt_mem = NULL;
-  ca_mem->dt_mem = (DtpntMem *) malloc((steps+1)*sizeof(struct DtpntMemRec *));
+  ca_mem->dt_mem = (CVdtpntMem *) malloc((steps+1)*sizeof(struct CVdtpntMemRec *));
   if (ca_mem->dt_mem == NULL) {
     free(ca_mem); ca_mem = NULL;
     cvProcessError(cv_mem, CV_MEM_FAIL, "CVODEA", "CVodeAdjInit", MSGCV_MEM_FAIL);
@@ -184,7 +184,7 @@ int CVodeAdjInit(void *cvode_mem, long int steps, int interp)
 
   for (i=0; i<=steps; i++) {
     ca_mem->dt_mem[i] = NULL;
-    ca_mem->dt_mem[i] = (DtpntMem) malloc(sizeof(struct DtpntMemRec));
+    ca_mem->dt_mem[i] = (CVdtpntMem) malloc(sizeof(struct CVdtpntMemRec));
     if (ca_mem->dt_mem[i] == NULL) {
       for(ii=0; ii<i; ii++) {free(ca_mem->dt_mem[ii]); ca_mem->dt_mem[ii] = NULL;}
       free(ca_mem->dt_mem); ca_mem->dt_mem = NULL;
@@ -381,7 +381,7 @@ int CVodeF(void *cvode_mem, realtype tout, N_Vector yout,
   CVadjMem ca_mem;
   CVodeMem cv_mem;
   CVckpntMem tmp;
-  DtpntMem *dt_mem;
+  CVdtpntMem *dt_mem;
   long int nstloc;
   int flag, i;
   booleantype allocOK, earlyret;
@@ -2098,7 +2098,7 @@ static void CVAbckpbDelete(CVodeBMem *cvB_memPtr)
 static int CVAdataStore(CVodeMem cv_mem, CVckpntMem ck_mem)
 {
   CVadjMem ca_mem;
-  DtpntMem *dt_mem;
+  CVdtpntMem *dt_mem;
   realtype t;
   long int i;
   int flag, sign;
@@ -2310,7 +2310,7 @@ static int CVAfindIndex(CVodeMem cv_mem, realtype t,
                         long int *indx, booleantype *newpoint)
 {
   CVadjMem ca_mem;
-  DtpntMem *dt_mem;
+  CVdtpntMem *dt_mem;
   int sign;
   booleantype to_left, to_right;
 
@@ -2427,7 +2427,7 @@ int CVodeGetAdjY(void *cvode_mem, realtype t, N_Vector y)
 static booleantype CVAhermiteMalloc(CVodeMem cv_mem)
 {
   CVadjMem ca_mem;
-  DtpntMem *dt_mem;
+  CVdtpntMem *dt_mem;
   CVhermiteDataMem content;
   long int i, ii=0;
   booleantype allocOK;
@@ -2546,7 +2546,7 @@ static booleantype CVAhermiteMalloc(CVodeMem cv_mem)
 static void CVAhermiteFree(CVodeMem cv_mem)
 {
   CVadjMem ca_mem;
-  DtpntMem *dt_mem;
+  CVdtpntMem *dt_mem;
   CVhermiteDataMem content;
   long int i;
 
@@ -2580,7 +2580,7 @@ static void CVAhermiteFree(CVodeMem cv_mem)
  * Note that the time is already stored.
  */
 
-static int CVAhermiteStorePnt(CVodeMem cv_mem, DtpntMem d)
+static int CVAhermiteStorePnt(CVodeMem cv_mem, CVdtpntMem d)
 {
   CVadjMem ca_mem;
   CVhermiteDataMem content;
@@ -2647,7 +2647,7 @@ static int CVAhermiteGetY(CVodeMem cv_mem, realtype t,
                           N_Vector y, N_Vector *yS)
 {
   CVadjMem ca_mem;
-  DtpntMem *dt_mem;
+  CVdtpntMem *dt_mem;
   CVhermiteDataMem content0, content1;
 
   realtype t0, t1, delta;
@@ -2822,7 +2822,7 @@ static int CVAhermiteGetY(CVodeMem cv_mem, realtype t,
 static booleantype CVApolynomialMalloc(CVodeMem cv_mem)
 {
   CVadjMem ca_mem;
-  DtpntMem *dt_mem;
+  CVdtpntMem *dt_mem;
   CVpolynomialDataMem content;
   long int i, ii=0;
   booleantype allocOK;
@@ -2919,7 +2919,7 @@ static booleantype CVApolynomialMalloc(CVodeMem cv_mem)
 static void CVApolynomialFree(CVodeMem cv_mem)
 {
   CVadjMem ca_mem;
-  DtpntMem *dt_mem;
+  CVdtpntMem *dt_mem;
   CVpolynomialDataMem content;
   long int i;
 
@@ -2951,7 +2951,7 @@ static void CVApolynomialFree(CVodeMem cv_mem)
  * Note that the time is already stored.
  */
 
-static int CVApolynomialStorePnt(CVodeMem cv_mem, DtpntMem d)
+static int CVApolynomialStorePnt(CVodeMem cv_mem, CVdtpntMem d)
 {
   CVadjMem ca_mem;
   CVpolynomialDataMem content;
@@ -2989,7 +2989,7 @@ static int CVApolynomialGetY(CVodeMem cv_mem, realtype t,
                              N_Vector y, N_Vector *yS)
 {
   CVadjMem ca_mem;
-  DtpntMem *dt_mem;
+  CVdtpntMem *dt_mem;
   CVpolynomialDataMem content;
 
   int flag, dir, order, i, j, is, NS, retval;

--- a/src/cvodes/cvodea.c
+++ b/src/cvodes/cvodea.c
@@ -54,14 +54,14 @@
  * =================================================================
  */
 
-static CkpntMem CVAckpntInit(CVodeMem cv_mem);
-static CkpntMem CVAckpntNew(CVodeMem cv_mem);
-static void CVAckpntDelete(CkpntMem *ck_memPtr);
+static CVckpntMem CVAckpntInit(CVodeMem cv_mem);
+static CVckpntMem CVAckpntNew(CVodeMem cv_mem);
+static void CVAckpntDelete(CVckpntMem *ck_memPtr);
 
 static void CVAbckpbDelete(CVodeBMem *cvB_memPtr);
 
-static int  CVAdataStore(CVodeMem cv_mem, CkpntMem ck_mem);
-static int  CVAckpntGet(CVodeMem cv_mem, CkpntMem ck_mem);
+static int  CVAdataStore(CVodeMem cv_mem, CVckpntMem ck_mem);
+static int  CVAckpntGet(CVodeMem cv_mem, CVckpntMem ck_mem);
 
 static int CVAfindIndex(CVodeMem cv_mem, realtype t,
                         long int *indx, booleantype *newpoint);
@@ -380,7 +380,7 @@ int CVodeF(void *cvode_mem, realtype tout, N_Vector yout,
 {
   CVadjMem ca_mem;
   CVodeMem cv_mem;
-  CkpntMem tmp;
+  CVckpntMem tmp;
   DtpntMem *dt_mem;
   long int nstloc;
   int flag, i;
@@ -1281,7 +1281,7 @@ int CVodeB(void *cvode_mem, realtype tBout, int itaskB)
   CVodeMem cv_mem;
   CVadjMem ca_mem;
   CVodeBMem cvB_mem, tmp_cvB_mem;
-  CkpntMem ck_mem;
+  CVckpntMem ck_mem;
   int sign, flag=0;
   realtype tfuzz, tBret, tBn;
   booleantype gotCheckpoint, isActive, reachedTBout;
@@ -1630,14 +1630,14 @@ int CVodeGetQuadB(void *cvode_mem, int which, realtype *tret, N_Vector qB)
  * information from the initial time.
  */
 
-static CkpntMem CVAckpntInit(CVodeMem cv_mem)
+static CVckpntMem CVAckpntInit(CVodeMem cv_mem)
 {
-  CkpntMem ck_mem;
+  CVckpntMem ck_mem;
   int is;
 
   /* Allocate space for ckdata */
   ck_mem = NULL;
-  ck_mem = (CkpntMem) malloc(sizeof(struct CkpntMemRec));
+  ck_mem = (CVckpntMem) malloc(sizeof(struct CVckpntMemRec));
   if (ck_mem == NULL) return(NULL);
 
   ck_mem->ck_zn[0] = N_VClone(cv_mem->cv_tempv);
@@ -1737,14 +1737,14 @@ static CkpntMem CVAckpntInit(CVodeMem cv_mem)
  * its data from current values in cv_mem.
  */
 
-static CkpntMem CVAckpntNew(CVodeMem cv_mem)
+static CVckpntMem CVAckpntNew(CVodeMem cv_mem)
 {
-  CkpntMem ck_mem;
+  CVckpntMem ck_mem;
   int j, jj, is, qmax;
 
   /* Allocate space for ckdata */
   ck_mem = NULL;
-  ck_mem = (CkpntMem) malloc(sizeof(struct CkpntMemRec));
+  ck_mem = (CVckpntMem) malloc(sizeof(struct CVckpntMemRec));
   if (ck_mem == NULL) return(NULL);
 
   /* Set cv_next to NULL */
@@ -1976,9 +1976,9 @@ static CkpntMem CVAckpntNew(CVodeMem cv_mem)
  * the new list head
  */
 
-static void CVAckpntDelete(CkpntMem *ck_memPtr)
+static void CVAckpntDelete(CVckpntMem *ck_memPtr)
 {
-  CkpntMem tmp;
+  CVckpntMem tmp;
   int j;
 
   if (*ck_memPtr == NULL) return;
@@ -2095,7 +2095,7 @@ static void CVAbckpbDelete(CVodeBMem *cvB_memPtr)
  * CV_FWD_FAIL
  */
 
-static int CVAdataStore(CVodeMem cv_mem, CkpntMem ck_mem)
+static int CVAdataStore(CVodeMem cv_mem, CVckpntMem ck_mem)
 {
   CVadjMem ca_mem;
   DtpntMem *dt_mem;
@@ -2151,7 +2151,7 @@ static int CVAdataStore(CVodeMem cv_mem, CkpntMem ck_mem)
  * the check point ck_mem
  */
 
-static int CVAckpntGet(CVodeMem cv_mem, CkpntMem ck_mem)
+static int CVAckpntGet(CVodeMem cv_mem, CVckpntMem ck_mem)
 {
   int flag, j, is, qmax, retval;
 
@@ -2428,7 +2428,7 @@ static booleantype CVAhermiteMalloc(CVodeMem cv_mem)
 {
   CVadjMem ca_mem;
   DtpntMem *dt_mem;
-  HermiteDataMem content;
+  CVhermiteDataMem content;
   long int i, ii=0;
   booleantype allocOK;
 
@@ -2458,7 +2458,7 @@ static booleantype CVAhermiteMalloc(CVodeMem cv_mem)
   for (i=0; i<=ca_mem->ca_nsteps; i++) {
 
     content = NULL;
-    content = (HermiteDataMem) malloc(sizeof(struct HermiteDataMemRec));
+    content = (CVhermiteDataMem) malloc(sizeof(struct CVhermiteDataMemRec));
     if (content == NULL) {
       ii = i;
       allocOK = SUNFALSE;
@@ -2522,7 +2522,7 @@ static booleantype CVAhermiteMalloc(CVodeMem cv_mem)
     }
 
     for (i=0; i<ii; i++) {
-      content = (HermiteDataMem) (dt_mem[i]->content);
+      content = (CVhermiteDataMem) (dt_mem[i]->content);
       N_VDestroy(content->y);
       N_VDestroy(content->yd);
       if (ca_mem->ca_IMstoreSensi) {
@@ -2547,7 +2547,7 @@ static void CVAhermiteFree(CVodeMem cv_mem)
 {
   CVadjMem ca_mem;
   DtpntMem *dt_mem;
-  HermiteDataMem content;
+  CVhermiteDataMem content;
   long int i;
 
   ca_mem = cv_mem->cv_adj_mem;
@@ -2561,7 +2561,7 @@ static void CVAhermiteFree(CVodeMem cv_mem)
   dt_mem = ca_mem->dt_mem;
 
   for (i=0; i<=ca_mem->ca_nsteps; i++) {
-    content = (HermiteDataMem) (dt_mem[i]->content);
+    content = (CVhermiteDataMem) (dt_mem[i]->content);
     N_VDestroy(content->y);
     N_VDestroy(content->yd);
     if (ca_mem->ca_IMstoreSensi) {
@@ -2583,12 +2583,12 @@ static void CVAhermiteFree(CVodeMem cv_mem)
 static int CVAhermiteStorePnt(CVodeMem cv_mem, DtpntMem d)
 {
   CVadjMem ca_mem;
-  HermiteDataMem content;
+  CVhermiteDataMem content;
   int is, retval;
 
   ca_mem = cv_mem->cv_adj_mem;
 
-  content = (HermiteDataMem) d->content;
+  content = (CVhermiteDataMem) d->content;
 
   /* Load solution */
 
@@ -2648,7 +2648,7 @@ static int CVAhermiteGetY(CVodeMem cv_mem, realtype t,
 {
   CVadjMem ca_mem;
   DtpntMem *dt_mem;
-  HermiteDataMem content0, content1;
+  CVhermiteDataMem content0, content1;
 
   realtype t0, t1, delta;
   realtype factor1, factor2, factor3;
@@ -2682,7 +2682,7 @@ static int CVAhermiteGetY(CVodeMem cv_mem, realtype t,
      then return y at the left limit. */
 
   if (indx == 0) {
-    content0 = (HermiteDataMem) (dt_mem[0]->content);
+    content0 = (CVhermiteDataMem) (dt_mem[0]->content);
     N_VScale(ONE, content0->y, y);
 
     if (NS > 0) {
@@ -2703,7 +2703,7 @@ static int CVAhermiteGetY(CVodeMem cv_mem, realtype t,
   t1 = dt_mem[indx]->t;
   delta = t1 - t0;
 
-  content0 = (HermiteDataMem) (dt_mem[indx-1]->content);
+  content0 = (CVhermiteDataMem) (dt_mem[indx-1]->content);
   y0  = content0->y;
   yd0 = content0->yd;
   if (ca_mem->ca_IMinterpSensi) {
@@ -2715,7 +2715,7 @@ static int CVAhermiteGetY(CVodeMem cv_mem, realtype t,
 
     /* Recompute Y0 and Y1 */
 
-    content1 = (HermiteDataMem) (dt_mem[indx]->content);
+    content1 = (CVhermiteDataMem) (dt_mem[indx]->content);
 
     y1  = content1->y;
     yd1 = content1->yd;
@@ -2823,7 +2823,7 @@ static booleantype CVApolynomialMalloc(CVodeMem cv_mem)
 {
   CVadjMem ca_mem;
   DtpntMem *dt_mem;
-  PolynomialDataMem content;
+  CVpolynomialDataMem content;
   long int i, ii=0;
   booleantype allocOK;
 
@@ -2853,7 +2853,7 @@ static booleantype CVApolynomialMalloc(CVodeMem cv_mem)
   for (i=0; i<=ca_mem->ca_nsteps; i++) {
 
     content = NULL;
-    content = (PolynomialDataMem) malloc(sizeof(struct PolynomialDataMemRec));
+    content = (CVpolynomialDataMem) malloc(sizeof(struct CVpolynomialDataMemRec));
     if (content == NULL) {
       ii = i;
       allocOK = SUNFALSE;
@@ -2896,7 +2896,7 @@ static booleantype CVApolynomialMalloc(CVodeMem cv_mem)
     }
 
     for (i=0; i<ii; i++) {
-      content = (PolynomialDataMem) (dt_mem[i]->content);
+      content = (CVpolynomialDataMem) (dt_mem[i]->content);
       N_VDestroy(content->y);
       if (ca_mem->ca_IMstoreSensi) {
         N_VDestroyVectorArray(content->yS, cv_mem->cv_Ns);
@@ -2920,7 +2920,7 @@ static void CVApolynomialFree(CVodeMem cv_mem)
 {
   CVadjMem ca_mem;
   DtpntMem *dt_mem;
-  PolynomialDataMem content;
+  CVpolynomialDataMem content;
   long int i;
 
   ca_mem = cv_mem->cv_adj_mem;
@@ -2934,7 +2934,7 @@ static void CVApolynomialFree(CVodeMem cv_mem)
   dt_mem = ca_mem->dt_mem;
 
   for (i=0; i<=ca_mem->ca_nsteps; i++) {
-    content = (PolynomialDataMem) (dt_mem[i]->content);
+    content = (CVpolynomialDataMem) (dt_mem[i]->content);
     N_VDestroy(content->y);
     if (ca_mem->ca_IMstoreSensi) {
       N_VDestroyVectorArray(content->yS, cv_mem->cv_Ns);
@@ -2954,12 +2954,12 @@ static void CVApolynomialFree(CVodeMem cv_mem)
 static int CVApolynomialStorePnt(CVodeMem cv_mem, DtpntMem d)
 {
   CVadjMem ca_mem;
-  PolynomialDataMem content;
+  CVpolynomialDataMem content;
   int is, retval;
 
   ca_mem = cv_mem->cv_adj_mem;
 
-  content = (PolynomialDataMem) d->content;
+  content = (CVpolynomialDataMem) d->content;
 
   N_VScale(ONE, cv_mem->cv_zn[0], content->y);
 
@@ -2990,7 +2990,7 @@ static int CVApolynomialGetY(CVodeMem cv_mem, realtype t,
 {
   CVadjMem ca_mem;
   DtpntMem *dt_mem;
-  PolynomialDataMem content;
+  CVpolynomialDataMem content;
 
   int flag, dir, order, i, j, is, NS, retval;
   long int indx, base;
@@ -3013,7 +3013,7 @@ static int CVApolynomialGetY(CVodeMem cv_mem, realtype t,
      then return y at the left limit. */
 
   if (indx == 0) {
-    content = (PolynomialDataMem) (dt_mem[0]->content);
+    content = (CVpolynomialDataMem) (dt_mem[0]->content);
     N_VScale(ONE, content->y, y);
 
     if (NS > 0) {
@@ -3039,12 +3039,12 @@ static int CVApolynomialGetY(CVodeMem cv_mem, realtype t,
 
   if (dir == 1) {
     base = indx;
-    content = (PolynomialDataMem) (dt_mem[base]->content);
+    content = (CVpolynomialDataMem) (dt_mem[base]->content);
     order = content->order;
     if(indx < order) base += order-indx;
   } else {
     base = indx-1;
-    content = (PolynomialDataMem) (dt_mem[base]->content);
+    content = (CVpolynomialDataMem) (dt_mem[base]->content);
     order = content->order;
     if (ca_mem->ca_np-indx > order) base -= indx+order-ca_mem->ca_np;
   }
@@ -3057,7 +3057,7 @@ static int CVApolynomialGetY(CVodeMem cv_mem, realtype t,
     if (dir == 1) {
       for(j=0;j<=order;j++) {
         ca_mem->ca_T[j] = dt_mem[base-j]->t;
-        content = (PolynomialDataMem) (dt_mem[base-j]->content);
+        content = (CVpolynomialDataMem) (dt_mem[base-j]->content);
         N_VScale(ONE, content->y, ca_mem->ca_Y[j]);
 
         if (NS > 0) {
@@ -3071,7 +3071,7 @@ static int CVApolynomialGetY(CVodeMem cv_mem, realtype t,
     } else {
       for(j=0;j<=order;j++) {
         ca_mem->ca_T[j] = dt_mem[base-1+j]->t;
-        content = (PolynomialDataMem) (dt_mem[base-1+j]->content);
+        content = (CVpolynomialDataMem) (dt_mem[base-1+j]->content);
         N_VScale(ONE, content->y, ca_mem->ca_Y[j]);
         if (NS > 0) {
           for (is=0; is<NS; is++)

--- a/src/cvodes/cvodea_io.c
+++ b/src/cvodes/cvodea_io.c
@@ -630,7 +630,7 @@ int CVodeGetAdjDataPointHermite(void *cvode_mem, int which,
 {
   CVodeMem cv_mem;
   CVadjMem ca_mem;
-  DtpntMem *dt_mem;
+  CVdtpntMem *dt_mem;
   CVhermiteDataMem content;
 
   /* Check if cvode_mem exists */
@@ -679,7 +679,7 @@ int CVodeGetAdjDataPointPolynomial(void *cvode_mem, int which,
 {
   CVodeMem cv_mem;
   CVadjMem ca_mem;
-  DtpntMem *dt_mem;
+  CVdtpntMem *dt_mem;
   CVpolynomialDataMem content;
 
   /* Check if cvode_mem exists */

--- a/src/cvodes/cvodea_io.c
+++ b/src/cvodes/cvodea_io.c
@@ -570,7 +570,7 @@ int CVodeGetAdjCheckPointsInfo(void *cvode_mem, CVadjCheckPointRec *ckpnt)
 {
   CVodeMem cv_mem;
   CVadjMem ca_mem;
-  CkpntMem ck_mem;
+  CVckpntMem ck_mem;
   int i;
 
   /* Check if cvode_mem exists */
@@ -631,7 +631,7 @@ int CVodeGetAdjDataPointHermite(void *cvode_mem, int which,
   CVodeMem cv_mem;
   CVadjMem ca_mem;
   DtpntMem *dt_mem;
-  HermiteDataMem content;
+  CVhermiteDataMem content;
 
   /* Check if cvode_mem exists */
   if (cvode_mem == NULL) {
@@ -656,7 +656,7 @@ int CVodeGetAdjDataPointHermite(void *cvode_mem, int which,
 
   *t = dt_mem[which]->t;
 
-  content = (HermiteDataMem) (dt_mem[which]->content);
+  content = (CVhermiteDataMem) (dt_mem[which]->content);
 
   if (y != NULL)
     N_VScale(ONE, content->y, y);
@@ -680,7 +680,7 @@ int CVodeGetAdjDataPointPolynomial(void *cvode_mem, int which,
   CVodeMem cv_mem;
   CVadjMem ca_mem;
   DtpntMem *dt_mem;
-  PolynomialDataMem content;
+  CVpolynomialDataMem content;
 
   /* Check if cvode_mem exists */
   if (cvode_mem == NULL) {
@@ -705,7 +705,7 @@ int CVodeGetAdjDataPointPolynomial(void *cvode_mem, int which,
 
   *t = dt_mem[which]->t;
 
-  content = (PolynomialDataMem) (dt_mem[which]->content);
+  content = (CVpolynomialDataMem) (dt_mem[which]->content);
 
   if (y != NULL)
     N_VScale(ONE, content->y, y);

--- a/src/cvodes/cvodes_impl.h
+++ b/src/cvodes/cvodes_impl.h
@@ -207,8 +207,8 @@ extern "C" {
  */
 
 typedef struct CVadjMemRec  *CVadjMem;
-typedef struct CkpntMemRec  *CkpntMem;
-typedef struct DtpntMemRec  *DtpntMem;
+typedef struct CVckpntMemRec  *CVckpntMem;
+typedef struct CVdtpntMemRec  *CVdtpntMem;
 typedef struct CVodeBMemRec *CVodeBMem;
 
 /*
@@ -704,15 +704,15 @@ typedef struct CVodeMemRec {
 
 /*
  * -----------------------------------------------------------------
- * Types : struct CkpntMemRec, CkpntMem
+ * Types : struct CVckpntMemRec, CVckpntMem
  * -----------------------------------------------------------------
- * The type CkpntMem is type pointer to struct CkpntMemRec.
+ * The type CVckpntMem is type pointer to struct CVckpntMemRec.
  * This structure contains fields to store all information at a
  * check point that is needed to 'hot' start cvodes.
  * -----------------------------------------------------------------
  */
 
-struct CkpntMemRec {
+struct CVckpntMemRec {
 
   /* Integration limits */
   realtype ck_t0;
@@ -768,7 +768,7 @@ struct CkpntMemRec {
   realtype ck_saved_tq5;
 
   /* Pointer to next structure in list */
-  struct CkpntMemRec *ck_next;
+  struct CVckpntMemRec *ck_next;
 
 };
 
@@ -790,11 +790,11 @@ struct CkpntMemRec {
 typedef booleantype (*cvaIMMallocFn)(CVodeMem cv_mem);
 typedef void (*cvaIMFreeFn)(CVodeMem cv_mem);
 typedef int (*cvaIMGetYFn)(CVodeMem cv_mem, realtype t, N_Vector y, N_Vector *yS);
-typedef int (*cvaIMStorePntFn)(CVodeMem cv_mem, DtpntMem d);
+typedef int (*cvaIMStorePntFn)(CVodeMem cv_mem, CVdtpntMem d);
 
 /*
  * -----------------------------------------------------------------
- * Type : struct DtpntMemRec
+ * Type : struct CVdtpntMemRec
  * -----------------------------------------------------------------
  * This structure contains fields to store all information at a
  * data point that is needed to interpolate solution of forward
@@ -802,25 +802,25 @@ typedef int (*cvaIMStorePntFn)(CVodeMem cv_mem, DtpntMem d);
  * -----------------------------------------------------------------
  */
 
-struct DtpntMemRec {
+struct CVdtpntMemRec {
   realtype t;    /* time */
   void *content; /* IMtype-dependent content */
 };
 
 /* Data for cubic Hermite interpolation */
-typedef struct HermiteDataMemRec {
+typedef struct CVhermiteDataMemRec {
   N_Vector y;
   N_Vector yd;
   N_Vector *yS;
   N_Vector *ySd;
-} *HermiteDataMem;
+} *CVhermiteDataMem;
 
 /* Data for polynomial interpolation */
-typedef struct PolynomialDataMemRec {
+typedef struct CVpolynomialDataMemRec {
   N_Vector y;
   N_Vector *yS;
   int order;
-} *PolynomialDataMem;
+} *CVpolynomialDataMem;
 
 
 /*
@@ -935,13 +935,13 @@ struct CVadjMemRec {
    * ---------------- */
 
   /* Storage for check point information */
-  struct CkpntMemRec *ck_mem;
+  struct CVckpntMemRec *ck_mem;
 
   /* Number of check points */
   int ca_nckpnts;
 
   /* address of the check point structure for which data is available */
-  struct CkpntMemRec *ca_ckpntData;
+  struct CVckpntMemRec *ca_ckpntData;
 
   /* ------------------
    * Interpolation data
@@ -954,7 +954,7 @@ struct CVadjMemRec {
   long int ca_ilast;
 
   /* Storage for data from forward runs */
-  struct DtpntMemRec **dt_mem;
+  struct CVdtpntMemRec **dt_mem;
 
   /* Actual number of data points in dt_mem (typically np=nsteps+1) */
   long int ca_np;

--- a/src/idas/idaa.c
+++ b/src/idas/idaa.c
@@ -46,30 +46,30 @@
 /*               Private Functions Prototypes                      */
 /*=================================================================*/
 
-static CkpntMem IDAAckpntInit(IDAMem IDA_mem);
-static CkpntMem IDAAckpntNew(IDAMem IDA_mem);
-static void IDAAckpntCopyVectors(IDAMem IDA_mem, CkpntMem ck_mem);
-static booleantype IDAAckpntAllocVectors(IDAMem IDA_mem, CkpntMem ck_mem);
-static void IDAAckpntDelete(CkpntMem *ck_memPtr);
+static IDAckpntMem IDAAckpntInit(IDAMem IDA_mem);
+static IDAckpntMem IDAAckpntNew(IDAMem IDA_mem);
+static void IDAAckpntCopyVectors(IDAMem IDA_mem, IDAckpntMem ck_mem);
+static booleantype IDAAckpntAllocVectors(IDAMem IDA_mem, IDAckpntMem ck_mem);
+static void IDAAckpntDelete(IDAckpntMem *ck_memPtr);
 
 static void IDAAbckpbDelete(IDABMem *IDAB_memPtr);
 
 static booleantype IDAAdataMalloc(IDAMem IDA_mem);
 static void IDAAdataFree(IDAMem IDA_mem);
-static int  IDAAdataStore(IDAMem IDA_mem, CkpntMem ck_mem);
+static int  IDAAdataStore(IDAMem IDA_mem, IDAckpntMem ck_mem);
 
-static int  IDAAckpntGet(IDAMem IDA_mem, CkpntMem ck_mem);
+static int  IDAAckpntGet(IDAMem IDA_mem, IDAckpntMem ck_mem);
 
 static booleantype IDAAhermiteMalloc(IDAMem IDA_mem);
 static void        IDAAhermiteFree(IDAMem IDA_mem);
-static int         IDAAhermiteStorePnt(IDAMem IDA_mem, DtpntMem d);
+static int         IDAAhermiteStorePnt(IDAMem IDA_mem, IDAdtpntMem d);
 static int         IDAAhermiteGetY(IDAMem IDA_mem, realtype t,
                                    N_Vector yy, N_Vector yp,
                                    N_Vector *yyS, N_Vector *ypS);
 
 static booleantype IDAApolynomialMalloc(IDAMem IDA_mem);
 static void        IDAApolynomialFree(IDAMem IDA_mem);
-static int         IDAApolynomialStorePnt(IDAMem IDA_mem, DtpntMem d);
+static int         IDAApolynomialStorePnt(IDAMem IDA_mem, IDAdtpntMem d);
 static int         IDAApolynomialGetY(IDAMem IDA_mem, realtype t,
                                       N_Vector yy, N_Vector yp,
                                       N_Vector *yyS, N_Vector *ypS);
@@ -360,8 +360,8 @@ int IDASolveF(void *ida_mem, realtype tout, realtype *tret,
 {
   IDAadjMem IDAADJ_mem;
   IDAMem IDA_mem;
-  CkpntMem tmp;
-  DtpntMem *dt_mem;
+  IDAckpntMem tmp;
+  IDAdtpntMem *dt_mem;
   long int nstloc;
   int flag, i;
   booleantype allocOK, earlyret;
@@ -1451,7 +1451,7 @@ int IDASolveB(void *ida_mem, realtype tBout, int itaskB)
 {
   IDAMem IDA_mem;
   IDAadjMem IDAADJ_mem;
-  CkpntMem ck_mem;
+  IDAckpntMem ck_mem;
   IDABMem IDAB_mem, tmp_IDAB_mem;
   int flag=0, sign;
   realtype tfuzz, tBret, tBn;
@@ -1798,12 +1798,12 @@ int IDAGetQuadB(void *ida_mem, int which, realtype *tret, N_Vector qB)
  * information from the initial time.
 */
 
-static CkpntMem IDAAckpntInit(IDAMem IDA_mem)
+static IDAckpntMem IDAAckpntInit(IDAMem IDA_mem)
 {
-  CkpntMem ck_mem;
+  IDAckpntMem ck_mem;
 
   /* Allocate space for ckdata */
-  ck_mem = (CkpntMem) malloc(sizeof(struct CkpntMemRec));
+  ck_mem = (IDAckpntMem) malloc(sizeof(struct IDAckpntMemRec));
   if (NULL==ck_mem) return(NULL);
 
   ck_mem->ck_t0    = IDA_mem->ida_tn;
@@ -1844,13 +1844,13 @@ static CkpntMem IDAAckpntInit(IDAMem IDA_mem)
  * its data from current values in IDA_mem.
 */
 
-static CkpntMem IDAAckpntNew(IDAMem IDA_mem)
+static IDAckpntMem IDAAckpntNew(IDAMem IDA_mem)
 {
-  CkpntMem ck_mem;
+  IDAckpntMem ck_mem;
   int j;
 
   /* Allocate space for ckdata */
-  ck_mem = (CkpntMem) malloc(sizeof(struct CkpntMemRec));
+  ck_mem = (IDAckpntMem) malloc(sizeof(struct IDAckpntMemRec));
   if (ck_mem == NULL) return(NULL);
 
   ck_mem->ck_nst       = IDA_mem->ida_nst;
@@ -1908,9 +1908,9 @@ static CkpntMem IDAAckpntNew(IDAMem IDA_mem)
  * This routine deletes the first check point in list.
 */
 
-static void IDAAckpntDelete(CkpntMem *ck_memPtr)
+static void IDAAckpntDelete(IDAckpntMem *ck_memPtr)
 {
-  CkpntMem tmp;
+  IDAckpntMem tmp;
   int j;
 
   if (*ck_memPtr != NULL) {
@@ -1951,7 +1951,7 @@ static void IDAAckpntDelete(CkpntMem *ck_memPtr)
  * current state of IDAMem.
  *
  */
-static booleantype IDAAckpntAllocVectors(IDAMem IDA_mem, CkpntMem ck_mem)
+static booleantype IDAAckpntAllocVectors(IDAMem IDA_mem, IDAckpntMem ck_mem)
 {
   int j, jj;
 
@@ -2032,7 +2032,7 @@ static booleantype IDAAckpntAllocVectors(IDAMem IDA_mem, CkpntMem ck_mem)
  * Copy phi* vectors from IDAMem in the corresponding vectors from checkpoint
  *
  */
-static void IDAAckpntCopyVectors(IDAMem IDA_mem, CkpntMem ck_mem)
+static void IDAAckpntCopyVectors(IDAMem IDA_mem, IDAckpntMem ck_mem)
 {
   int j, is;
 
@@ -2096,18 +2096,18 @@ static void IDAAckpntCopyVectors(IDAMem IDA_mem, CkpntMem ck_mem)
 static booleantype IDAAdataMalloc(IDAMem IDA_mem)
 {
   IDAadjMem IDAADJ_mem;
-  DtpntMem *dt_mem;
+  IDAdtpntMem *dt_mem;
   long int i, j;
 
   IDAADJ_mem = IDA_mem->ida_adj_mem;
   IDAADJ_mem->dt_mem = NULL;
 
-  dt_mem = (DtpntMem *)malloc((IDAADJ_mem->ia_nsteps+1)*sizeof(struct DtpntMemRec *));
+  dt_mem = (IDAdtpntMem *)malloc((IDAADJ_mem->ia_nsteps+1)*sizeof(struct IDAdtpntMemRec *));
   if (dt_mem==NULL) return(SUNFALSE);
 
   for (i=0; i<=IDAADJ_mem->ia_nsteps; i++) {
 
-    dt_mem[i] = (DtpntMem)malloc(sizeof(struct DtpntMemRec));
+    dt_mem[i] = (IDAdtpntMem)malloc(sizeof(struct IDAdtpntMemRec));
 
     /* On failure, free any allocated memory and return NULL. */
     if (dt_mem[i] == NULL) {
@@ -2166,10 +2166,10 @@ static void IDAAdataFree(IDAMem IDA_mem)
  *   - IDA_SUCCESS
  */
 
-static int IDAAdataStore(IDAMem IDA_mem, CkpntMem ck_mem)
+static int IDAAdataStore(IDAMem IDA_mem, IDAckpntMem ck_mem)
 {
   IDAadjMem IDAADJ_mem;
-  DtpntMem *dt_mem;
+  IDAdtpntMem *dt_mem;
   realtype t;
   long int i;
   int flag, sign;
@@ -2222,7 +2222,7 @@ static int IDAAdataStore(IDAMem IDA_mem, CkpntMem ck_mem)
  * the check point ck_mem
  */
 
-static int IDAAckpntGet(IDAMem IDA_mem, CkpntMem ck_mem)
+static int IDAAckpntGet(IDAMem IDA_mem, IDAckpntMem ck_mem)
 {
   int flag, j, is;
 
@@ -2331,8 +2331,8 @@ static int IDAAckpntGet(IDAMem IDA_mem, CkpntMem ck_mem)
 static booleantype IDAAhermiteMalloc(IDAMem IDA_mem)
 {
   IDAadjMem IDAADJ_mem;
-  DtpntMem *dt_mem;
-  HermiteDataMem content;
+  IDAdtpntMem *dt_mem;
+  IDAhermiteDataMem content;
   long int i, ii=0;
   booleantype allocOK;
 
@@ -2377,7 +2377,7 @@ static booleantype IDAAhermiteMalloc(IDAMem IDA_mem)
   for (i=0; i<=IDAADJ_mem->ia_nsteps; i++) {
 
     content = NULL;
-    content = (HermiteDataMem) malloc(sizeof(struct HermiteDataMemRec));
+    content = (IDAhermiteDataMem) malloc(sizeof(struct IDAhermiteDataMemRec));
     if (content == NULL) {
       ii = i;
       allocOK = SUNFALSE;
@@ -2442,7 +2442,7 @@ static booleantype IDAAhermiteMalloc(IDAMem IDA_mem)
     }
 
     for (i=0; i<ii; i++) {
-      content = (HermiteDataMem) (dt_mem[i]->content);
+      content = (IDAhermiteDataMem) (dt_mem[i]->content);
       N_VDestroy(content->y);
       N_VDestroy(content->yd);
 
@@ -2468,8 +2468,8 @@ static booleantype IDAAhermiteMalloc(IDAMem IDA_mem)
 static void IDAAhermiteFree(IDAMem IDA_mem)
 {
   IDAadjMem IDAADJ_mem;
-  DtpntMem *dt_mem;
-  HermiteDataMem content;
+  IDAdtpntMem *dt_mem;
+  IDAhermiteDataMem content;
   long int i;
 
   IDAADJ_mem = IDA_mem->ida_adj_mem;
@@ -2486,7 +2486,7 @@ static void IDAAhermiteFree(IDAMem IDA_mem)
 
   for (i=0; i<=IDAADJ_mem->ia_nsteps; i++) {
 
-    content = (HermiteDataMem) (dt_mem[i]->content);
+    content = (IDAhermiteDataMem) (dt_mem[i]->content);
     /* content might be NULL, if IDAAdjInit was called but IDASolveF was not. */
     if(content) {
 
@@ -2511,15 +2511,15 @@ static void IDAAhermiteFree(IDAMem IDA_mem)
  * Note that the time is already stored.
  */
 
-static int IDAAhermiteStorePnt(IDAMem IDA_mem, DtpntMem d)
+static int IDAAhermiteStorePnt(IDAMem IDA_mem, IDAdtpntMem d)
 {
   IDAadjMem IDAADJ_mem;
-  HermiteDataMem content;
+  IDAhermiteDataMem content;
   int is, retval;
 
   IDAADJ_mem = IDA_mem->ida_adj_mem;
 
-  content = (HermiteDataMem) d->content;
+  content = (IDAhermiteDataMem) d->content;
 
   /* Load solution(s) */
   N_VScale(ONE, IDA_mem->ida_phi[0], content->y);
@@ -2559,8 +2559,8 @@ static int IDAAhermiteGetY(IDAMem IDA_mem, realtype t,
                           N_Vector *yyS, N_Vector *ypS)
 {
   IDAadjMem IDAADJ_mem;
-  DtpntMem *dt_mem;
-  HermiteDataMem content0, content1;
+  IDAdtpntMem *dt_mem;
+  IDAhermiteDataMem content0, content1;
 
   realtype t0, t1, delta;
   realtype factor1, factor2, factor3;
@@ -2592,7 +2592,7 @@ static int IDAAhermiteGetY(IDAMem IDA_mem, realtype t,
      then return y at the left limit. */
 
   if (indx == 0) {
-    content0 = (HermiteDataMem) (dt_mem[0]->content);
+    content0 = (IDAhermiteDataMem) (dt_mem[0]->content);
     N_VScale(ONE, content0->y,  yy);
     N_VScale(ONE, content0->yd, yp);
 
@@ -2615,7 +2615,7 @@ static int IDAAhermiteGetY(IDAMem IDA_mem, realtype t,
   t1 = dt_mem[indx]->t;
   delta = t1 - t0;
 
-  content0 = (HermiteDataMem) (dt_mem[indx-1]->content);
+  content0 = (IDAhermiteDataMem) (dt_mem[indx-1]->content);
   y0  = content0->y;
   yd0 = content0->yd;
   if (IDAADJ_mem->ia_interpSensi) {
@@ -2626,7 +2626,7 @@ static int IDAAhermiteGetY(IDAMem IDA_mem, realtype t,
   if (newpoint) {
 
     /* Recompute Y0 and Y1 */
-    content1 = (HermiteDataMem) (dt_mem[indx]->content);
+    content1 = (IDAhermiteDataMem) (dt_mem[indx]->content);
 
     y1  = content1->y;
     yd1 = content1->yd;
@@ -2770,8 +2770,8 @@ static int IDAAhermiteGetY(IDAMem IDA_mem, realtype t,
 static booleantype IDAApolynomialMalloc(IDAMem IDA_mem)
 {
   IDAadjMem IDAADJ_mem;
-  DtpntMem *dt_mem;
-  PolynomialDataMem content;
+  IDAdtpntMem *dt_mem;
+  IDApolynomialDataMem content;
   long int i, ii=0;
   booleantype allocOK;
 
@@ -2814,7 +2814,7 @@ static booleantype IDAApolynomialMalloc(IDAMem IDA_mem)
   for (i=0; i<=IDAADJ_mem->ia_nsteps; i++) {
 
     content = NULL;
-    content = (PolynomialDataMem) malloc(sizeof(struct PolynomialDataMemRec));
+    content = (IDApolynomialDataMem) malloc(sizeof(struct IDApolynomialDataMemRec));
     if (content == NULL) {
       ii = i;
       allocOK = SUNFALSE;
@@ -2887,7 +2887,7 @@ static booleantype IDAApolynomialMalloc(IDAMem IDA_mem)
     }
 
     for (i=0; i<ii; i++) {
-      content = (PolynomialDataMem) (dt_mem[i]->content);
+      content = (IDApolynomialDataMem) (dt_mem[i]->content);
       N_VDestroy(content->y);
 
       if (content->yd) N_VDestroy(content->yd);
@@ -2915,8 +2915,8 @@ static booleantype IDAApolynomialMalloc(IDAMem IDA_mem)
 static void IDAApolynomialFree(IDAMem IDA_mem)
 {
   IDAadjMem IDAADJ_mem;
-  DtpntMem *dt_mem;
-  PolynomialDataMem content;
+  IDAdtpntMem *dt_mem;
+  IDApolynomialDataMem content;
   long int i;
 
   IDAADJ_mem = IDA_mem->ida_adj_mem;
@@ -2933,7 +2933,7 @@ static void IDAApolynomialFree(IDAMem IDA_mem)
 
   for (i=0; i<=IDAADJ_mem->ia_nsteps; i++) {
 
-    content = (PolynomialDataMem) (dt_mem[i]->content);
+    content = (IDApolynomialDataMem) (dt_mem[i]->content);
 
     /* content might be NULL, if IDAAdjInit was called but IDASolveF was not. */
     if(content) {
@@ -2964,14 +2964,14 @@ static void IDAApolynomialFree(IDAMem IDA_mem)
  * in which case content->yp is non-null.
  */
 
-static int IDAApolynomialStorePnt(IDAMem IDA_mem, DtpntMem d)
+static int IDAApolynomialStorePnt(IDAMem IDA_mem, IDAdtpntMem d)
 {
   IDAadjMem IDAADJ_mem;
-  PolynomialDataMem content;
+  IDApolynomialDataMem content;
   int is, retval;
 
   IDAADJ_mem = IDA_mem->ida_adj_mem;
-  content = (PolynomialDataMem) d->content;
+  content = (IDApolynomialDataMem) d->content;
 
   N_VScale(ONE, IDA_mem->ida_phi[0], content->y);
 
@@ -3013,8 +3013,8 @@ static int IDAApolynomialGetY(IDAMem IDA_mem, realtype t,
                               N_Vector *yyS, N_Vector *ypS)
 {
   IDAadjMem IDAADJ_mem;
-  DtpntMem *dt_mem;
-  PolynomialDataMem content;
+  IDAdtpntMem *dt_mem;
+  IDApolynomialDataMem content;
 
   int flag, dir, order, i, j, is, NS, retval;
   long int indx, base;
@@ -3035,7 +3035,7 @@ static int IDAApolynomialGetY(IDAMem IDA_mem, realtype t,
      then return y at the left limit. */
 
   if (indx == 0) {
-    content = (PolynomialDataMem) (dt_mem[0]->content);
+    content = (IDApolynomialDataMem) (dt_mem[0]->content);
     N_VScale(ONE, content->y,  yy);
     N_VScale(ONE, content->yd, yp);
 
@@ -3064,12 +3064,12 @@ static int IDAApolynomialGetY(IDAMem IDA_mem, realtype t,
 
   if (dir == 1) {
     base = indx;
-    content = (PolynomialDataMem) (dt_mem[base]->content);
+    content = (IDApolynomialDataMem) (dt_mem[base]->content);
     order = content->order;
     if(indx < order) base += order-indx;
   } else {
     base = indx-1;
-    content = (PolynomialDataMem) (dt_mem[base]->content);
+    content = (IDApolynomialDataMem) (dt_mem[base]->content);
     order = content->order;
     if (IDAADJ_mem->ia_np-indx > order) base -= indx+order-IDAADJ_mem->ia_np;
   }
@@ -3082,7 +3082,7 @@ static int IDAApolynomialGetY(IDAMem IDA_mem, realtype t,
     if (dir == 1) {
       for(j=0;j<=order;j++) {
         IDAADJ_mem->ia_T[j] = dt_mem[base-j]->t;
-        content = (PolynomialDataMem) (dt_mem[base-j]->content);
+        content = (IDApolynomialDataMem) (dt_mem[base-j]->content);
         N_VScale(ONE, content->y, IDAADJ_mem->ia_Y[j]);
 
         if (NS > 0) {
@@ -3096,7 +3096,7 @@ static int IDAApolynomialGetY(IDAMem IDA_mem, realtype t,
     } else {
       for(j=0;j<=order;j++) {
         IDAADJ_mem->ia_T[j] = dt_mem[base-1+j]->t;
-        content = (PolynomialDataMem) (dt_mem[base-1+j]->content);
+        content = (IDApolynomialDataMem) (dt_mem[base-1+j]->content);
         N_VScale(ONE, content->y, IDAADJ_mem->ia_Y[j]);
 
         if (NS > 0) {
@@ -3289,7 +3289,7 @@ static int IDAAfindIndex(IDAMem ida_mem, realtype t,
 {
   IDAadjMem IDAADJ_mem;
   IDAMem IDA_mem;
-  DtpntMem *dt_mem;
+  IDAdtpntMem *dt_mem;
   int sign;
   booleantype to_left, to_right;
 

--- a/src/idas/idaa_io.c
+++ b/src/idas/idaa_io.c
@@ -553,7 +553,7 @@ int IDAGetAdjCheckPointsInfo(void *ida_mem, IDAadjCheckPointRec *ckpnt)
 {
   IDAMem IDA_mem;
   IDAadjMem IDAADJ_mem;
-  CkpntMem ck_mem;
+  IDAckpntMem ck_mem;
   int i;
   
   /* Is ida_mem valid? */
@@ -666,8 +666,8 @@ int IDAGetAdjDataPointHermite(void *ida_mem, int which,
 {
   IDAMem IDA_mem;
   IDAadjMem IDAADJ_mem;
-  DtpntMem *dt_mem;
-  HermiteDataMem content;
+  IDAdtpntMem *dt_mem;
+  IDAhermiteDataMem content;
 
     /* Is ida_mem valid? */
   if (ida_mem == NULL) {
@@ -691,7 +691,7 @@ int IDAGetAdjDataPointHermite(void *ida_mem, int which,
   }
 
   *t = dt_mem[which]->t;
-  content = (HermiteDataMem) dt_mem[which]->content;
+  content = (IDAhermiteDataMem) dt_mem[which]->content;
 
   if (yy != NULL) N_VScale(ONE, content->y, yy);
   if (yd != NULL) N_VScale(ONE, content->yd, yd);
@@ -716,8 +716,8 @@ int IDAGetAdjDataPointPolynomial(void *ida_mem, int which,
 {
   IDAMem IDA_mem;
   IDAadjMem IDAADJ_mem;
-  DtpntMem *dt_mem;
-  PolynomialDataMem content;
+  IDAdtpntMem *dt_mem;
+  IDApolynomialDataMem content;
   /* Is ida_mem valid? */
   if (ida_mem == NULL) {
     IDAProcessError(NULL, IDA_MEM_NULL, "IDAA", "IDAGetAdjDataPointPolynomial", MSGAM_NULL_IDAMEM);
@@ -740,7 +740,7 @@ int IDAGetAdjDataPointPolynomial(void *ida_mem, int which,
   }
 
   *t = dt_mem[which]->t;
-  content = (PolynomialDataMem) dt_mem[which]->content;
+  content = (IDApolynomialDataMem) dt_mem[which]->content;
  
   if (y != NULL) N_VScale(ONE, content->y, y); 
 

--- a/src/idas/idas_impl.h
+++ b/src/idas/idas_impl.h
@@ -550,8 +550,8 @@ typedef struct IDAMemRec {
  */
 
 typedef struct IDAadjMemRec *IDAadjMem;
-typedef struct CkpntMemRec *CkpntMem;
-typedef struct DtpntMemRec *DtpntMem;
+typedef struct IDAckpntMemRec *IDAckpntMem;
+typedef struct IDAdtpntMemRec *IDAdtpntMem;
 typedef struct IDABMemRec *IDABMem;
 
 /*
@@ -574,19 +574,19 @@ typedef void (*IDAAMFreeFn)(IDAMem IDA_mem);
 typedef int (*IDAAGetYFn)(IDAMem IDA_mem, realtype t,
                           N_Vector yy, N_Vector yp,
                           N_Vector *yyS, N_Vector *ypS);
-typedef int (*IDAAStorePntFn)(IDAMem IDA_mem, DtpntMem d);
+typedef int (*IDAAStorePntFn)(IDAMem IDA_mem, IDAdtpntMem d);
 
 /*
  * -----------------------------------------------------------------
- * Types : struct CkpntMemRec, CkpntMem
+ * Types : struct IDAckpntMemRec, IDAckpntMem
  * -----------------------------------------------------------------
- * The type CkpntMem is type pointer to struct CkpntMemRec.
+ * The type IDAckpntMem is type pointer to struct IDAckpntMemRec.
  * This structure contains fields to store all information at a
  * check point that is needed to 'hot' start IDAS.
  * -----------------------------------------------------------------
  */
 
-struct CkpntMemRec {
+struct IDAckpntMemRec {
 
   /* Integration limits */
   realtype ck_t0;
@@ -646,12 +646,12 @@ struct CkpntMemRec {
   int          ck_phi_alloc;
 
   /* Pointer to next structure in list */
-  struct CkpntMemRec *ck_next;
+  struct IDAckpntMemRec *ck_next;
 };
 
 /*
  * -----------------------------------------------------------------
- * Type : struct DtpntMemRec
+ * Type : struct IDAdtpntMemRec
  * -----------------------------------------------------------------
  * This structure contains fields to store all information at a
  * data point that is needed to interpolate solution of forward
@@ -659,21 +659,21 @@ struct CkpntMemRec {
  * -----------------------------------------------------------------
  */
 
-struct DtpntMemRec {
+struct IDAdtpntMemRec {
   realtype t;    /* time */
   void *content; /* interpType-dependent content */
 };
 
 /* Data for cubic Hermite interpolation */
-typedef struct HermiteDataMemRec {
+typedef struct IDAhermiteDataMemRec {
   N_Vector y;
   N_Vector yd;
   N_Vector *yS;
   N_Vector *ySd;
-} *HermiteDataMem;
+} *IDAhermiteDataMem;
 
 /* Data for polynomial interpolation */
-typedef struct PolynomialDataMemRec {
+typedef struct IDApolynomialDataMemRec {
   N_Vector y;
   N_Vector *yS;
 
@@ -682,7 +682,7 @@ typedef struct PolynomialDataMemRec {
   N_Vector yd;
   N_Vector *ySd;
   int order;
-} *PolynomialDataMem;
+} *IDApolynomialDataMem;
 
 /*
  * -----------------------------------------------------------------
@@ -798,10 +798,10 @@ struct IDAadjMemRec {
    * ---------------- */
 
   /* Storage for check point information */
-  struct CkpntMemRec *ck_mem;
+  struct IDAckpntMemRec *ck_mem;
 
   /* address of the check point structure for which data is available */
-  struct CkpntMemRec *ia_ckpntData;
+  struct IDAckpntMemRec *ia_ckpntData;
 
   /* Number of checkpoints. */
   int ia_nckpnts;
@@ -817,7 +817,7 @@ struct IDAadjMemRec {
   long int ia_ilast;
 
   /* Storage for data from forward runs */
-  struct DtpntMemRec **dt_mem;
+  struct IDAdtpntMemRec **dt_mem;
 
   /* Actual number of data points saved in current dt_mem */
   /* Commonly, np = nsteps+1                              */


### PR DESCRIPTION
Fixes #333. Some other typedefs already had specialized (towards idas or cvodes) prefixed names, it won't harm to generalize this. 