### PR TITLE
Add a Python library for developer utilities with an initial module for log parsing

### DIFF
--- a/doc/developers
+++ b/doc/developers
@@ -1,0 +1,1 @@
+superbuild/source/developers

--- a/doc/superbuild/source/developers/index.rst
+++ b/doc/superbuild/source/developers/index.rst
@@ -34,6 +34,7 @@ meant for SUNDIALS developers.
    pull_requests/index
    releases/index
    packages/index
+   sundialsdev/index
    appendix/index
 
 .. only:: html

--- a/doc/superbuild/source/developers/style_guide/SourceCode.rst
+++ b/doc/superbuild/source/developers/style_guide/SourceCode.rst
@@ -338,6 +338,24 @@ Coding Conventions and Rules
    x;`` to ``return(x);``. Note, however, lots of older SUNDIALS source code
    uses ``return(x);``.
 
+#. ``SUNLogger`` statements must be in the format:
+
+   .. code-block:: c
+
+      [log level][rank][scope][label] key1 = value, key2 = value
+
+   or if the payload (the part after the label) is a vector/array:
+
+   .. code-block:: c
+
+      [log level][rank][scope][label] key(:)
+      value1
+      value2
+
+   Note that the ``(:)`` is needed for the ``scripts/sundialsdev/logs.py`` Python
+   utility to understand that the payload is an array.
+
+   .. code-block:: c
 
 .. _Style.Formatting:
 

--- a/doc/superbuild/source/developers/style_guide/SourceCode.rst
+++ b/doc/superbuild/source/developers/style_guide/SourceCode.rst
@@ -348,7 +348,7 @@ Coding Conventions and Rules
 
    .. code-block:: c
 
-      [log level][rank][scope][label] key(:)
+      [log level][rank][scope][label] key(:) =
       value1
       value2
 

--- a/doc/superbuild/source/developers/sundialsdev/index.rst
+++ b/doc/superbuild/source/developers/sundialsdev/index.rst
@@ -1,0 +1,23 @@
+..
+   -----------------------------------------------------------------------------
+   SUNDIALS Copyright Start
+   Copyright (c) 2002-2024, Lawrence Livermore National Security
+   and Southern Methodist University.
+   All rights reserved.
+
+   See the top-level LICENSE and NOTICE files for details.
+
+   SPDX-License-Identifier: BSD-3-Clause
+   SUNDIALS Copyright End
+   -----------------------------------------------------------------------------
+
+.. _SUNDIALS_DEV:
+
+sundialsdev Python Library
+==========================
+
+This is a Python library of utilities SUNDIALS developer may find useful.
+Right now it consists of the following modules:
+
+- ``logs``: this module has functions for parsing logs produced by `SUNLogger`.
+

--- a/scripts/sundialsdev/__init__.py
+++ b/scripts/sundialsdev/__init__.py
@@ -1,0 +1,8 @@
+
+"""
+This is a Python library of utilities SUNDIALS developer may find useful.
+Right now it consists of the following modules:
+
+- `logs`: this module has functions for parsing logs produced by `SUNLogger`.
+
+"""

