### PR TITLE
Fix aliasing potential `ALIAS` target `SuiteSparse::KLU`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ repeatedly.
 Fixed compilation errors when building the Trilinos Teptra NVector with CUDA
 support.
 
+Fixed a CMake configuration issue related to aliasing an `ALIAS` target when
+using `ENABLE_KLU=ON` in combination with a static-only build of SuiteSparse.
+
 ### Deprecation Notices
 
 ## Changes to SUNDIALS in release 7.1.1

--- a/cmake/tpl/FindKLU.cmake
+++ b/cmake/tpl/FindKLU.cmake
@@ -43,7 +43,7 @@ if(NOT
       # For static-only builds of SuiteSparse, SuiteSparse::KLU will itself be
       # an ALIAS target which can't be aliased.
       get_target_property(klu_aliased_target SuiteSparse::KLU ALIASED_TARGET)
-      if (klu_aliased_target)
+      if(klu_aliased_target)
         add_library(SUNDIALS::KLU ALIAS ${klu_aliased_target})
       else()
         add_library(SUNDIALS::KLU ALIAS SuiteSparse::KLU)

--- a/cmake/tpl/FindKLU.cmake
+++ b/cmake/tpl/FindKLU.cmake
@@ -48,7 +48,7 @@ if(NOT
       else()
         add_library(SUNDIALS::KLU ALIAS SuiteSparse::KLU)
       endif()
-    set(KLU_SUITESPARSE_TARGET ON)
+      set(KLU_SUITESPARSE_TARGET ON)
       mark_as_advanced(KLU_SUITESPARSE_TARGET)
     endif()
     return()

--- a/cmake/tpl/FindKLU.cmake
+++ b/cmake/tpl/FindKLU.cmake
@@ -40,8 +40,15 @@ if(NOT
 
   if(TARGET SuiteSparse::KLU)
     if(NOT TARGET SUNDIALS::KLU)
-      add_library(SUNDIALS::KLU ALIAS SuiteSparse::KLU)
-      set(KLU_SUITESPARSE_TARGET ON)
+      # For static-only builds of SuiteSparse, SuiteSparse::KLU will itself be
+      # an ALIAS target which can't be aliased.
+      get_target_property(klu_aliased_target SuiteSparse::KLU ALIASED_TARGET)
+      if (klu_aliased_target)
+        add_library(SUNDIALS::KLU ALIAS ${klu_aliased_target})
+      else()
+        add_library(SUNDIALS::KLU ALIAS SuiteSparse::KLU)
+      endif()
+    set(KLU_SUITESPARSE_TARGET ON)
       mark_as_advanced(KLU_SUITESPARSE_TARGET)
     endif()
     return()

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -35,4 +35,7 @@ repeatedly.
 Fixed compilation errors when building the Trilinos Teptra NVector with CUDA
 support.
 
+Fixed a CMake configuration issue related to aliasing an ``ALIAS`` target when
+using ``ENABLE_KLU=ON`` in combination with a static-only build of SuiteSparse.
+
 **Deprecation Notices**


### PR DESCRIPTION
Fixes a CMake configuration issue related to aliasing an ``ALIAS`` target when using ``ENABLE_KLU=ON`` in combination with a static-only build of SuiteSparse.

See #579 for details.

Fixes #579.
