### PR TITLE
CMake: Link sundials_sunlinsolsuperlumt to blas

### DIFF
--- a/src/sunlinsol/superlumt/CMakeLists.txt
+++ b/src/sunlinsol/superlumt/CMakeLists.txt
@@ -47,4 +47,8 @@ sundials_add_library(sundials_sunlinsolsuperlumt
   ${sunlinsollib_SOVERSION}
 )
 
+if (BLAS_FOUND)
+  target_link_libraries(sundials_sunlinsolsuperlumt_shared PRIVATE ${BLAS_LIBRARIES})
+endif ()
+
 message(STATUS "Added SUNLINSOL_SUPERLUMT module")


### PR DESCRIPTION
else it cannot be loaded:
/lib/x86_64-linux-gnu/libsundials_sunlinsolsuperlumt.so.4: undefined symbol: dtrsm_
probably because superlumt is usually static