### PR TITLE
Fix variable arguments start/end

### DIFF
--- a/include/sundials/priv/sundials_errors_impl.h
+++ b/include/sundials/priv/sundials_errors_impl.h
@@ -186,10 +186,12 @@ static inline void SUNHandleErrWithFmtMsg(int line, const char* func,
   msglen = (size_t)vsnprintf(NULL, (size_t)0, msgfmt, values); /* determine size
                                                                   of buffer
                                                                   needed */
-  msg    = (char*)malloc(msglen + 1);
-  vsnprintf(msg, msglen + 1, msgfmt, values);
-  SUNHandleErrWithMsg(line, func, file, msg, code, sunctx);
   va_end(values);
+  msg = (char*)malloc(msglen + 1);
+  va_start(values, sunctx);
+  vsnprintf(msg, msglen + 1, msgfmt, values);
+  va_end(values);
+  SUNHandleErrWithMsg(line, func, file, msg, code, sunctx);
   free(msg);
 }
 

--- a/src/sundials/sundials_errors.c
+++ b/src/sundials/sundials_errors.c
@@ -94,23 +94,23 @@ void SUNGlobalFallbackErrHandler(int line, const char* func, const char* file,
   char* log_msg       = NULL;
   char* file_and_line = NULL;
 
-  va_start(ap, err_code);
-
   file_and_line = sunCombineFileAndLine(__LINE__, __FILE__);
+  va_start(ap, err_code);
   sunCreateLogMessage(SUN_LOGLEVEL_ERROR, 0, file_and_line,
                       __func__, "The SUNDIALS SUNContext was corrupt or NULL when an error occurred. As such, error messages have been printed to stderr.",
                       ap, &log_msg);
+  va_end(ap);
   fprintf(stderr, "%s", log_msg);
   free(log_msg);
   free(file_and_line);
 
   file_and_line = sunCombineFileAndLine(line, file);
   if (msgfmt == NULL) { msgfmt = SUNGetErrMsg(err_code); }
+  va_start(ap, err_code);
   sunCreateLogMessage(SUN_LOGLEVEL_ERROR, 0, file_and_line, func, msgfmt, ap,
                       &log_msg);
+  va_end(ap);
   fprintf(stderr, "%s", log_msg);
   free(log_msg);
   free(file_and_line);
-
-  va_end(ap);
 }

--- a/src/sundials/sundials_logger.c
+++ b/src/sundials/sundials_logger.c
@@ -333,12 +333,12 @@ SUNErrCode SUNLogger_QueueMsg(SUNLogger logger, SUNLogLevel lvl,
       return retval;
     }
 
-    va_list args;
-    va_start(args, msg_txt);
-
     if (logger->queuemsg)
     {
+      va_list args;
+      va_start(args, msg_txt);
       retval = logger->queuemsg(logger, lvl, scope, label, msg_txt, args);
+      va_end(args);
     }
     else
     {
@@ -347,7 +347,10 @@ SUNErrCode SUNLogger_QueueMsg(SUNLogger logger, SUNLogLevel lvl,
       if (sunLoggerIsOutputRank(logger, &rank))
       {
         char* log_msg = NULL;
+        va_list args;
+        va_start(args, msg_txt);
         sunCreateLogMessage(lvl, rank, scope, label, msg_txt, args, &log_msg);
+        va_end(args);
 
         switch (lvl)
         {
@@ -372,8 +375,6 @@ SUNErrCode SUNLogger_QueueMsg(SUNLogger logger, SUNLogLevel lvl,
         free(log_msg);
       }
     }
-
-    va_end(args);
   }
 #else
   /* silence warnings when all logging is disabled */

--- a/test/unit_tests/sundials/test_sundials_errors.cpp
+++ b/test/unit_tests/sundials/test_sundials_errors.cpp
@@ -171,22 +171,25 @@ protected:
   SUNContext sunctx;
 };
 
-static void firstHandler(int line, const char* func, const char* file, const char* msg,
-                  SUNErrCode err_code, void* err_user_data, SUNContext sunctx)
+static void firstHandler(int line, const char* func, const char* file,
+                         const char* msg, SUNErrCode err_code,
+                         void* err_user_data, SUNContext sunctx)
 {
   std::vector<int>* order = static_cast<std::vector<int>*>(err_user_data);
   order->push_back(0);
 }
 
-static void secondHandler(int line, const char* func, const char* file, const char* msg,
-                   SUNErrCode err_code, void* err_user_data, SUNContext sunctx)
+static void secondHandler(int line, const char* func, const char* file,
+                          const char* msg, SUNErrCode err_code,
+                          void* err_user_data, SUNContext sunctx)
 {
   std::vector<int>* order = static_cast<std::vector<int>*>(err_user_data);
   order->push_back(1);
 }
 
-static void thirdHandler(int line, const char* func, const char* file, const char* msg,
-                  SUNErrCode err_code, void* err_user_data, SUNContext sunctx)
+static void thirdHandler(int line, const char* func, const char* file,
+                         const char* msg, SUNErrCode err_code,
+                         void* err_user_data, SUNContext sunctx)
 {
   std::vector<int>* order = static_cast<std::vector<int>*>(err_user_data);
   order->push_back(2);

--- a/test/unit_tests/sundials/test_sundials_errors.cpp
+++ b/test/unit_tests/sundials/test_sundials_errors.cpp
@@ -171,21 +171,21 @@ protected:
   SUNContext sunctx;
 };
 
-void firstHandler(int line, const char* func, const char* file, const char* msg,
+static void firstHandler(int line, const char* func, const char* file, const char* msg,
                   SUNErrCode err_code, void* err_user_data, SUNContext sunctx)
 {
   std::vector<int>* order = static_cast<std::vector<int>*>(err_user_data);
   order->push_back(0);
 }
 
-void secondHandler(int line, const char* func, const char* file, const char* msg,
+static void secondHandler(int line, const char* func, const char* file, const char* msg,
                    SUNErrCode err_code, void* err_user_data, SUNContext sunctx)
 {
   std::vector<int>* order = static_cast<std::vector<int>*>(err_user_data);
   order->push_back(1);
 }
 
-void thirdHandler(int line, const char* func, const char* file, const char* msg,
+static void thirdHandler(int line, const char* func, const char* file, const char* msg,
                   SUNErrCode err_code, void* err_user_data, SUNContext sunctx)
 {
   std::vector<int>* order = static_cast<std::vector<int>*>(err_user_data);


### PR DESCRIPTION
The `test_sundials_errors` test was failing for me which I traced down to the handling of variable arguments. It's the same issue discussed in https://github.com/LLNL/sundials/issues/461 which was partially fixed in https://github.com/LLNL/sundials/pull/462. This PR should finish it off.