--- a/scripts/sundialsdev/logs.py
+++ b/scripts/sundialsdev/logs.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# -----------------------------------------------------------------------------
+# Programmer(s): Cody Balos @ LLNL
+# -----------------------------------------------------------------------------
+# SUNDIALS Copyright Start
+# Copyright (c) 2002-2024, Lawrence Livermore National Security
+# and Southern Methodist University.
+# All rights reserved.
+#
+# See the top-level LICENSE and NOTICE files for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# SUNDIALS Copyright End
+# -----------------------------------------------------------------------------
+# Module of Python functions that may be useful to SUNDIALS developers writing
+# scripts to parse logs produced by SUNLogger.
+# -----------------------------------------------------------------------------
+
+import re
+import numpy as np
+
+
+def parse_logfile_payload(payload, line_number, all_lines, array_indicator="(:)"):
+    """
+    This function parses the payload of in a SUNDIALS log file line
+    into a dictionary. The payload of a SUNDIALS log file line
+    is the part after all the [ ] brackets.
+    """
+    kvpstrs = payload.split(",")
+    kvp_dict = {}
+    for kvpstr in kvpstrs:
+        kvp = kvpstr.split("=")
+        if len(kvp) == 1:
+            kvp_dict[kvp[0].strip()] = ""
+        else:
+            key, value = kvp
+            values = []
+            if array_indicator in key:
+                for line in all_lines[line_number + 1 :]:
+                    if line.startswith("["):
+                        break
+                    values.append(np.double(line))
+                kvp_dict[key.strip()] = values
+            else:
+                kvp_dict[key.strip()] = value.strip()
+    return kvp_dict
+
+
+def parse_logfile_line(line, line_number, all_lines):
+    """
+    This function takes a line from a SUNDIALS log file and parses it into a dictionary.
+    A log file line has the form:
+      [loglvl][rank][scope][label] key1 = value, key2 = value
+    Log file payloads can be multiline if they are an array/vector with one value per line.
+    I.e.
+      [loglvl][rank][scope][label] y(:)
+      y_1
+      y_2
+      ...
+    """
+    pattern = re.compile("\[(\w+)\]\[(rank \d+)\]\[(.*)\]\[(.*)\](.*)")
+    matches = pattern.findall(line)
+    line_dict = {}
+    if matches:
+        line_dict["loglvl"] = matches[0][0]
+        line_dict["rank"] = matches[0][1]
+        line_dict["scope"] = matches[0][2]
+        line_dict["label"] = matches[0][3]
+        line_dict["payload"] = parse_logfile_payload(
+            matches[0][4], line_number, all_lines
+        )
+    return line_dict
+
+
+def log_file_to_list(filename, step_scope_txt):
+    """
+    This function takes a debug log file from CVODE and creates a list where
+    each list entry is a step attempt.
+
+    E.g.,
+    [
+      [
+          {
+              "loglvl": "DEBUG",
+              "rank": "rank 0",
+              "scope": "<step_scope_txt>",
+              "label": "enter-step-attempt-loop",
+              "payload": {"step": "0", "h": "1e-06", "q": "1", "t_n": "0"},
+          }, ...
+      ], ...
+    ]
+    """
+    with open(filename, "r") as logfile:
+        log = []
+        lines_for_this_step = None
+        all_lines = logfile.readlines()
+        for line_number, line in enumerate(all_lines):
+            line_dict = parse_logfile_line(line.rstrip(), line_number, all_lines)
+            if not line_dict:
+                continue
+            if (
+                line_dict["scope"] == step_scope_txt
+                and line_dict["label"] == "enter-step-attempt-loop"
+            ):
+                if lines_for_this_step is None:
+                    lines_for_this_step = [line_dict]
+                else:
+                    log.append(lines_for_this_step)
+                    lines_for_this_step = [line_dict]
+            else:
+                lines_for_this_step.append(line_dict)
+    return log
+
+
+def cvode_debug_file_to_list(filename):
+    """
+    This function takes a debug log file from CVODE and creates a list where
+    each list entry is a step attempt. See log_file_to_list.
+    """
+    return log_file_to_list(filename, "CVODE::cvStep")

--- a/scripts/sundialsdev/logs.py
+++ b/scripts/sundialsdev/logs.py
@@ -74,7 +74,7 @@ def parse_logfile_line(line, line_number, all_lines):
 
 def log_file_to_list(filename, step_scope_txt):
     """
-    This function takes a debug log file from CVODE and creates a list where
+    This function takes a debug log file from a SUNDIALS log file and creates a list where
     each list element represents an integrator step attempt.
 
     E.g.,

--- a/scripts/sundialsdev/logs.py
+++ b/scripts/sundialsdev/logs.py
@@ -58,7 +58,7 @@ def parse_logfile_line(line, line_number, all_lines):
       y_2
       ...
     """
