### PR TITLE
CMake: remove CMAKE_CUDA_ARCHITECTURES default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### New Features and Enhancements
 
+The default value of `CMAKE_CUDA_ARCHITECTURES` is no longer set to `70` and is
+now determined automatically by CMake. Users are encouraged to override the
+default value as it varies across compilers and compiler versions.
+
 ### Bug Fixes
 
 Fixed the loading of ARKStep's default first order explicit method.

--- a/cmake/SundialsTPLOptions.cmake
+++ b/cmake/SundialsTPLOptions.cmake
@@ -46,10 +46,6 @@ sundials_option(ENABLE_PTHREAD BOOL "Enable Pthreads support" OFF)
 # -------------------------------------------------------------
 sundials_option(ENABLE_CUDA BOOL "Enable CUDA support" OFF)
 
-# CMake 3.18 adds this option.
-sundials_option(CMAKE_CUDA_ARCHITECTURES STRING "Target CUDA architecture" "70"
-                DEPENDS_ON ENABLE_CUDA)
-
 # -------------------------------------------------------------
 # Enable HIP support?
 # -------------------------------------------------------------

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -2,6 +2,10 @@
 
 **New Features and Enhancements**
 
+The default value of :cmakeop:`CMAKE_CUDA_ARCHITECTURES` is no longer set to
+``70`` and is now determined automatically by CMake. Users are encouraged to
+override the default value as it varies across compilers and compiler versions.
+
 **Bug Fixes**
 
 Fixed the loading of ARKStep's default first order explicit method.

--- a/doc/shared/sundials/Install.rst
+++ b/doc/shared/sundials/Install.rst
@@ -523,9 +523,11 @@ illustration only.
 
 .. cmakeoption:: CMAKE_CUDA_ARCHITECTURES
 
-   Specifies the CUDA architecture to compile for.
+   Specifies the CUDA architecture to compile for i.e., ``60`` for Pascal,
+   ``70`` Volta, ``80`` for Ampere, ``90`` for Hopper, etc.
 
-   Default: ``sm_30``
+   Default: Determined automatically by CMake. Users are encouraged to override
+   this value as it varies across compilers and compiler versions.
 
 .. cmakeoption:: EXAMPLES_ENABLE_C
 


### PR DESCRIPTION
Allow CMake to automatically determine `CMAKE_CUDA_ARCHITECTURES` is it is not set rather than defaulting to `70`