### PR TITLE
Bugfix: Default IMEX-MRI method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ architecture for their system.
 
 Fixed the loading of ARKStep's default first order explicit method.
 
+Fixed loading the default IMEX-MRI method if ``ARKodeSetOrder`` is used to
+specify a third or fourth order method. Previously, the default second order
+method was loaded in both cases.
+
 Fixed a CMake bug regarding usage of missing "print_warning" macro
 that was only triggered when the deprecated `CUDA_ARCH` option was used.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ architecture for their system.
 
 Fixed the loading of ARKStep's default first order explicit method.
 
-Fixed loading the default IMEX-MRI method if ``ARKodeSetOrder`` is used to
+Fixed loading the default IMEX-MRI method if `ARKodeSetOrder` is used to
 specify a third or fourth order method. Previously, the default second order
 method was loaded in both cases.
 

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -12,6 +12,10 @@ override this value with the architecture for their system.
 
 Fixed the loading of ARKStep's default first order explicit method.
 
+Fixed loading the default IMEX-MRI method if :c:func:`ARKodeSetOrder` is used to
+specify a third or fourth order method. Previously, the default second order
+method was loaded in both cases.
+
 Fixed a CMake bug regarding usage of missing "print_warning" macro
 that was only triggered when the deprecated ``CUDA_ARCH`` option was used.
 

--- a/src/arkode/arkode_mristep.c
+++ b/src/arkode/arkode_mristep.c
@@ -1759,8 +1759,8 @@ int mriStep_SetCoupling(ARKodeMem ark_mem)
     {
     case 1: table_id = MRISTEP_DEFAULT_IMEX_SD_1; break;
     case 2: table_id = MRISTEP_DEFAULT_IMEX_SD_2; break;
-    case 3: table_id = MRISTEP_DEFAULT_IMEX_SD_2; break;
-    case 4: table_id = MRISTEP_DEFAULT_IMEX_SD_2; break;
+    case 3: table_id = MRISTEP_DEFAULT_IMEX_SD_3; break;
+    case 4: table_id = MRISTEP_DEFAULT_IMEX_SD_4; break;
     }
 
     /**** implicit methods ****/


### PR DESCRIPTION
Fix loading the default IMEX-MRI method if `ARKodeSetOrder` is used to specify a third or fourth order method. Previously, the default second order method was loaded in both cases.