### PR TITLE
Bugfix: SPRK Table Create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ Fixed a memory leak when an error handler was added to a `SUNContext`. Fixes [Gi
 
 Fixed a CMake bug that caused an MPI linking error for our C++ examples in some instances. Fixes [GitHub Issue #464](https://github.com/LLNL/sundials/issues/464).
 
+Fixed a bug in `ARKodeSPRKTable_Create` where the coefficient arrays where not
+allocated.
+
 ## Changes to SUNDIALS in release v7.0.0
 
 ### Major Feature

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -62,3 +62,6 @@ Fixed a bug that caused error messages to be cut off in some cases. Fixes `GitHu
 Fixed a memory leak when an error handler was added to a :c:type:`SUNContext`. Fixes `GitHub Issue #466 <https://github.com/LLNL/sundials/issues/466>`_.
 
 Fixed a CMake bug that caused an MPI linking error for our C++ examples in some instances. Fixes `GitHub Issue #464 <https://github.com/LLNL/sundials/issues/464>`_.
+
+Fixed a bug in :c:func:`ARKodeSPRKTable_Create` where the coefficient arrays
+where not allocated.

--- a/src/arkode/arkode_sprk.c
+++ b/src/arkode/arkode_sprk.c
@@ -403,16 +403,15 @@ ARKodeSPRKTable ARKodeSymplecticSofroniou10(void)
 ARKodeSPRKTable ARKodeSPRKTable_Create(int s, int q, const sunrealtype* a,
                                        const sunrealtype* ahat)
 {
-  int i                      = 0;
-  ARKodeSPRKTable sprk_table = NULL;
+  if (s < 1 || !a || !ahat) { return NULL; }
 
-  sprk_table = (ARKodeSPRKTable)malloc(sizeof(struct ARKodeSPRKTableMem));
+  ARKodeSPRKTable sprk_table = ARKodeSPRKTable_Alloc(s);
   if (!sprk_table) { return NULL; }
 
   sprk_table->stages = s;
   sprk_table->q      = q;
 
-  for (i = 0; i < s; i++)
+  for (int i = 0; i < s; i++)
   {
     sprk_table->a[i]    = a[i];
     sprk_table->ahat[i] = ahat[i];


### PR DESCRIPTION
ARKodeSPRKTable_Create did not allocate coefficient arrays