### PR TITLE
revert change to N_VSpace_Sycl that was missed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+Fixed a [bug](https://github.com/LLNL/sundials/pull/523) in v7.1.0 with the SYCL N_Vector `N_VSpace` function. 
+
 ### Deprecation Notices
 
 ## Changes to SUNDIALS in release 7.1.0

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -4,4 +4,6 @@
 
 **Bug Fixes**
 
+Fixed a `bug <https://github.com/LLNL/sundials/pull/523>`_ in v7.1.0 with the SYCL N_Vector ``N_VSpace`` function. 
+
 **Deprecation Notices**

--- a/src/nvector/sycl/nvector_sycl.cpp
+++ b/src/nvector/sycl/nvector_sycl.cpp
@@ -870,7 +870,7 @@ void N_VDestroy_Sycl(N_Vector v)
   return;
 }
 
-void N_VSpace_Sycl(N_Vector X, long int* lrw, long int* liw)
+void N_VSpace_Sycl(N_Vector X, sunindextype* lrw, sunindextype* liw)
 {
   *lrw = NVEC_SYCL_CONTENT(X)->length;
   *liw = 2;


### PR DESCRIPTION
This change was supposed to be reverted in #447 but it was missed. This will fix https://github.com/spack/spack/pull/44814#issuecomment-2185415334. 