### PR TITLE
Maintenance: relocate private macros

### DIFF
--- a/examples/cvodes/F2003_serial/cvsAdvDiff_FSA_non_f2003.f90
+++ b/examples/cvodes/F2003_serial/cvsAdvDiff_FSA_non_f2003.f90
@@ -195,7 +195,8 @@ program main
   type(c_ptr)                       :: cvodes_mem
   type(N_Vector),           pointer :: u, uiS
   type(c_ptr)                       :: uS
-  type(SUNNonlinearSolver), pointer :: NLS, NLSsens
+  type(SUNNonlinearSolver), pointer :: NLS
+  type(SUNNonlinearSolver), pointer :: NLSsens => null()
   integer(c_int)                    :: iout, retval
   real(c_double)                    :: reltol, abstol, tout, t(1)
   integer(c_int)                    :: is

--- a/examples/sunlinsol/test_sunlinsol.f90
+++ b/examples/sunlinsol/test_sunlinsol.f90
@@ -43,12 +43,13 @@ contains
     integer(SUNLinearSolver_Type)  :: mysunid, sunid
     integer(C_INT)                 :: myid
 
+    failure = 0
+
     sunid = FSUNLinSolGetType(S)
     if (sunid /= mysunid) then
       failure = 1
       write(*,*) ">>> FAILED test -- FSUNLinSolGetType, Proc", myid
     else if (myid == 0) then
-      failure = 0
       write(*,*) "    PASSED test -- FSUNLinSolGetType"
     end if
   end function Test_FSUNLinSolGetType

--- a/include/sundials/priv/sundials_errors_impl.h
+++ b/include/sundials/priv/sundials_errors_impl.h
@@ -22,6 +22,7 @@
 
 #include <sundials/sundials_errors.h>
 
+#include "sundials/sundials_config.h"
 #include "sundials/sundials_context.h"
 #include "sundials/sundials_export.h"
 #include "sundials/sundials_logger.h"
@@ -29,6 +30,54 @@
 
 #ifdef __cplusplus /* wrapper to enable C++ usage */
 extern "C" {
+#endif
+
+/* ----------------------------------------------------------------------------
+ * Macros used in error handling
+ * ---------------------------------------------------------------------------*/
+
+/* ------------------------------------------------------------------
+ * SUNDIALS __builtin_expect related macros.
+ * These macros provide hints to the compiler that the condition
+ * is typically false (or true) which may allow the compiler to
+ * optimize.
+ * -----------------------------------------------------------------*/
+
+/* Hint to the compiler that the branch is unlikely to be taken */
+#ifdef SUNDIALS_C_COMPILER_HAS_BUILTIN_EXPECT
+#define SUNHintFalse(cond) __builtin_expect((cond), 0)
+#else
+#define SUNHintFalse(cond) (cond)
+#endif
+
+/* Hint to the compiler that the branch is likely to be taken */
+#ifdef SUNDIALS_C_COMPILER_HAS_BUILTIN_EXPECT
+#define SUNHintTrue(cond) __builtin_expect((cond), 1)
+#else
+#define SUNHintTrue(cond) (cond)
+#endif
+
+/* ------------------------------------------------------------------
+ * SUNAssume
+ *
+ * This macro tells the compiler that the condition should be assumed
+ * to be true. The consequence is that what happens if the assumption
+ * is violated is undefined. If there is not compiler support for
+ * assumptions, then we dont do anything as there is no reliable
+ * way to avoid the condition being executed in all cases (such as
+ * the condition being an opaque function call, which we have a lot of).
+ * -----------------------------------------------------------------*/
+
+#if __cplusplus >= 202302L
+#define SUNAssume(...) [[assume(__VA_ARGS__)]]
+#elif defined(SUNDIALS_C_COMPILER_HAS_ATTRIBUTE_ASSUME)
+#define SUNAssume(...) __attribute__((assume(__VA_ARGS__)))
+#elif defined(SUNDIALS_C_COMPILER_HAS_BUILTIN_ASSUME)
+#define SUNAssume(...) __builtin_assume(__VA_ARGS__)
+#elif defined(SUNDIALS_C_COMPILER_HAS_ASSUME)
+#define SUNAssume(...) __assume(__VA_ARGS__)
+#else
+#define SUNAssume(...)
 #endif
 
 /* ----------------------------------------------------------------------------

--- a/include/sundials/sundials_config.in
+++ b/include/sundials/sundials_config.in
@@ -294,48 +294,4 @@
  */
 @F77_MANGLE_MACRO2@
 
-/* ------------------------------------------------------------------
- * SUNDIALS __builtin_expect related macros.
- * These macros provide hints to the compiler that the condition
- * is typically false (or true) which may allow the compiler to
- * optimize.
- * -----------------------------------------------------------------*/
-
-/* Hint to the compiler that the branch is unlikely to be taken */
-#ifdef SUNDIALS_C_COMPILER_HAS_BUILTIN_EXPECT
-#define SUNHintFalse(cond) __builtin_expect((cond), 0)
-#else
-#define SUNHintFalse(cond) (cond)
-#endif
-
-/* Hint to the compiler that the branch is likely to be taken */
-#ifdef SUNDIALS_C_COMPILER_HAS_BUILTIN_EXPECT
-#define SUNHintTrue(cond) __builtin_expect((cond), 1)
-#else
-#define SUNHintTrue(cond) (cond)
-#endif
-
-/* ------------------------------------------------------------------
- * SUNAssume
- *
- * This macro tells the compiler that the condition should be assumed
- * to be true. The consequence is that what happens if the assumption
- * is violated is undefined. If there is not compiler support for
- * assumptions, then we dont do anything as there is no reliable
- * way to avoid the condition being executed in all cases (such as
- * the condition being an opaque function call, which we have a lot of).
- * -----------------------------------------------------------------*/
-
-#if __cplusplus >= 202302L
-#define SUNAssume(...) [[assume(__VA_ARGS__)]]
-#elif defined(SUNDIALS_C_COMPILER_HAS_ATTRIBUTE_ASSUME)
-#define SUNAssume(...) __attribute__((assume(__VA_ARGS__)))
-#elif defined(SUNDIALS_C_COMPILER_HAS_BUILTIN_ASSUME)
-#define SUNAssume(...) __builtin_assume(__VA_ARGS__)
-#elif defined(SUNDIALS_C_COMPILER_HAS_ASSUME)
-#define SUNAssume(...) __assume(__VA_ARGS__)
-#else
-#define SUNAssume(...)
-#endif
-
 #endif /* _SUNDIALS_CONFIG_H */


### PR DESCRIPTION
* Move `SUNHint` and `SUNAssume` macros not intended for users to private header
* Fix some compiler warnings