### PR TITLE
Fix soversion ?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # SUNDIALS Changelog
 
+Fixed missing soversions.
+
 ## Changes to SUNDIALS in release 6.6.1
 
 Updated the Tpetra NVector interface to support Trilinos 14.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Improved computational complexity of `SUNMatScaleAddI_Sparse` from `O(M*N)` to
 
 Fixed scaling bug in `SUNMatScaleAddI_Sparse` for non-square matrices.
 
-Fixed missing soversions in some SUNLinearSolver targets.
+Fixed missing soversions in some `SUNLinearSolver` CMake targets.
 
 ## Changes to SUNDIALS in release 6.6.1
 

--- a/doc/arkode/guide/source/Introduction.rst
+++ b/doc/arkode/guide/source/Introduction.rst
@@ -133,9 +133,12 @@ Changes from previous versions
 Changes in vX.X.X
 -----------------
 
-Improved computational complexity of `SUNMatScaleAddI_Sparse` from `O(M*N)` to
-`O(NNZ)`.
-Fixed scaling bug in `SUNMatScaleAddI_Sparse` for non-square matrices.
+Improved computational complexity of ``SUNMatScaleAddI_Sparse`` from ``O(M*N)`` to
+``O(NNZ)``.
+
+Fixed scaling bug in ``SUNMatScaleAddI_Sparse`` for non-square matrices.
+
+Fixed missing soversions in some ``SUNLinearSolver`` CMake targets.
 
 Changes in v5.6.1
 -----------------

--- a/doc/cvode/guide/source/Introduction.rst
+++ b/doc/cvode/guide/source/Introduction.rst
@@ -114,9 +114,12 @@ Changes from previous versions
 Changes in vX.X.X
 -----------------
 
-Improved computational complexity of `SUNMatScaleAddI_Sparse` from `O(M*N)` to
-`O(NNZ)`.
-Fixed scaling bug in `SUNMatScaleAddI_Sparse` for non-square matrices.
+Improved computational complexity of ``SUNMatScaleAddI_Sparse`` from ``O(M*N)`` to
+``O(NNZ)``.
+
+Fixed scaling bug in ``SUNMatScaleAddI_Sparse`` for non-square matrices.
+
+Fixed missing soversions in some ``SUNLinearSolver`` CMake targets.
 
 Changes in v6.6.1
 -----------------

--- a/doc/cvodes/guide/source/Introduction.rst
+++ b/doc/cvodes/guide/source/Introduction.rst
@@ -116,9 +116,12 @@ Changes in vX.X.X
 
 Renamed some internal types in CVODES and IDAS to allow both packages to be built together in the same binary.
 
-Improved computational complexity of `SUNMatScaleAddI_Sparse` from `O(M*N)` to
-`O(NNZ)`.
-Fixed scaling bug in `SUNMatScaleAddI_Sparse` for non-square matrices.
+Improved computational complexity of ``SUNMatScaleAddI_Sparse`` from ``O(M*N)`` to
+``O(NNZ)``.
+
+Fixed scaling bug in ``SUNMatScaleAddI_Sparse`` for non-square matrices.
+
+Fixed missing soversions in some ``SUNLinearSolver`` CMake targets.
 
 Changes in v6.6.1
 -----------------

--- a/doc/ida/guide/source/Introduction.rst
+++ b/doc/ida/guide/source/Introduction.rst
@@ -75,9 +75,12 @@ Changes from previous versions
 Changes in vX.X.X
 -----------------
 
-Improved computational complexity of `SUNMatScaleAddI_Sparse` from `O(M*N)` to
-`O(NNZ)`.
-Fixed scaling bug in `SUNMatScaleAddI_Sparse` for non-square matrices.
+Improved computational complexity of ``SUNMatScaleAddI_Sparse`` from ``O(M*N)`` to
+``O(NNZ)``.
+
+Fixed scaling bug in ``SUNMatScaleAddI_Sparse`` for non-square matrices.
+
+Fixed missing soversions in some ``SUNLinearSolver`` CMake targets.
 
 Changes in v6.6.1
 -----------------

--- a/doc/idas/guide/source/Introduction.rst
+++ b/doc/idas/guide/source/Introduction.rst
@@ -91,9 +91,12 @@ Changes in vX.X.X
 
 Renamed some internal types in CVODES and IDAS to allow both packages to be built together in the same binary.
 