-    pattern = re.compile("\[(\w+)\]\[(rank \d+)\]\[(.*)\]\[(.*)\](.*)")
+    pattern = re.compile(r"\[(\w+)\]\[(rank \d+)\]\[(.*)\]\[(.*)\](.*)")
     matches = pattern.findall(line)
     line_dict = {}
     if matches:

--- a/scripts/sundialsdev/logs.py
+++ b/scripts/sundialsdev/logs.py
@@ -75,7 +75,7 @@ def parse_logfile_line(line, line_number, all_lines):
 def log_file_to_list(filename, step_scope_txt):
     """
     This function takes a debug log file from CVODE and creates a list where
-    each list entry is a step attempt.
+    each list element represents an integrator step attempt.
 
     E.g.,
     [

--- a/src/arkode/arkode_arkstep.c
+++ b/src/arkode/arkode_arkstep.c
@@ -1838,20 +1838,20 @@ int arkStep_TakeStep_Z(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
     SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG,
                        "ARKODE::arkStep_TakeStep_Z", "explicit stage",
-                       "z[%i] =", 0);
+                       "z_%i(:) =", 0);
     N_VPrintFile(ark_mem->ycur, ARK_LOGGER->debug_fp);
     if (step_mem->implicit)
     {
       SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG,
                          "ARKODE::arkStep_TakeStep_Z", "implicit RHS",
-                         "Fi[%i] =", 0);
+                         "Fi_%i(:) =", 0);
       N_VPrintFile(step_mem->Fi[0], ARK_LOGGER->debug_fp);
     }
     if (step_mem->explicit)
     {
       SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG,
                          "ARKODE::arkStep_TakeStep_Z", "explicit RHS",
-                         "Fe[%i] =", 0);
+                         "Fe_%i(:) =", 0);
       N_VPrintFile(step_mem->Fe[0], ARK_LOGGER->debug_fp);
     }
 #endif
@@ -1919,7 +1919,7 @@ int arkStep_TakeStep_Z(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
 
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
     SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG,
-                       "ARKODE::arkStep_TakeStep_Z", "predictor", "zpred =", "");
+                       "ARKODE::arkStep_TakeStep_Z", "predictor", "zpred(:) =", "");
     N_VPrintFile(step_mem->zpred, ARK_LOGGER->debug_fp);
 #endif
 
@@ -1929,7 +1929,7 @@ int arkStep_TakeStep_Z(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
 
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
     SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG,
-                       "ARKODE::arkStep_TakeStep_Z", "rhs data", "sdata =", "");
+                       "ARKODE::arkStep_TakeStep_Z", "rhs data", "sdata(:) =", "");
     N_VPrintFile(step_mem->sdata, ARK_LOGGER->debug_fp);
 #endif
 
@@ -1944,7 +1944,7 @@ int arkStep_TakeStep_Z(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
       SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG,
                          "ARKODE::arkStep_TakeStep_Z", "implicit stage",
-                         "z[%i] =", is);
+                         "z_%i(:) =", is);
       N_VPrintFile(ark_mem->ycur, ARK_LOGGER->debug_fp);
 #endif
 
@@ -1968,7 +1968,7 @@ int arkStep_TakeStep_Z(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
       SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG,
                          "ARKODE::arkStep_TakeStep_Z", "explicit stage",
-                         "z[%i] =", is);
+                         "z_%i(:) =", is);
       N_VPrintFile(ark_mem->ycur, ARK_LOGGER->debug_fp);
 #endif
     }
@@ -2013,7 +2013,7 @@ int arkStep_TakeStep_Z(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
       SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG,
                          "ARKODE::arkStep_TakeStep_Z", "implicit RHS",
-                         "Fi[%i] =", is);
+                         "Fi_%i(:) =", is);
       N_VPrintFile(step_mem->Fi[is], ARK_LOGGER->debug_fp);
 #endif
 
@@ -2031,7 +2031,7 @@ int arkStep_TakeStep_Z(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
       SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG,
                          "ARKODE::arkStep_TakeStep_Z", "explicit RHS",
-                         "Fe[%i] =", is);
+                         "Fe_%i(:) =", is);
       N_VPrintFile(step_mem->Fe[is], ARK_LOGGER->debug_fp);
 #endif
 
@@ -2050,7 +2050,7 @@ int arkStep_TakeStep_Z(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
         SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG,
                            "ARKODE::arkStep_TakeStep_Z", "M^{-1} implicit RHS",
-                           "Fi[%i] =", is);
+                           "Fi_%i(:) =", is);
         N_VPrintFile(step_mem->Fi[is], ARK_LOGGER->debug_fp);
 #endif
         if (*nflagPtr != ARK_SUCCESS) { return (TRY_AGAIN); }
@@ -2062,7 +2062,7 @@ int arkStep_TakeStep_Z(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
         SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG,
                            "ARKODE::arkStep_TakeStep_Z", "M^{-1} explicit RHS",
-                           "Fe[%i] =", is);
+                           "Fe_%i(:) =", is);
         N_VPrintFile(step_mem->Fe[is], ARK_LOGGER->debug_fp);
 #endif
         if (*nflagPtr != ARK_SUCCESS) { return (TRY_AGAIN); }
@@ -2084,7 +2084,7 @@ int arkStep_TakeStep_Z(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
 
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
   SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG, "ARKODE::arkStep_TakeStep_Z",
-                     "updated solution", "ycur =", "");
+                     "updated solution", "ycur(:) =", "");
   N_VPrintFile(ark_mem->ycur, ARK_LOGGER->debug_fp);
 #endif
 

--- a/src/arkode/arkode_arkstep.c
+++ b/src/arkode/arkode_arkstep.c
@@ -1919,7 +1919,8 @@ int arkStep_TakeStep_Z(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
 
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
     SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG,
-                       "ARKODE::arkStep_TakeStep_Z", "predictor", "zpred(:) =", "");
+                       "ARKODE::arkStep_TakeStep_Z", "predictor",
+                       "zpred(:) =", "");
     N_VPrintFile(step_mem->zpred, ARK_LOGGER->debug_fp);
 #endif
 
@@ -1929,7 +1930,8 @@ int arkStep_TakeStep_Z(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
 
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
     SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG,
-                       "ARKODE::arkStep_TakeStep_Z", "rhs data", "sdata(:) =", "");
+                       "ARKODE::arkStep_TakeStep_Z", "rhs data",
+                       "sdata(:) =", "");
     N_VPrintFile(step_mem->sdata, ARK_LOGGER->debug_fp);
 #endif
 

--- a/src/arkode/arkode_arkstep_nls.c
+++ b/src/arkode/arkode_arkstep_nls.c
@@ -425,7 +425,7 @@ int arkStep_Nls(ARKodeMem ark_mem, int nflag)
 
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
   SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG, "ARKODE::arkStep_Nls",
-                     "correction", "zcor =", "");
+                     "correction", "zcor(:) =", "");
   N_VPrintFile(step_mem->zcor, ARK_LOGGER->debug_fp);
 #endif
 

--- a/src/arkode/arkode_erkstep.c
+++ b/src/arkode/arkode_erkstep.c
@@ -635,10 +635,10 @@ int erkStep_TakeStep(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
 
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
   SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG, "ARKODE::erkStep_TakeStep",
-                     "stage", "z[0] =", "");
+                     "stage", "z_0(:) =", "");
   N_VPrintFile(ark_mem->ycur, ARK_LOGGER->debug_fp);
   SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG, "ARKODE::erkStep_TakeStep",
-                     "stage RHS", "F[0] =", "");
+                     "stage RHS", "F_0(:) =", "");
   N_VPrintFile(step_mem->F[0], ARK_LOGGER->debug_fp);
 #endif
 
@@ -704,7 +704,7 @@ int erkStep_TakeStep(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
 
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
     SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG,
-                       "ARKODE::erkStep_TakeStep", "stage RHS", "F[%i] =", is);
+                       "ARKODE::erkStep_TakeStep", "stage RHS", "F_%i(:) =", is);
     N_VPrintFile(step_mem->F[is], ARK_LOGGER->debug_fp);
 #endif
 
@@ -716,7 +716,7 @@ int erkStep_TakeStep(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
 
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
   SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG, "ARKODE::erkStep_TakeStep",
-                     "updated solution", "ycur =", "");
+                     "updated solution", "ycur(:) =", "");
   N_VPrintFile(ark_mem->ycur, ARK_LOGGER->debug_fp);
 #endif
 

--- a/src/arkode/arkode_mristep.c
+++ b/src/arkode/arkode_mristep.c
@@ -1497,19 +1497,19 @@ int mriStep_TakeStep(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
 
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
   SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG, "ARKODE::mriStep_TakeStep",
-                     "slow stage", "z[0] =", "");
+                     "slow stage", "z_0(:) =", "");
   N_VPrintFile(ark_mem->ycur, ARK_LOGGER->debug_fp);
 
   if (step_mem->explicit_rhs)
   {
     SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG, "ARKODE::mriStep_TakeStep",
-                       "slow explicit RHS", "Fse[0] =", "");
+                       "slow explicit RHS", "Fse_0(:) =", "");
     N_VPrintFile(step_mem->Fse[0], ARK_LOGGER->debug_fp);
   }
   if (step_mem->implicit_rhs)
   {
     SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG, "ARKODE::mriStep_TakeStep",
-                       "slow implicit RHS", "Fsi[0] =", "");
+                       "slow implicit RHS", "Fsi_0(:) =", "");
     N_VPrintFile(step_mem->Fsi[0], ARK_LOGGER->debug_fp);
   }
 #endif
@@ -1555,7 +1555,7 @@ int mriStep_TakeStep(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
 
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
     SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG,
-                       "ARKODE::mriStep_TakeStep", "slow stage", "z[%i] =", is);
+                       "ARKODE::mriStep_TakeStep", "slow stage", "z_%i(:) =", is);
     N_VPrintFile(ark_mem->ycur, ARK_LOGGER->debug_fp);
 #endif
 
@@ -1593,7 +1593,7 @@ int mriStep_TakeStep(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
         SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG,
                            "ARKODE::mriStep_TakeStep", "slow explicit RHS",
-                           "Fse[%i] =", is);
+                           "Fse_%i(:) =", is);
         N_VPrintFile(step_mem->Fse[step_mem->stage_map[is]],
                      ARK_LOGGER->debug_fp);
 #endif
@@ -1623,7 +1623,7 @@ int mriStep_TakeStep(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
         SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG,
                            "ARKODE::mriStep_TakeStep", "slow implicit RHS",
-                           "Fsi[%i] =", is);
+                           "Fsi_%i(:) =", is);
         N_VPrintFile(step_mem->Fsi[step_mem->stage_map[is]],
                      ARK_LOGGER->debug_fp);
 #endif
@@ -1633,7 +1633,7 @@ int mriStep_TakeStep(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
 
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
   SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG, "ARKODE::mriStep_TakeStep",
-                     "updated solution", "ycur =", "");
+                     "updated solution", "ycur(:) =", "");
   N_VPrintFile(ark_mem->ycur, ARK_LOGGER->debug_fp);
 #endif
 
@@ -2161,7 +2161,7 @@ int mriStep_StageDIRKNoFast(ARKodeMem ark_mem, ARKodeMRIStepMem step_mem,
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
   SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG,
                      "ARKODE::mriStep_StageDIRKNoFast", "predictor",
-                     "zpred =", "");
+                     "zpred(:) =", "");
   N_VPrintFile(step_mem->zpred, ARK_LOGGER->debug_fp);
 #endif
 
@@ -2177,7 +2177,7 @@ int mriStep_StageDIRKNoFast(ARKodeMem ark_mem, ARKodeMRIStepMem step_mem,
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
   SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG,
                      "ARKODE::mriStep_StageDIRKNoFast", "rhs data",
-                     "sdata =", "");
+                     "sdata(:) =", "");
   N_VPrintFile(step_mem->sdata, ARK_LOGGER->debug_fp);
 #endif
 
@@ -2316,7 +2316,7 @@ int mriStep_ComputeInnerForcing(SUNDIALS_MAYBE_UNUSED ARKodeMem ark_mem,
   {
     SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG,
                        "ARKODE::mriStep_ComputeInnerForcing", "forcing",
-                       "forcing[%i] =", k);
+                       "forcing_%i(:) =", k);
     N_VPrintFile(step_mem->stepper->forcing[k], ARK_LOGGER->debug_fp);
   }
 #endif

--- a/src/arkode/arkode_mristep_nls.c
+++ b/src/arkode/arkode_mristep_nls.c
@@ -328,7 +328,7 @@ int mriStep_Nls(ARKodeMem ark_mem, int nflag)
 
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
   SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG, "ARKODE::mriStep_Nls",
-                     "correction", "zcor =", "");
+                     "correction", "zcor(:) =", "");
   N_VPrintFile(step_mem->zcor, ARK_LOGGER->debug_fp);
 #endif
 

--- a/src/arkode/arkode_relaxation.c
+++ b/src/arkode/arkode_relaxation.c
@@ -357,7 +357,7 @@ static int arkRelaxSolve(ARKodeMem ark_mem, ARKodeRelaxMem relax_mem,
 
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
   SUNLogger_QueueMsg(ARK_LOGGER, SUN_LOGLEVEL_DEBUG, "ARKODE::arkRelaxSolve",
-                     "compute delta y", "delta_y =", "");
+                     "compute delta y", "delta_y(:) =", "");
   N_VPrintFile(ark_mem->tempv2, ARK_LOGGER->debug_fp);
 #endif
 

--- a/src/cvode/cvode.c
+++ b/src/cvode/cvode.c
@@ -2704,7 +2704,7 @@ static void cvPredict(CVodeMem cv_mem)
 
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
   SUNLogger_QueueMsg(CV_LOGGER, SUN_LOGLEVEL_DEBUG, "CVODE::cvPredict",
-                     "return", "zn0(:) =", "");
+                     "return", "zn_0(:) =", "");
   N_VPrintFile(cv_mem->cv_zn[0], CV_LOGGER->debug_fp);
 #endif
 }

--- a/src/cvode/cvode.c
+++ b/src/cvode/cvode.c
@@ -2704,7 +2704,7 @@ static void cvPredict(CVodeMem cv_mem)
 
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
   SUNLogger_QueueMsg(CV_LOGGER, SUN_LOGLEVEL_DEBUG, "CVODE::cvPredict",
-                     "return", "predictor =", "");
+                     "return", "zn0(:) =", "");
   N_VPrintFile(cv_mem->cv_zn[0], CV_LOGGER->debug_fp);
 #endif
 }

--- a/src/cvodes/cvodes.c
+++ b/src/cvodes/cvodes.c
@@ -6531,7 +6531,7 @@ static void cvPredict(CVodeMem cv_mem)
 
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
   SUNLogger_QueueMsg(CV_LOGGER, SUN_LOGLEVEL_DEBUG, "CVODES::cvPredict",
-                     "forward", "predictor =", "");
+                     "forward", "zn_0(:) =", "");
   N_VPrintFile(cv_mem->cv_zn[0], CV_LOGGER->debug_fp);
 #endif
 
@@ -6548,7 +6548,7 @@ static void cvPredict(CVodeMem cv_mem)
 
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
     SUNLogger_QueueMsg(CV_LOGGER, SUN_LOGLEVEL_DEBUG, "CVODES::cvPredict",
-                       "quad", "predictor =", "");
+                       "quad", "znQ_0(:) =", "");
     N_VPrintFile(cv_mem->cv_znQ[0], CV_LOGGER->debug_fp);
 #endif
   }
@@ -6566,7 +6566,7 @@ static void cvPredict(CVodeMem cv_mem)
         for (i = 0; i < cv_mem->cv_Ns; i++)
         {
           SUNLogger_QueueMsg(CV_LOGGER, SUN_LOGLEVEL_DEBUG, "CVODES::cvPredict",
-                             "sensi", " i = %d,  predictor_i = ", i);
+                             "sensi", " i = %d,  znS_i(:) = ", i);
           N_VPrintFile(cv_mem->cv_znS[0][i], CV_LOGGER->debug_fp);
         }
 #endif
@@ -6587,7 +6587,7 @@ static void cvPredict(CVodeMem cv_mem)
         for (i = 0; i < cv_mem->cv_Ns; i++)
         {
           SUNLogger_QueueMsg(CV_LOGGER, SUN_LOGLEVEL_DEBUG, "CVODES::cvPredict",
-                             "quad-sensi", " i = %d,  predictor_i = ", i);
+                             "quad-sensi", " i = %d,  znQS_i(:) = ", i);
           N_VPrintFile(cv_mem->cv_znQS[0][i], CV_LOGGER->debug_fp);
         }
 #endif

--- a/src/kinsol/kinsol.c
+++ b/src/kinsol/kinsol.c
@@ -2842,7 +2842,7 @@ static int KINFP(KINMem kin_mem)
 
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
   SUNLogger_QueueMsg(KIN_LOGGER, SUN_LOGLEVEL_DEBUG, "KINSOL::KINFP", "begin",
-                     "%s", "u_0:");
+                     "%s", "u_0(:) =");
   N_VPrintFile(kin_mem->kin_uu, KIN_LOGGER->debug_fp);
 #endif
 
@@ -2862,7 +2862,7 @@ static int KINFP(KINMem kin_mem)
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
     SUNLogger_QueueMsg(KIN_LOGGER, SUN_LOGLEVEL_DEBUG, "KINSOL::KINFP",
                        "while-loop-before-compute-new",
-                       "G_%ld:", kin_mem->kin_nni - 1);
+                       "G_%ld(:) =", kin_mem->kin_nni - 1);
     N_VPrintFile(kin_mem->kin_fval, KIN_LOGGER->debug_fp);
 #endif
 
@@ -2917,7 +2917,7 @@ static int KINFP(KINMem kin_mem)
 
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
     SUNLogger_QueueMsg(KIN_LOGGER, SUN_LOGLEVEL_DEBUG, "KINSOL::KINFP",
-                       "while-loop-after-compute-new", "u_%ld:\n",
+                       "while-loop-after-compute-new", "u_%ld(:) =",
                        kin_mem->kin_nni);
     N_VPrintFile(kin_mem->kin_unew, KIN_LOGGER->debug_fp);
 #endif

--- a/src/kinsol/kinsol.c
+++ b/src/kinsol/kinsol.c
@@ -2917,8 +2917,8 @@ static int KINFP(KINMem kin_mem)
 
 #ifdef SUNDIALS_LOGGING_EXTRA_DEBUG
     SUNLogger_QueueMsg(KIN_LOGGER, SUN_LOGLEVEL_DEBUG, "KINSOL::KINFP",
-                       "while-loop-after-compute-new", "u_%ld(:) =",
-                       kin_mem->kin_nni);
+                       "while-loop-after-compute-new",
+                       "u_%ld(:) =", kin_mem->kin_nni);
     N_VPrintFile(kin_mem->kin_unew, KIN_LOGGER->debug_fp);
 #endif
 


### PR DESCRIPTION
I started this on another branch where I needed to parse the `SUNLogger` log files to understand (and plot) some CVode behavior.  The intent is to add more of our Python utilities for plotting stuff like step size over time etc.  We can also add other modules unrelated to logging. 