### PR TITLE
Bugfix: Replace use of FindPythonInterp

### DIFF
--- a/cmake/SundialsSetupTesting.cmake
+++ b/cmake/SundialsSetupTesting.cmake
@@ -20,13 +20,7 @@ include(CTest)
 # Check if development tests are enabled
 if (SUNDIALS_TEST_DEVTESTS OR BUILD_BENCHMARKS)
   # Python is needed to use the test runner
-  find_package(PythonInterp REQUIRED)
-  if(${PYTHON_VERSION_MAJOR} LESS 3)
-    if(${PYTHON_VERSION_MINOR} LESS 7)
-      print_warning("Python version must be 2.7.x or greater to run development tests"
-        "Examples will build but 'make test' may fail.")
-    endif()
-  endif()
+  find_package(Python3 REQUIRED)
 
   # look for the testRunner script in the test directory
   find_program(TESTRUNNER testRunner PATHS test NO_DEFAULT_PATH)


### PR DESCRIPTION
Replace `FindPythonInterp` with `FindPython3`. The former was deprecated in CMake 3.12 and removed in 3.27, [CMP0148](https://cmake.org/cmake/help/v3.27/policy/CMP0148.html)