-Improved computational complexity of `SUNMatScaleAddI_Sparse` from `O(M*N)` to
-`O(NNZ)`.
-Fixed scaling bug in `SUNMatScaleAddI_Sparse` for non-square matrices.
+Improved computational complexity of ``SUNMatScaleAddI_Sparse`` from ``O(M*N)`` to
+``O(NNZ)``.
+
+Fixed scaling bug in ``SUNMatScaleAddI_Sparse`` for non-square matrices.
+
+Fixed missing soversions in some ``SUNLinearSolver`` CMake targets.
 
 Changes in v5.6.1
 -----------------

--- a/doc/kinsol/guide/source/Introduction.rst
+++ b/doc/kinsol/guide/source/Introduction.rst
@@ -91,9 +91,12 @@ Changes from previous versions
 Changes in vX.X.X
 -----------------
 
-Improved computational complexity of `SUNMatScaleAddI_Sparse` from `O(M*N)` to
-`O(NNZ)`.
-Fixed scaling bug in `SUNMatScaleAddI_Sparse` for non-square matrices.
+Improved computational complexity of ``SUNMatScaleAddI_Sparse`` from ``O(M*N)`` to
+``O(NNZ)``.
+
+Fixed scaling bug in ``SUNMatScaleAddI_Sparse`` for non-square matrices.
+
+Fixed missing soversions in some ``SUNLinearSolver`` CMake targets.
 
 Changes in v6.6.1
 -----------------

--- a/src/sunlinsol/band/CMakeLists.txt
+++ b/src/sunlinsol/band/CMakeLists.txt
@@ -34,7 +34,7 @@ sundials_add_library(sundials_sunlinsolband
   VERSION
     ${sunlinsollib_VERSION}
   SOVERSION
-    ${sunlinsollib_VERSION}
+  ${sunlinsollib_SOVERSION}
 )
 
 message(STATUS "Added SUNLINSOL_BAND module")

--- a/src/sunlinsol/cusolversp/CMakeLists.txt
+++ b/src/sunlinsol/cusolversp/CMakeLists.txt
@@ -33,7 +33,7 @@ sundials_add_library(sundials_sunlinsolcusolversp
   VERSION
     ${sunlinsollib_VERSION}
   SOVERSION
-    ${sunlinsollib_VERSION}
+  ${sunlinsollib_SOVERSION}
 )
 
 message(STATUS "Added SUNLINSOL_CUSOLVERSP module")

--- a/src/sunlinsol/dense/CMakeLists.txt
+++ b/src/sunlinsol/dense/CMakeLists.txt
@@ -34,7 +34,7 @@ sundials_add_library(sundials_sunlinsoldense
   VERSION
     ${sunlinsollib_VERSION}
   SOVERSION
-    ${sunlinsollib_VERSION}
+    ${sunlinsollib_SOVERSION}
 )
 
 message(STATUS "Added SUNLINSOL_DENSE module")

--- a/src/sunlinsol/klu/CMakeLists.txt
+++ b/src/sunlinsol/klu/CMakeLists.txt
@@ -33,7 +33,7 @@ sundials_add_library(sundials_sunlinsolklu
   VERSION
     ${sunlinsollib_VERSION}
   SOVERSION
-    ${sunlinsollib_VERSION}
+  ${sunlinsollib_SOVERSION}
 )
 
 message(STATUS "Added SUNLINSOL_KLU module")

--- a/src/sunlinsol/lapackband/CMakeLists.txt
+++ b/src/sunlinsol/lapackband/CMakeLists.txt
@@ -33,7 +33,7 @@ sundials_add_library(sundials_sunlinsollapackband
   VERSION
     ${sunlinsollib_VERSION}
   SOVERSION
-    ${sunlinsollib_VERSION}
+  ${sunlinsollib_SOVERSION}
 )
 
 message(STATUS "Added SUNLINSOL_LAPACKBAND module")

--- a/src/sunlinsol/lapackdense/CMakeLists.txt
+++ b/src/sunlinsol/lapackdense/CMakeLists.txt
@@ -33,7 +33,7 @@ sundials_add_library(sundials_sunlinsollapackdense
   VERSION
     ${sunlinsollib_VERSION}
   SOVERSION
-    ${sunlinsollib_VERSION}
+  ${sunlinsollib_SOVERSION}
 )
 
 message(STATUS "Added SUNLINSOL_LAPACKDENSE module")

--- a/src/sunlinsol/pcg/CMakeLists.txt
+++ b/src/sunlinsol/pcg/CMakeLists.txt
@@ -32,7 +32,7 @@ sundials_add_library(sundials_sunlinsolpcg
   VERSION
     ${sunlinsollib_VERSION}
   SOVERSION
-    ${sunlinsollib_VERSION}
+  ${sunlinsollib_SOVERSION}
 )
 
 message(STATUS "Added SUNLINSOL_PCG module")

