### PR TITLE
Bugfix: HIP_PLATFORM default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # SUNDIALS Changelog
 
+## Changes to SUNDIALS in release X.X.X
+
+Updated the CMake variable `HIP_PLATFORM` default to `amd` as the previous
+default, `hcc`, is no longer recognized in ROCm 5.7.0 or newer. The new default
+is also valid in older version of ROCm (at least back to version 4.3.1).
+
+Fixed a bug in the HIP execution policies where `WAPR_SIZE` would not be set
+with ROCm 6.0.0 or newer.
+
 ## Changes to SUNDIALS in release v7.0.0
 
 ### Major Feature

--- a/cmake/SundialsSetupHIP.cmake
+++ b/cmake/SundialsSetupHIP.cmake
@@ -32,9 +32,9 @@ endif()
 
 if(NOT DEFINED HIP_PLATFORM)
   if(NOT DEFINED ENV{HIP_PLATFORM})
-    set(HIP_PLATFORM "hcc" CACHE STRING "HIP platform (hcc, nvcc)")
+    set(HIP_PLATFORM "amd" CACHE STRING "HIP platform (amd, nvidia)")
   else()
-    set(HIP_PLATFORM "$ENV{HIP_PLATFORM}" CACHE STRING "HIP platform (hcc, nvcc)")
+    set(HIP_PLATFORM "$ENV{HIP_PLATFORM}" CACHE STRING "HIP platform (amd, nvidia)")
   endif()
 endif()
 

--- a/doc/arkode/guide/source/Introduction.rst
+++ b/doc/arkode/guide/source/Introduction.rst
@@ -130,6 +130,17 @@ provided with SUNDIALS, or again may utilize a user-supplied module.
 Changes from previous versions
 ==============================
 
+Changes in vX.X.X
+------------------
+
+Updated the CMake variable ``HIP_PLATFORM`` default to ``amd`` as the previous
+default, ``hcc``, is no longer recognized in ROCm 5.7.0 or newer. The new
+default is also valid in older version of ROCm (at least back to version 4.3.1).
+
+Fixed a bug in the HIP execution policies where ``WAPR_SIZE`` would not be set
+with ROCm 6.0.0 or newer.
+
+
 Changes in v6.0.0
 ----------------------
 

--- a/doc/cvode/guide/source/Introduction.rst
+++ b/doc/cvode/guide/source/Introduction.rst
@@ -111,6 +111,17 @@ implementations.
 Changes from previous versions
 ==============================
 
+Changes in vX.X.X
+------------------
+
+Updated the CMake variable ``HIP_PLATFORM`` default to ``amd`` as the previous
+default, ``hcc``, is no longer recognized in ROCm 5.7.0 or newer. The new
+default is also valid in older version of ROCm (at least back to version 4.3.1).
+
+Fixed a bug in the HIP execution policies where ``WAPR_SIZE`` would not be set
+with ROCm 6.0.0 or newer.
+
+
 Changes in v7.0.0
 ----------------------
 

--- a/doc/cvodes/guide/source/Introduction.rst
+++ b/doc/cvodes/guide/source/Introduction.rst
@@ -111,6 +111,17 @@ Fortran.
 Changes from previous versions
 ==============================
 
+Changes in vX.X.X
+------------------
+
+Updated the CMake variable ``HIP_PLATFORM`` default to ``amd`` as the previous
+default, ``hcc``, is no longer recognized in ROCm 5.7.0 or newer. The new
+default is also valid in older version of ROCm (at least back to version 4.3.1).
+
+Fixed a bug in the HIP execution policies where ``WAPR_SIZE`` would not be set
+with ROCm 6.0.0 or newer.
+
+
 Changes in v7.0.0
 ----------------------
 

--- a/doc/ida/guide/source/Introduction.rst
+++ b/doc/ida/guide/source/Introduction.rst
@@ -72,6 +72,17 @@ systems.
 Changes from previous versions
 ==============================
 
+Changes in vX.X.X
+------------------
+
+Updated the CMake variable ``HIP_PLATFORM`` default to ``amd`` as the previous
+default, ``hcc``, is no longer recognized in ROCm 5.7.0 or newer. The new
+default is also valid in older version of ROCm (at least back to version 4.3.1).
+
+Fixed a bug in the HIP execution policies where ``WAPR_SIZE`` would not be set
+with ROCm 6.0.0 or newer.
+
+
 Changes in v7.0.0
 ----------------------
 

--- a/doc/idas/guide/source/Introduction.rst
+++ b/doc/idas/guide/source/Introduction.rst
@@ -86,6 +86,17 @@ integrate any final-condition ODE dependent on the solution of the original IVP
 Changes from previous versions
 ==============================
 
+Changes in vX.X.X
+------------------
+
+Updated the CMake variable ``HIP_PLATFORM`` default to ``amd`` as the previous
+default, ``hcc``, is no longer recognized in ROCm 5.7.0 or newer. The new
+default is also valid in older version of ROCm (at least back to version 4.3.1).
+
+Fixed a bug in the HIP execution policies where ``WAPR_SIZE`` would not be set
+with ROCm 6.0.0 or newer.
+
+
 Changes in v6.0.0
 ----------------------
 

--- a/doc/kinsol/guide/source/Introduction.rst
+++ b/doc/kinsol/guide/source/Introduction.rst
@@ -88,6 +88,17 @@ applications written in Fortran.
 Changes from previous versions
 ==============================
 
+Changes in vX.X.X
+------------------
+
+Updated the CMake variable ``HIP_PLATFORM`` default to ``amd`` as the previous
+default, ``hcc``, is no longer recognized in ROCm 5.7.0 or newer. The new
+default is also valid in older version of ROCm (at least back to version 4.3.1).
+
+Fixed a bug in the HIP execution policies where ``WAPR_SIZE`` would not be set
+with ROCm 6.0.0 or newer.
+
+
 Changes in v7.0.0
 ----------------------
 

--- a/include/sundials/sundials_hip_policies.hpp
+++ b/include/sundials/sundials_hip_policies.hpp
@@ -31,6 +31,8 @@ namespace hip {
 constexpr const sunindextype WARP_SIZE = 64;
 #elif defined(__HIP_PLATFORM_NVCC__) || defined(__HIP_PLATFORM_NVDIA__)
 constexpr const sunindextype WARP_SIZE = 32;
+#else
+#error "Unknown HIP_PLATFORM, report to github.com/LLNL/sundials/issues"
 #endif
 constexpr const sunindextype MAX_BLOCK_SIZE = 1024;
 constexpr const sunindextype MAX_WARPS      = MAX_BLOCK_SIZE / WARP_SIZE;


### PR DESCRIPTION
`HIP_PLATFORM` default to `amd` as the previous default, `hcc`, is no longer recognized in ROCm 5.7.0 or newer. The new default is also valid in older version of ROCm (at least back to version 4.3.1).