### PR TITLE
use LC template for gitlab id tokens and limit github actions push events

### DIFF
--- a/.github/workflows/double-precision.yml
+++ b/.github/workflows/double-precision.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - main
       - develop
-      - 'releases/**'
   pull_request:
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/double-precision.yml
+++ b/.github/workflows/double-precision.yml
@@ -3,6 +3,10 @@ name: Build and Test - Ubuntu/gcc double precision (TPLs, no GPUs)
 
 on:
   push:
+    branches:
+      - main
+      - develop
+      - 'releases/**'
   pull_request:
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/extended-precision.yml
+++ b/.github/workflows/extended-precision.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - main
       - develop
-      - 'releases/**'
   pull_request:
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/extended-precision.yml
+++ b/.github/workflows/extended-precision.yml
@@ -2,6 +2,11 @@
 name: Build and Test - Ubuntu/gcc extended precision (TPLs, no GPUs)
 
 on:
+  push:
+    branches:
+      - main
+      - develop
+      - 'releases/**'
   pull_request:
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/single-precision.yml
+++ b/.github/workflows/single-precision.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - main
       - develop
-      - 'releases/**'
   pull_request:
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/single-precision.yml
+++ b/.github/workflows/single-precision.yml
@@ -2,6 +2,11 @@
 name: Build and Test - Ubuntu/gcc single precision (TPLs, no GPUs)
 
 on:
+  push:
+    branches:
+      - main
+      - develop
+      - 'releases/**'
   pull_request:
   merge_group:
   workflow_dispatch:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,6 +126,8 @@ stages:
 
 # This is where jobs are included.
 include:
+  - project: 'lc-templates/id_tokens'
+    file: 'id_tokens.yml'
   - local: .gitlab/quartz-templates.yml
   - local: .gitlab/quartz-jobs.yml
   - local: .gitlab/lassen-templates.yml


### PR DESCRIPTION
Addresses https://hpc.llnl.gov/technical-bulletins/bulletin-568 and also limits our github action workflows to only run on push to certain branches.