### PR TITLE
Update sundials_hip_policies.hpp to account for "amd" HIP_PLATFORM

### DIFF
--- a/include/sundials/sundials_hip_policies.hpp
+++ b/include/sundials/sundials_hip_policies.hpp
@@ -27,7 +27,7 @@
 namespace sundials {
 namespace hip {
 
-#if defined(__HIP_PLATFORM_HCC__)
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
 constexpr const sunindextype WARP_SIZE = 64;
 #elif defined(__HIP_PLATFORM_NVCC__)
 constexpr const sunindextype WARP_SIZE = 32;

--- a/include/sundials/sundials_hip_policies.hpp
+++ b/include/sundials/sundials_hip_policies.hpp
@@ -29,7 +29,7 @@ namespace hip {
 
 #if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
 constexpr const sunindextype WARP_SIZE = 64;
-#elif defined(__HIP_PLATFORM_NVCC__)
+#elif defined(__HIP_PLATFORM_NVCC__) || defined(__HIP_PLATFORM_NVDIA__)
 constexpr const sunindextype WARP_SIZE = 32;
 #endif
 constexpr const sunindextype MAX_BLOCK_SIZE = 1024;


### PR DESCRIPTION
With newer versions of rocm, specifically 6.0.0, we have observed that the environment variable HIP_PLATFORM needs to be "amd". As a consequence, the WARP_SIZE goes undefined. I have spoken with AMD personnel, and they too suggest setting HIP_PLATFORM=AMD.