--- a/src/sunlinsol/spbcgs/CMakeLists.txt
+++ b/src/sunlinsol/spbcgs/CMakeLists.txt
@@ -32,7 +32,7 @@ sundials_add_library(sundials_sunlinsolspbcgs
   VERSION
     ${sunlinsollib_VERSION}
   SOVERSION
-    ${sunlinsollib_VERSION}
+  ${sunlinsollib_SOVERSION}
 )
 
 message(STATUS "Added SUNLINSOL_SPBCGS module")

--- a/src/sunlinsol/spfgmr/CMakeLists.txt
+++ b/src/sunlinsol/spfgmr/CMakeLists.txt
@@ -31,7 +31,7 @@ sundials_add_library(sundials_sunlinsolspfgmr
   VERSION
     ${sunlinsollib_VERSION}
   SOVERSION
-    ${sunlinsollib_VERSION}
+  ${sunlinsollib_SOVERSION}
 )
 
 message(STATUS "Added SUNLINSOL_SPFGMR module")

--- a/src/sunlinsol/spgmr/CMakeLists.txt
+++ b/src/sunlinsol/spgmr/CMakeLists.txt
@@ -31,7 +31,7 @@ sundials_add_library(sundials_sunlinsolspgmr
   VERSION
     ${sunlinsollib_VERSION}
   SOVERSION
-    ${sunlinsollib_VERSION}
+    ${sunlinsollib_SOVERSION}
 )
 
 message(STATUS "Added SUNLINSOL_SPGMR module")

--- a/src/sunlinsol/sptfqmr/CMakeLists.txt
+++ b/src/sunlinsol/sptfqmr/CMakeLists.txt
@@ -31,7 +31,7 @@ sundials_add_library(sundials_sunlinsolsptfqmr
   VERSION
     ${sunlinsollib_VERSION}
   SOVERSION
-    ${sunlinsollib_VERSION}
+    ${sunlinsollib_SOVERSION}
 )
 
 message(STATUS "Added SUNLINSOL_SPTFQMR module")

--- a/src/sunlinsol/superludist/CMakeLists.txt
+++ b/src/sunlinsol/superludist/CMakeLists.txt
@@ -39,7 +39,7 @@ sundials_add_library(sundials_sunlinsolsuperludist
   VERSION
     ${sunlinsollib_VERSION}
   SOVERSION
-    ${sunlinsollib_VERSION}
+  ${sunlinsollib_SOVERSION}
 )
 
 message(STATUS "Added SUNLINSOL_SUPERLUDIST module")

--- a/src/sunlinsol/superlumt/CMakeLists.txt
+++ b/src/sunlinsol/superlumt/CMakeLists.txt
@@ -43,7 +43,7 @@ sundials_add_library(sundials_sunlinsolsuperlumt
   VERSION
     ${sunlinsollib_VERSION}
   SOVERSION
-    ${sunlinsollib_VERSION}
+  ${sunlinsollib_SOVERSION}
 )
 
 message(STATUS "Added SUNLINSOL_SUPERLUMT module")

--- a/src/sunnonlinsol/fixedpoint/CMakeLists.txt
+++ b/src/sunnonlinsol/fixedpoint/CMakeLists.txt
@@ -31,7 +31,7 @@ sundials_add_library(sundials_sunnonlinsolfixedpoint
   VERSION
     ${sunnonlinsollib_VERSION}
   SOVERSION
-    ${sunnonlinsollib_VERSION}
+    ${sunnonlinsollib_SOVERSION}
 )
 
 message(STATUS "Added SUNNONLINSOL_FIXEDPOINT module")

--- a/src/sunnonlinsol/newton/CMakeLists.txt
+++ b/src/sunnonlinsol/newton/CMakeLists.txt
@@ -31,7 +31,7 @@ sundials_add_library(sundials_sunnonlinsolnewton
   VERSION
     ${sunnonlinsollib_VERSION}
   SOVERSION
-    ${sunnonlinsollib_VERSION}
+  ${sunnonlinsollib_SOVERSION}
 )
 
 message(STATUS "Added SUNNONLINSOL_NEWTON module")


### PR DESCRIPTION
some libs are missing soversion, and this causes clients libs to link against full version instead:
xref https://github.com/conda-forge/assimulo-feedstock/issues/88
this doesnt look intentional because matching soversion macros are actually defined

cc @gardner48 @jmrohwer