### PR TITLE
Bugfix: ARKODE ONE_STEP Description

### DIFF
--- a/doc/arkode/guide/source/Usage/ARKStep_c_interface/User_callable.rst
+++ b/doc/arkode/guide/source/Usage/ARKStep_c_interface/User_callable.rst
@@ -726,11 +726,8 @@ the user has set a stop time (with a call to the optional input function
         in :numref:`ARKODE.Mathematics.Interpolation`).
 
         The *ARK_ONE_STEP* option tells the solver to only take a
-        single internal step :math:`y_{n-1} \to y_{n}` and then return
-        control back to the calling program.  If this step will
-        overtake *tout* then the solver will again return an
-        interpolated result; otherwise it will return a copy of the
-        internal solution :math:`y_{n}` in the vector *yout*.
+        single internal step, :math:`y_{n-1} \to y_{n}`, and return the solution
+        at that point, :math:`y_{n}`, in the vector *yout*.
 
    **Return value:**
       * *ARK_SUCCESS* if successful.
@@ -795,8 +792,8 @@ the user has set a stop time (with a call to the optional input function
       only to get the direction and a rough scale of the independent
       variable.
 
-      All failure return values are negative and so testing the return argument for
-      negative values will trap all :c:func:`ARKStepEvolve()` failures.
+      All failure return values are negative and so testing the return argument
+      for negative values will trap all :c:func:`ARKStepEvolve()` failures.
 
       Since interpolation may reduce the accuracy in the reported
       solution, if full method accuracy is desired the user should issue

--- a/doc/arkode/guide/source/Usage/ERKStep_c_interface/User_callable.rst
+++ b/doc/arkode/guide/source/Usage/ERKStep_c_interface/User_callable.rst
@@ -352,11 +352,8 @@ has requested rootfinding.
         :numref:`ARKODE.Mathematics.Interpolation`).
 
         The *ARK_ONE_STEP* option tells the solver to only take a
-        single internal step :math:`y_{n-1} \to y_{n}` and then return
-        control back to the calling program.  If this step will
-        overtake *tout* then the solver will again return an
-        interpolated result; otherwise it will return a copy of the
-        internal solution :math:`y_{n}` in the vector *yout*.
+        single internal step, :math:`y_{n-1} \to y_{n}`, and return the solution
+        at that point, :math:`y_{n}`, in the vector *yout*.
 
    **Return value:**
       * *ARK_SUCCESS* if successful.
@@ -399,7 +396,9 @@ has requested rootfinding.
 
       In *ARK_ONE_STEP* mode, *tout* is used only on the first call, and
       only to get the direction and a rough scale of the independent
-      variable. All failure return values are negative and so testing the
+      variable.
+
+      All failure return values are negative and so testing the
       return argument for negative values will trap all
       :c:func:`ERKStepEvolve()` failures.
 

--- a/doc/arkode/guide/source/Usage/MRIStep_c_interface/User_callable.rst
+++ b/doc/arkode/guide/source/Usage/MRIStep_c_interface/User_callable.rst
@@ -545,11 +545,8 @@ the user has set a stop time (with a call to the optional input function
         in :numref:`ARKODE.Mathematics.Interpolation`).
 
         The *ARK_ONE_STEP* option tells the solver to only take a
-        single internal step :math:`y_{n-1} \to y_{n}` and then return
-        control back to the calling program.  If this step will
-        overtake *tout* then the solver will again return an
-        interpolated result; otherwise it will return a copy of the
-        internal solution :math:`y_{n}` in the vector *yout*.
+        single internal step, :math:`y_{n-1} \to y_{n}`, and return the solution
+        at that point, :math:`y_{n}`, in the vector *yout*.
 
    **Return value:**
       * *ARK_SUCCESS* if successful.
@@ -604,8 +601,8 @@ the user has set a stop time (with a call to the optional input function
       only to get the direction and a rough scale of the independent
       variable.
 
-      All failure return values are negative and so testing the return argument for
-      negative values will trap all :c:func:`MRIStepEvolve()` failures.
+      All failure return values are negative and so testing the return argument
+      for negative values will trap all :c:func:`MRIStepEvolve()` failures.
 
       Since interpolation may reduce the accuracy in the reported
       solution, if full method accuracy is desired the user should issue

--- a/doc/arkode/guide/source/Usage/SPRKStep_c_interface/User_callable.rst
+++ b/doc/arkode/guide/source/Usage/SPRKStep_c_interface/User_callable.rst
@@ -152,11 +152,8 @@ has requested rootfinding.
                  :numref:`ARKODE.Mathematics.Interpolation`).
 
                  The *ARK_ONE_STEP* option tells the solver to only take a
-                 single internal step :math:`y_{n-1} \to y_{n}` and then return
-                 control back to the calling program.  If this step will
-                 overtake *tout* then the solver will again return an
-                 interpolated result; otherwise it will return a copy of the
-                 internal solution :math:`y_{n}` in the vector *yout*.
+                 single internal step, :math:`y_{n-1} \to y_{n}`, and return the
+                 solution at that point, :math:`y_{n}`, in the vector *yout*.
 
    :retval ARK_SUCCESS: if successful.
    :retval ARK_ROOT_RETURN: if :c:func:`SPRKStepEvolve()` succeeded, and
@@ -191,7 +188,9 @@ has requested rootfinding.
 
       In *ARK_ONE_STEP* mode, *tout* is used only on the first call, and
       only to get the direction and a rough scale of the independent
-      variable. All failure return values are negative and so testing the
+      variable.
+
+      All failure return values are negative and so testing the
       return argument for negative values will trap all
       :c:func:`SPRKStepEvolve()` failures.
 


### PR DESCRIPTION
Fix the description of `ONE_STEP` mode in ARKODE. The solution at the end of the step is always returned and interpolation is not performed. 