### PR TITLE
Make hscale=0 for ARKodeResize consistent with docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Example programs using *hypre* have been updated to support v2.20 and newer.
 
 ### Bug Fixes
 
+Fixed `ARKodeResize` not using the default `hscale` when an argument of `0` was
+provided.
+
 Fixed the loading of ARKStep's default first order explicit method.
 
 Fixed a CMake bug regarding usage of missing "print_warning" macro

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -17,6 +17,9 @@ Example programs using *hypre* have been updated to support v2.20 and newer.
 
 **Bug Fixes**
 
+Fixed c:func:`ARKodeResize` not using the default ``hscale`` when an argument of
+``0`` was provided.
+
 Fixed the loading of ARKStep's default first order explicit method.
 
 Fixed a CMake bug regarding usage of missing "print_warning" macro

--- a/src/arkode/arkode.c
+++ b/src/arkode/arkode.c
@@ -115,7 +115,7 @@ int ARKodeResize(void* arkode_mem, N_Vector y0, sunrealtype hscale,
 
   /* Update time-stepping parameters */
   /*   adjust upcoming step size depending on hscale */
-  if (hscale < ZERO) { hscale = ONE; }
+  if (hscale <= ZERO) { hscale = ONE; }
   if (hscale != ONE)
   {
     /* Encode hscale into ark_mem structure */


### PR DESCRIPTION
The [docs](https://sundials.readthedocs.io/en/latest/arkode/Usage/User_callable.html#arkode-system-resize-function) state

> If a value hscale<=0 is specified, the default of 1.0 will be used