### PR TITLE
Fix MRIStepSetOrder docs

### DIFF
--- a/doc/arkode/guide/source/Usage/MRIStep/User_callable.rst
+++ b/doc/arkode/guide/source/Usage/MRIStep/User_callable.rst
@@ -830,7 +830,7 @@ Optional inputs for IVP method selection
 
    Select the default MRI method of a given order.
 
-   The default order is 3. An order less than 3 or greater than 4 will result in
+   The default order is 3. An order less than 1 or greater than 4 will result in
    using the default.
 
    **Arguments:**


### PR DESCRIPTION
When #439 was added, I forgot to update this documentation for `MRIStepSetOrder`.