### PR TITLE
Maintenance: Use SYCL 2020 header

### DIFF
--- a/doc/shared/sundials/Install.rst
+++ b/doc/shared/sundials/Install.rst
@@ -1012,6 +1012,10 @@ illustration only.
 
    .. note::
 
+      Building with SYCL enabled requires a compiler that supports a subset of
+      the of SYCL 2020 specification (specifically ``sycl/sycl.hpp`` must be
+      available).
+
       CMake does not currently support autodetection of SYCL compilers and
       ``CMAKE_CXX_COMPILER`` must be set to a valid SYCL compiler. At present
       the only supported SYCL compilers are the Intel oneAPI compilers i.e.,

--- a/examples/utilities/custom_memory_helper_sycl.h
+++ b/examples/utilities/custom_memory_helper_sycl.h
@@ -15,8 +15,8 @@
  * unmanaged memory only and synchronous copies.
  * -----------------------------------------------------------------*/
 
-#include <CL/sycl.hpp>
 #include <cstdlib>
+#include <sycl/sycl.hpp>
 #include <sundials/sundials_memory.h>
 
 int MyMemoryHelper_Alloc(SUNMemoryHelper helper, SUNMemory* memptr,

--- a/examples/utilities/custom_memory_helper_sycl.h
+++ b/examples/utilities/custom_memory_helper_sycl.h
@@ -16,8 +16,8 @@
  * -----------------------------------------------------------------*/
 
 #include <cstdlib>
-#include <sycl/sycl.hpp>
 #include <sundials/sundials_memory.h>
+#include <sycl/sycl.hpp>
 
 int MyMemoryHelper_Alloc(SUNMemoryHelper helper, SUNMemory* memptr,
                          size_t mem_size, SUNMemoryType mem_type, void* queue)

--- a/include/nvector/nvector_sycl.h
+++ b/include/nvector/nvector_sycl.h
@@ -18,7 +18,7 @@
 #ifndef _NVECTOR_SYCL_H
 #define _NVECTOR_SYCL_H
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <stdio.h>
 #include <sundials/sundials_config.h>
 #include <sundials/sundials_nvector.h>

--- a/include/nvector/nvector_sycl.h
+++ b/include/nvector/nvector_sycl.h
@@ -18,12 +18,12 @@
 #ifndef _NVECTOR_SYCL_H
 #define _NVECTOR_SYCL_H
 
-#include <sycl/sycl.hpp>
 #include <stdio.h>
 #include <sundials/sundials_config.h>
 #include <sundials/sundials_nvector.h>
 #include <sundials/sundials_sycl_policies.hpp>
 #include <sunmemory/sunmemory_sycl.h>
+#include <sycl/sycl.hpp>
 
 #ifdef __cplusplus /* wrapper to enable C++ usage */
 extern "C" {

--- a/include/sundials/sundials_sycl_policies.hpp
+++ b/include/sundials/sundials_sycl_policies.hpp
@@ -18,9 +18,9 @@
 #ifndef _SUNDIALS_SYCLEXECPOLICIES_HPP
 #define _SUNDIALS_SYCLEXECPOLICIES_HPP
 
-#include <CL/sycl.hpp>
 #include <cstdio>
 #include <stdexcept>
+#include <sycl/sycl.hpp>
 
 namespace sundials {
 namespace sycl {

--- a/include/sunlinsol/sunlinsol_onemkldense.h
+++ b/include/sunlinsol/sunlinsol_onemkldense.h
@@ -18,7 +18,8 @@
 #ifndef _SUNLINSOL_ONEMKLDENSE_H
 #define _SUNLINSOL_ONEMKLDENSE_H
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
+
 #include <sundials/sundials_linearsolver.h>
 #include <sundials/sundials_matrix.h>
 #include <sundials/sundials_memory.h>

--- a/include/sunlinsol/sunlinsol_onemkldense.h
+++ b/include/sunlinsol/sunlinsol_onemkldense.h
@@ -18,12 +18,11 @@
 #ifndef _SUNLINSOL_ONEMKLDENSE_H
 #define _SUNLINSOL_ONEMKLDENSE_H
 
-#include <sycl/sycl.hpp>
-
 #include <sundials/sundials_linearsolver.h>
 #include <sundials/sundials_matrix.h>
 #include <sundials/sundials_memory.h>
 #include <sundials/sundials_nvector.h>
+#include <sycl/sycl.hpp>
 
 #ifdef __cplusplus /* wrapper to enable C++ usage */
 extern "C" {

--- a/include/sunmatrix/sunmatrix_onemkldense.h
+++ b/include/sunmatrix/sunmatrix_onemkldense.h
@@ -18,8 +18,9 @@
 #ifndef _SUNMATRIX_ONEMKLDENSE_H
 #define _SUNMATRIX_ONEMKLDENSE_H
 
-#include <CL/sycl.hpp>
 #include <stdio.h>
+#include <sycl/sycl.hpp>
+
 #include <sundials/sundials_matrix.h>
 #include <sundials/sundials_memory.h>
 #include <sundials/sundials_sycl_policies.hpp>

--- a/include/sunmatrix/sunmatrix_onemkldense.h
+++ b/include/sunmatrix/sunmatrix_onemkldense.h
@@ -19,11 +19,10 @@
 #define _SUNMATRIX_ONEMKLDENSE_H
 
 #include <stdio.h>
-#include <sycl/sycl.hpp>
-
 #include <sundials/sundials_matrix.h>
 #include <sundials/sundials_memory.h>
 #include <sundials/sundials_sycl_policies.hpp>
+#include <sycl/sycl.hpp>
 
 #ifdef __cplusplus /* wrapper to enable C++ usage */
 extern "C" {

--- a/include/sunmemory/sunmemory_sycl.h
+++ b/include/sunmemory/sunmemory_sycl.h
@@ -17,8 +17,8 @@
 #ifndef _SUNDIALS_SYCLMEMORY_H
 #define _SUNDIALS_SYCLMEMORY_H
 
-#include <sycl/sycl.hpp>
 #include <sundials/sundials_memory.h>
+#include <sycl/sycl.hpp>
 
 #ifdef __cplusplus /* wrapper to enable C++ usage */
 extern "C" {

--- a/include/sunmemory/sunmemory_sycl.h
+++ b/include/sunmemory/sunmemory_sycl.h
@@ -17,7 +17,7 @@
 #ifndef _SUNDIALS_SYCLMEMORY_H
 #define _SUNDIALS_SYCLMEMORY_H
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <sundials/sundials_memory.h>
 
 #ifdef __cplusplus /* wrapper to enable C++ usage */

--- a/src/nvector/raja/nvector_raja.cpp
+++ b/src/nvector/raja/nvector_raja.cpp
@@ -45,7 +45,7 @@
 #elif defined(SUNDIALS_RAJA_BACKENDS_SYCL)
 #include <sunmemory/sunmemory_sycl.h>
 #include <sycl/sycl.hpp>
-#define SUNDIALS_RAJA_EXEC_STREAM RAJA::sycl_exec< 256 >
+#define SUNDIALS_RAJA_EXEC_STREAM RAJA::sycl_exec<256>
 #if RAJA_VERSION_MAJOR >= 2022
 #define SUNDIALS_RAJA_EXEC_REDUCE RAJA::sycl_exec<256>
 #else

--- a/src/nvector/raja/nvector_raja.cpp
+++ b/src/nvector/raja/nvector_raja.cpp
@@ -43,9 +43,9 @@
 #define SUNDIALS_GPU_PREFIX(val)  hip##val
 #define SUNDIALS_GPU_VERIFY       SUNDIALS_HIP_VERIFY
 #elif defined(SUNDIALS_RAJA_BACKENDS_SYCL)
-#include <CL/sycl.hpp>
 #include <sunmemory/sunmemory_sycl.h>
-#define SUNDIALS_RAJA_EXEC_STREAM RAJA::sycl_exec<256>
+#include <sycl/sycl.hpp>
+#define SUNDIALS_RAJA_EXEC_STREAM RAJA::sycl_exec< 256 >
 #if RAJA_VERSION_MAJOR >= 2022
 #define SUNDIALS_RAJA_EXEC_REDUCE RAJA::sycl_exec<256>
 #else

--- a/src/nvector/sycl/nvector_sycl.cpp
+++ b/src/nvector/sycl/nvector_sycl.cpp
@@ -17,7 +17,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-
 #include <sycl/sycl.hpp>
 
 /* SUNDIALS public headers */

--- a/src/nvector/sycl/nvector_sycl.cpp
+++ b/src/nvector/sycl/nvector_sycl.cpp
@@ -2081,8 +2081,8 @@ static int InitializeReductionBuffer(N_Vector v, const sunrealtype value, size_t
   N_PrivateVectorContent_Sycl vcp = NVEC_SYCL_PRIVATE(v);
 
   /* Wrap the initial value as SUNMemory object */
-  SUNMemory value_mem =
-    SUNMemoryHelper_Wrap(NVEC_SYCL_MEMHELP(v), (void*)&value, SUNMEMTYPE_HOST);
+  SUNMemory value_mem = SUNMemoryHelper_Wrap(NVEC_SYCL_MEMHELP(v),
+                                             (void*)&value, SUNMEMTYPE_HOST);
 
   /* check if the existing reduction memory is not large enough */
   if (vcp->reduce_buffer_bytes < bytes)

--- a/src/nvector/sycl/nvector_sycl.cpp
+++ b/src/nvector/sycl/nvector_sycl.cpp
@@ -2082,7 +2082,7 @@ static int InitializeReductionBuffer(N_Vector v, const sunrealtype value, size_t
 
   /* Wrap the initial value as SUNMemory object */
   SUNMemory value_mem =
-    SUNMemoryHelper_Wrap((NVEC_SYCL_MEMHELP(v), void*)&value, SUNMEMTYPE_HOST);
+    SUNMemoryHelper_Wrap(NVEC_SYCL_MEMHELP(v), (void*)&value, SUNMEMTYPE_HOST);
 
   /* check if the existing reduction memory is not large enough */
   if (vcp->reduce_buffer_bytes < bytes)

--- a/src/nvector/sycl/nvector_sycl.cpp
+++ b/src/nvector/sycl/nvector_sycl.cpp
@@ -15,9 +15,10 @@
  * of the NVECTOR package.
  * -----------------------------------------------------------------*/
 
-#include <CL/sycl.hpp>
 #include <stdio.h>
 #include <stdlib.h>
+
+#include <sycl/sycl.hpp>
 
 /* SUNDIALS public headers */
 #include <nvector/nvector_sycl.h>

--- a/src/sundials/sundials_sycl.h
+++ b/src/sundials/sundials_sycl.h
@@ -15,7 +15,7 @@
  * with SYCL.
  * ---------------------------------------------------------------------------*/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <sundials/sundials_types.h>
 
 #ifndef _SUNDIALS_SYCL_H

--- a/src/sundials/sundials_sycl.h
+++ b/src/sundials/sundials_sycl.h
@@ -15,8 +15,8 @@
  * with SYCL.
  * ---------------------------------------------------------------------------*/
 
-#include <sycl/sycl.hpp>
 #include <sundials/sundials_types.h>
+#include <sycl/sycl.hpp>
 
 #ifndef _SUNDIALS_SYCL_H
 #define _SUNDIALS_SYCL_H

--- a/src/sunmatrix/onemkldense/sunmatrix_onemkldense.cpp
+++ b/src/sunmatrix/onemkldense/sunmatrix_onemkldense.cpp
@@ -15,10 +15,11 @@
  * SUNMATRIX class using the Intel oneAPI Math Kernel Library (oneMKL).
  * ---------------------------------------------------------------------------*/
 
-#include <CL/sycl.hpp>
-#include <oneapi/mkl/blas.hpp>
 #include <stdio.h>
 #include <stdlib.h>
+
+#include <sycl/sycl.hpp>
+#include <oneapi/mkl/blas.hpp>
 
 // SUNDIALS public headers
 #include <sunmatrix/sunmatrix_onemkldense.h>

--- a/src/sunmatrix/onemkldense/sunmatrix_onemkldense.cpp
+++ b/src/sunmatrix/onemkldense/sunmatrix_onemkldense.cpp
@@ -15,11 +15,10 @@
  * SUNMATRIX class using the Intel oneAPI Math Kernel Library (oneMKL).
  * ---------------------------------------------------------------------------*/
 
+#include <oneapi/mkl/blas.hpp>
 #include <stdio.h>
 #include <stdlib.h>
-
 #include <sycl/sycl.hpp>
-#include <oneapi/mkl/blas.hpp>
 
 // SUNDIALS public headers
 #include <sunmatrix/sunmatrix_onemkldense.h>

--- a/test/unit_tests/sunmemory/sycl/test_sunmemory_sycl.cpp
+++ b/test/unit_tests/sunmemory/sycl/test_sunmemory_sycl.cpp
@@ -10,7 +10,7 @@
  * SUNDIALS Copyright End
  *-----------------------------------------------------------------*/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 #include <sundials/sundials_memory.h>
 #include <sundials/sundials_types.h>

--- a/test/unit_tests/sunmemory/sycl/test_sunmemory_sycl.cpp
+++ b/test/unit_tests/sunmemory/sycl/test_sunmemory_sycl.cpp
@@ -10,11 +10,11 @@
  * SUNDIALS Copyright End
  *-----------------------------------------------------------------*/
 
-#include <sycl/sycl.hpp>
 #include <iostream>
 #include <sundials/sundials_memory.h>
 #include <sundials/sundials_types.h>
 #include <sunmemory/sunmemory_sycl.h>
+#include <sycl/sycl.hpp>
 
 int test_instance(SUNMemoryHelper helper, SUNMemoryType mem_type,
                   bool print_test_status)


### PR DESCRIPTION
The SYCL 2020 standard specifies `sycl/sycl.hpp` as the standard header to include however, implementations may still define the  old `CL/sycl.hpp` header for backwards compatibility. We already require SYCL 2020 but were still using the old header.