### PR TITLE
Bugfix/sparse add i

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ specific linker flags e.g., MKL.
 
 ### Bug Fixes
 
+Fixed a [bug](https://github.com/LLNL/sundials/issues/581) in 
+`SUNMatScaleAddI_Sparse` which caused out of bounds writes unless `indexvals`
+were in ascending order for each row/column.
+
 Fixed `ARKodeResize` not using the default `hscale` when an argument of `0` was
 provided.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,9 @@ specific linker flags e.g., MKL.
 
 ### Bug Fixes
 
-Fixed a [bug](https://github.com/LLNL/sundials/issues/581) in 
-`SUNMatScaleAddI_Sparse` which caused out of bounds writes unless `indexvals`
-were in ascending order for each row/column.
+Fixed a [bug](https://github.com/LLNL/sundials/issues/581) in the sparse matrix
+implementation of `SUNMatScaleAddI` which caused out of bounds writes unless
+`indexvals` were in ascending order for each row/column.
 
 Fixed `ARKodeResize` not using the default `hscale` when an argument of `0` was
 provided.

--- a/benchmarks/nvector/test_nvector_performance.c
+++ b/benchmarks/nvector/test_nvector_performance.c
@@ -43,7 +43,7 @@ static void time_stats(N_Vector X, double* times, int start, int ntimes,
 int print_time = 0; /* flag for printing timing data */
 int nwarmups   = 1; /* number of extra tests to perform and ignore in average */
 
-#if defined(SUNDIALS_HAVE_POSIX_TIMERS) && defined(_POSIX_TIMERS)
+#if defined(SUNDIALS_HAVE_POSIX_TIMERS)
 time_t base_time_tv_sec = 0; /* Base time; makes time values returned
                                 by get_time easier to read when
                                 printed since they will be zero
@@ -2723,7 +2723,7 @@ void SetNumWarmups(int num_warmups)
 
 void SetTiming(int onoff, int myid)
 {
-#if defined(SUNDIALS_HAVE_POSIX_TIMERS) && defined(_POSIX_TIMERS)
+#if defined(SUNDIALS_HAVE_POSIX_TIMERS)
   struct timespec spec;
   clock_gettime(CLOCK_MONOTONIC, &spec);
   base_time_tv_sec = spec.tv_sec;
@@ -2812,7 +2812,7 @@ void rand_realtype_constraints(sunrealtype* data, sunindextype len)
 static double get_time(void)
 {
   double time;
-#if defined(SUNDIALS_HAVE_POSIX_TIMERS) && defined(_POSIX_TIMERS)
+#if defined(SUNDIALS_HAVE_POSIX_TIMERS)
   struct timespec spec;
   clock_gettime(CLOCK_MONOTONIC, &spec);
   time = (double)(spec.tv_sec - base_time_tv_sec) +

--- a/doc/shared/Changelog.rst
+++ b/doc/shared/Changelog.rst
@@ -31,7 +31,7 @@ Changes to SUNDIALS in release 7.1.1
 
 **Bug Fixes**
 
-Fixed a `bug <https://github.com/LLNL/sundials/pull/523>`_ in v7.1.0 with the
+Fixed a `bug <https://github.com/LLNL/sundials/pull/523>`__ in v7.1.0 with the
 SYCL N_Vector ``N_VSpace`` function.
 
 Changes to SUNDIALS in release 7.1.0
@@ -109,11 +109,11 @@ to ``SYCL`` to match Ginkgo's updated naming convention.
 
 Changed the CMake version compatibility mode for SUNDIALS to ``AnyNewerVersion``
 instead of ``SameMajorVersion``. This fixes the issue seen `here
-<https://github.com/AMReX-Codes/amrex/pull/3835>`_.
+<https://github.com/AMReX-Codes/amrex/pull/3835>`__.
 
 Fixed a CMake bug that caused an MPI linking error for our C++ examples in some
 instances. Fixes `GitHub Issue #464
-<https://github.com/LLNL/sundials/issues/464>`_.
+<https://github.com/LLNL/sundials/issues/464>`__.
 
 Fixed the runtime library installation path for windows systems. This fix
 changes the default library installation path from
@@ -134,11 +134,11 @@ Fixed a bug in the HIP execution policies where ``WARP_SIZE`` would not be set
 with ROCm 6.0.0 or newer.
 
 Fixed a bug that caused error messages to be cut off in some cases. Fixes
-`GitHub Issue #461 <https://github.com/LLNL/sundials/issues/461>`_.
+`GitHub Issue #461 <https://github.com/LLNL/sundials/issues/461>`__.
 
 Fixed a memory leak when an error handler was added to a
 :c:type:`SUNContext`. Fixes `GitHub Issue #466
-<https://github.com/LLNL/sundials/issues/466>`_.
+<https://github.com/LLNL/sundials/issues/466>`__.
 
 Fixed a bug where :c:func:`MRIStepEvolve` would not handle a recoverable error
 produced from evolving the inner stepper.
@@ -187,7 +187,7 @@ be built with additional error checking by default. See
 SUNDIALS now requires using a compiler that supports a subset of the C99
 standard. Note with the Microsoft C/C++ compiler the subset of C99 features
 utilized by SUNDIALS are available starting with `Visual Studio 2015
-<https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance?view=msvc-170#c-standard-library-features-1>`_.
+<https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance?view=msvc-170#c-standard-library-features-1>`__.
 
 *Minimum CMake Version*
 
@@ -297,7 +297,7 @@ and a typedef to a ``MPI_Comm`` in builds with MPI. As a result:
 
 The change away from type-erased pointers for :c:type:`SUNComm` fixes problems
 like the one described in
-`GitHub Issue #275 <https://github.com/LLNL/sundials/issues/275>`_.
+`GitHub Issue #275 <https://github.com/LLNL/sundials/issues/275>`__.
 
 The SUNLogger is now always MPI-aware if MPI is enabled in SUNDIALS and the
 ``SUNDIALS_LOGGING_ENABLE_MPI`` CMake option and macro definition were removed
@@ -358,12 +358,12 @@ interface.
 
 **Bug Fixes**
 
-Fixed `GitHub Issue #329 <https://github.com/LLNL/sundials/issues/329>`_ so
+Fixed `GitHub Issue #329 <https://github.com/LLNL/sundials/issues/329>`__ so
 that C++20 aggregate initialization can be used.
 
 Fixed integer overflow in the internal SUNDIALS hashmap. This resolves
-`GitHub Issues #409 <https://github.com/LLNL/sundials/issues/409>`_ and
-`#249 <https://github.com/LLNL/sundials/issues/249>`_.
+`GitHub Issues #409 <https://github.com/LLNL/sundials/issues/409>`__ and
+`#249 <https://github.com/LLNL/sundials/issues/249>`__.
 
 **Deprecation Notice**
 
@@ -431,7 +431,7 @@ an :c:type:`MRIStepInnerFullRhsFn` optional.
 **Bug Fixes**
 
 Changed the :c:type:`SUNProfiler` so that it does not rely on ``MPI_WTime`` in
-any case. This fixes `GitHub Issue #312 <https://github.com/LLNL/sundials/issues/312>`_.
+any case. This fixes `GitHub Issue #312 <https://github.com/LLNL/sundials/issues/312>`__.
 
 Fixed scaling bug in ``SUNMatScaleAddI_Sparse`` for non-square matrices.
 
@@ -587,7 +587,7 @@ Added support for the SYCL backend with RAJA 2022.x.y.
 **Bug Fixes**
 
 Fixed an underflow bug during root finding in ARKODE, CVODE, CVODES, IDA and
-IDAS. This fixes `GitHub Issue #57 <https://github.com/LLNL/sundials/issues/57>`_.
+IDAS. This fixes `GitHub Issue #57 <https://github.com/LLNL/sundials/issues/57>`__.
 
 Fixed an issue with finding oneMKL when using the ``icpx`` compiler with the
 ``-fsycl`` flag as the C++ compiler instead of ``dpcpp``.
@@ -624,13 +624,13 @@ e.g., CUDA, HIP, RAJA, Trilinos, SuperLU_DIST, MAGMA, Ginkgo, and Kokkos.
 
 **Major Features**
 
-Added support for the `Ginkgo <https://ginkgo-project.github.io/>`_ linear
+Added support for the `Ginkgo <https://ginkgo-project.github.io/>`__ linear
 algebra library. This support includes new SUNDIALS matrix and linear solver
 implementations, see the sections :numref:`SUNMatrix.Ginkgo` and
 :numref:`SUNLinSol.Ginkgo`.
 
 Added new SUNDIALS vector, dense matrix, and dense linear solver implementations
-utilizing the `Kokkos Ecosystem <https://kokkos.org/>`_ for performance
+utilizing the `Kokkos Ecosystem <https://kokkos.org/>`__ for performance
 portability, see sections :numref:`NVectors.Kokkos`, :numref:`SUNMatrix.Kokkos`,
 and :numref:`SUNLinSol.Kokkos` for more information.
 
@@ -702,7 +702,7 @@ functions when they are available and the user may provide the math library to
 link to via the advanced CMake option :cmakeop:`SUNDIALS_MATH_LIBRARY`.
 
 Changed ``SUNDIALS_LOGGING_ENABLE_MPI`` CMake option default to be ``OFF``. This
-fixes `GitHub Issue #177 <https://github.com/LLNL/sundials/issues/177>`_.
+fixes `GitHub Issue #177 <https://github.com/LLNL/sundials/issues/177>`__.
 
 Changes to SUNDIALS in release 6.2.0
 ====================================
@@ -1052,7 +1052,7 @@ namespace.
 A capability to profile/instrument SUNDIALS library code has been added. This
 can be enabled with the CMake option :cmakeop:`SUNDIALS_BUILD_WITH_PROFILING`. A
 built-in profiler will be used by default, but the `Caliper
-<https://github.com/LLNL/Caliper>`_ library can also be used instead with the
+<https://github.com/LLNL/Caliper>`__ library can also be used instead with the
 CMake option :cmakeop:`ENABLE_CALIPER`. See the documentation section on
 profiling for more details.
 
@@ -2656,7 +2656,7 @@ these vectors both move all data to the GPU device upon construction, and
 speedup will only be realized if the user also conducts the right-hand-side
 function evaluation on the device. In addition, these vectors assume the problem
 fits on one GPU. For further information about RAJA, users are referred to the
-`RAJA web site <https://software.llnl.gov/RAJA/>`_.
+`RAJA web site <https://software.llnl.gov/RAJA/>`__.
 
 Added the type :c:type:`sunindextype` to support using 32-bit or 64-bit integer
 types for indexing arrays within all SUNDIALS structures. :c:type:`sunindextype`
@@ -2680,11 +2680,11 @@ The file ``include/sundials_fconfig.h`` was added. This file contains SUNDIALS
 type information for use in Fortran programs.
 
 Added support for many xSDK-compliant build system keys. For more information on
-on xSDK compliance the `xSDK policies <https://xsdk.info/policies/>`_. The xSDK
+on xSDK compliance the `xSDK policies <https://xsdk.info/policies/>`__. The xSDK
 is a movement in scientific software to provide a foundation for the rapid and
 efficient production of high-quality, sustainable extreme-scale scientific
 applications. For more information visit the
-`xSDK web site <https://xsdk.info>`_.
+`xSDK web site <https://xsdk.info>`__.
 
 Added functions :c:func:`SUNDIALSGetVersion` and
 :c:func:`SUNDIALSGetVersionNumber` to get SUNDIALS release version information

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -20,12 +20,13 @@ which should ease building SUNDIALS with LAPACK libraries that require setting
 specific linker flags e.g., MKL.
 
 **Bug Fixes**
-Fixed a `bug <https://github.com/LLNL/sundials/issues/581>`_ in 
-:c:func:`SUNMatScaleAddI_Sparse` which caused out of bounds writes unless
-``indexvals`` were in ascending order for each row/column.
 
-Fixed c:func:`ARKodeResize` not using the default ``hscale`` when an argument of
-``0`` was provided.
+Fixed a `bug <https://github.com/LLNL/sundials/issues/581>`__ in the sparse
+matrix implementation of :c:func:`SUNMatScaleAddI` which caused out of bounds
+writes unless ``indexvals`` were in ascending order for each row/column.
+
+Fixed :c:func:`ARKodeResize` not using the default ``hscale`` when an argument
+of ``0`` was provided.
 
 Fixed the loading of ARKStep's default first order explicit method.
 

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -20,6 +20,9 @@ which should ease building SUNDIALS with LAPACK libraries that require setting
 specific linker flags e.g., MKL.
 
 **Bug Fixes**
+Fixed a `bug <https://github.com/LLNL/sundials/issues/581>`_ in 
+:c:func:`SUNMatScaleAddI_Sparse` which caused out of bounds writes unless
+``indexvals`` were in ascending order for each row/column.
 
 Fixed c:func:`ARKodeResize` not using the default ``hscale`` when an argument of
 ``0`` was provided.

--- a/examples/nvector/test_nvector.c
+++ b/examples/nvector/test_nvector.c
@@ -48,7 +48,7 @@
 /* all tests need a SUNContext */
 SUNContext sunctx = NULL;
 
-#if defined(SUNDIALS_HAVE_POSIX_TIMERS) && defined(_POSIX_TIMERS)
+#if defined(SUNDIALS_HAVE_POSIX_TIMERS)
 static time_t base_time_tv_sec = 0; /* Base time; makes time values returned
                                        by get_time easier to read when
                                        printed since they will be zero
@@ -5993,7 +5993,7 @@ int Test_N_VBufUnpack(N_Vector x, sunindextype local_length, int myid)
 
 void SetTiming(int onoff, int myid)
 {
-#if defined(SUNDIALS_HAVE_POSIX_TIMERS) && defined(_POSIX_TIMERS)
+#if defined(SUNDIALS_HAVE_POSIX_TIMERS)
   struct timespec spec;
   clock_gettime(CLOCK_MONOTONIC, &spec);
   base_time_tv_sec = spec.tv_sec;
@@ -6016,7 +6016,7 @@ void SetTiming(int onoff, int myid)
 static double get_time(void)
 {
   double time;
-#if defined(SUNDIALS_HAVE_POSIX_TIMERS) && defined(_POSIX_TIMERS)
+#if defined(SUNDIALS_HAVE_POSIX_TIMERS)
   struct timespec spec;
   clock_gettime(CLOCK_MONOTONIC, &spec);
   time = (double)(spec.tv_sec - base_time_tv_sec) +

--- a/examples/sunlinsol/test_sunlinsol.c
+++ b/examples/sunlinsol/test_sunlinsol.c
@@ -27,7 +27,7 @@
 #include <sundials/sundials_math.h>
 #include <sundials/sundials_types.h>
 
-#if defined(SUNDIALS_HAVE_POSIX_TIMERS) && defined(_POSIX_TIMERS)
+#if defined(SUNDIALS_HAVE_POSIX_TIMERS)
 #include <time.h>
 #include <unistd.h>
 #endif
@@ -519,7 +519,7 @@ int Test_SUNLinSolSolve(SUNLinearSolver S, SUNMatrix A, N_Vector x, N_Vector b,
  * Private functions
  * ====================================================================*/
 
-#if defined(SUNDIALS_HAVE_POSIX_TIMERS) && defined(_POSIX_TIMERS)
+#if defined(SUNDIALS_HAVE_POSIX_TIMERS)
 time_t base_time_tv_sec = 0; /* Base time; makes time values returned
                                 by get_time easier to read when
                                 printed since they will be zero
@@ -531,7 +531,7 @@ void SetTiming(int onoff)
 {
   print_time = onoff;
 
-#if defined(SUNDIALS_HAVE_POSIX_TIMERS) && defined(_POSIX_TIMERS)
+#if defined(SUNDIALS_HAVE_POSIX_TIMERS)
   struct timespec spec;
   clock_gettime(CLOCK_MONOTONIC, &spec);
   base_time_tv_sec = spec.tv_sec;
@@ -543,7 +543,7 @@ void SetTiming(int onoff)
  * --------------------------------------------------------------------*/
 static double get_time(void)
 {
-#if defined(SUNDIALS_HAVE_POSIX_TIMERS) && defined(_POSIX_TIMERS)
+#if defined(SUNDIALS_HAVE_POSIX_TIMERS)
   struct timespec spec;
   clock_gettime(CLOCK_MONOTONIC, &spec);
   double time = (double)(spec.tv_sec - base_time_tv_sec) +

--- a/examples/sunmatrix/test_sunmatrix.c
+++ b/examples/sunmatrix/test_sunmatrix.c
@@ -27,7 +27,7 @@
 #include <sundials/sundials_matrix.h>
 #include <sundials/sundials_types.h>
 
-#if defined(SUNDIALS_HAVE_POSIX_TIMERS) && defined(_POSIX_TIMERS)
+#if defined(SUNDIALS_HAVE_POSIX_TIMERS)
 #include <time.h>
 #include <unistd.h>
 #endif
@@ -611,7 +611,7 @@ int Test_SUNMatSpace(SUNMatrix A, int myid)
  * Private functions
  * ====================================================================*/
 
-#if defined(SUNDIALS_HAVE_POSIX_TIMERS) && defined(_POSIX_TIMERS)
+#if defined(SUNDIALS_HAVE_POSIX_TIMERS)
 time_t base_time_tv_sec = 0; /* Base time; makes time values returned
                                 by get_time easier to read when
                                 printed since they will be zero
@@ -623,7 +623,7 @@ void SetTiming(int onoff)
 {
   print_time = onoff;
 
-#if defined(SUNDIALS_HAVE_POSIX_TIMERS) && defined(_POSIX_TIMERS)
+#if defined(SUNDIALS_HAVE_POSIX_TIMERS)
   struct timespec spec;
   clock_gettime(CLOCK_MONOTONIC, &spec);
   base_time_tv_sec = spec.tv_sec;
@@ -637,7 +637,7 @@ void SetPrintAllRanks(int onoff) { print_all_ranks = onoff; }
  * --------------------------------------------------------------------*/
 static double get_time(void)
 {
-#if defined(SUNDIALS_HAVE_POSIX_TIMERS) && defined(_POSIX_TIMERS)
+#if defined(SUNDIALS_HAVE_POSIX_TIMERS)
   struct timespec spec;
   clock_gettime(CLOCK_MONOTONIC, &spec);
   double time = (double)(spec.tv_sec - base_time_tv_sec) +

--- a/src/sunmatrix/sparse/sunmatrix_sparse.c
+++ b/src/sunmatrix/sparse/sunmatrix_sparse.c
@@ -667,7 +667,7 @@ SUNErrCode SUNMatScaleAddI_Sparse(sunrealtype c, SUNMatrix A)
     Ax = SM_DATA_S(A);
   }
 
-  for (sunindextype j = N - 1; j >= 0 && newvals > 0; j--)
+  for (sunindextype j = N - 1; newvals > 0; j--)
   {
     sunbooleantype found = SUNFALSE;
     for (sunindextype i = Ap[j + 1] - 1; i >= Ap[j]; i--)

--- a/src/sunmatrix/sparse/sunmatrix_sparse.c
+++ b/src/sunmatrix/sparse/sunmatrix_sparse.c
@@ -624,13 +624,14 @@ SUNErrCode SUNMatCopy_Sparse(SUNMatrix A, SUNMatrix B)
 SUNErrCode SUNMatScaleAddI_Sparse(sunrealtype c, SUNMatrix A)
 {
   SUNFunctionBegin(A->sunctx);
-  const sunindextype N = SM_SPARSETYPE_S(A) == CSC_MAT ? SM_COLUMNS_S(A) : SM_ROWS_S(A);
+  const sunindextype N = SM_SPARSETYPE_S(A) == CSC_MAT ? SM_COLUMNS_S(A)
+                                                       : SM_ROWS_S(A);
 
-  sunindextype * Ap = SM_INDEXPTRS_S(A);
+  sunindextype* Ap = SM_INDEXPTRS_S(A);
   SUNAssert(Ap, SUN_ERR_ARG_CORRUPT);
-  sunindextype * Ai = SM_INDEXVALS_S(A);
+  sunindextype* Ai = SM_INDEXVALS_S(A);
   SUNAssert(Ai, SUN_ERR_ARG_CORRUPT);
-  sunrealtype * Ax = SM_DATA_S(A);
+  sunrealtype* Ax = SM_DATA_S(A);
   SUNAssert(Ax, SUN_ERR_ARG_CORRUPT);
 
   sunindextype newvals = 0;
@@ -644,7 +645,8 @@ SUNErrCode SUNMatScaleAddI_Sparse(sunrealtype c, SUNMatrix A)
       {
         found = SUNTRUE;
         Ax[i] = ONE + c * Ax[i];
-      } else { Ax[i] *= c; }
+      }
+      else { Ax[i] *= c; }
     }
     /* if no diagonal found, increment necessary storage counter */
     if (!found) { newvals++; }
@@ -654,21 +656,20 @@ SUNErrCode SUNMatScaleAddI_Sparse(sunrealtype c, SUNMatrix A)
    * diagonal elements that need to be added (of which there are newvals). Now,
    * we allocate additional storage if needed */
   const sunindextype new_nnz = Ap[N] + newvals;
-  if (new_nnz > SM_NNZ_S(A)) {
+  if (new_nnz > SM_NNZ_S(A))
+  {
     SUNCheckCall(SUNSparseMatrix_Reallocate(A, new_nnz));
     Ap = SM_INDEXPTRS_S(A);
     Ai = SM_INDEXVALS_S(A);
     Ax = SM_DATA_S(A);
   }
 
-  for (sunindextype j = N - 1; j >= 0 && newvals > 0; j--) {
+  for (sunindextype j = N - 1; j >= 0 && newvals > 0; j--)
+  {
     sunbooleantype found = SUNFALSE;
     for (sunindextype i = Ap[j + 1] - 1; i >= Ap[j]; i--)
     {
-      if (Ai[i] == j)
-      {
-        found = SUNTRUE;
-      }
+      if (Ai[i] == j) { found = SUNTRUE; }
 
       /* Shift elements to make room for diagonal elements */
       Ai[i + newvals] = Ai[i];
@@ -676,7 +677,8 @@ SUNErrCode SUNMatScaleAddI_Sparse(sunrealtype c, SUNMatrix A)
     }
 
     Ap[j + 1] += newvals;
-    if (!found) {
+    if (!found)
+    {
       /* This column (row) needs a diagonal element added */
       newvals--;
       Ai[Ap[j] + newvals] = j;

--- a/src/sunmatrix/sparse/sunmatrix_sparse.c
+++ b/src/sunmatrix/sparse/sunmatrix_sparse.c
@@ -2,6 +2,7 @@
  * -----------------------------------------------------------------
  * Programmer(s): Daniel Reynolds @ SMU
  *                David Gardner @ LLNL
+ *                Steven B. Roberts @ LLNL
  * Based on code sundials_sparse.c by: Carol Woodward and
  *     Slaven Peles @ LLNL, and Daniel R. Reynolds @ SMU
  * -----------------------------------------------------------------

--- a/src/sunmatrix/sparse/sunmatrix_sparse.c
+++ b/src/sunmatrix/sparse/sunmatrix_sparse.c
@@ -623,234 +623,67 @@ SUNErrCode SUNMatCopy_Sparse(SUNMatrix A, SUNMatrix B)
 
 SUNErrCode SUNMatScaleAddI_Sparse(sunrealtype c, SUNMatrix A)
 {
-  sunindextype j, i, p, nz, newvals, M, N, cend, nw;
-  sunbooleantype newmat, found;
-  sunindextype *w, *Ap, *Ai, *Cp, *Ci;
-  sunrealtype *x, *Ax, *Cx;
-  SUNMatrix C;
   SUNFunctionBegin(A->sunctx);
+  const sunindextype N = SM_SPARSETYPE_S(A) == CSC_MAT ? SM_COLUMNS_S(A) : SM_ROWS_S(A);
 
-  /* store shortcuts to matrix dimensions (M is inner dimension, N is outer) */
-  if (SM_SPARSETYPE_S(A) == CSC_MAT)
-  {
-    M = SM_ROWS_S(A);
-    N = SM_COLUMNS_S(A);
-  }
-  else
-  {
-    M = SM_COLUMNS_S(A);
-    N = SM_ROWS_S(A);
-  }
-
-  /* access data arrays from A */
-  Ap = NULL;
-  Ai = NULL;
-  Ax = NULL;
-  Ap = SM_INDEXPTRS_S(A);
+  sunindextype * Ap = SM_INDEXPTRS_S(A);
   SUNAssert(Ap, SUN_ERR_ARG_CORRUPT);
-  Ai = SM_INDEXVALS_S(A);
+  sunindextype * Ai = SM_INDEXVALS_S(A);
   SUNAssert(Ai, SUN_ERR_ARG_CORRUPT);
-  Ax = SM_DATA_S(A);
+  sunrealtype * Ax = SM_DATA_S(A);
   SUNAssert(Ax, SUN_ERR_ARG_CORRUPT);
 
-  /* determine if A: contains values on the diagonal (so I can just be added
-     in); if not, then increment counter for extra storage that should be
-     required. */
-  newvals = 0;
-  for (j = 0; j < SUNMIN(M, N); j++)
+  sunindextype newvals = 0;
+  for (sunindextype j = 0; j < N; j++)
   {
     /* scan column (row if CSR) of A, searching for diagonal value */
-    found = SUNFALSE;
-    for (i = Ap[j]; i < Ap[j + 1]; i++)
+    sunbooleantype found = SUNFALSE;
+    for (sunindextype i = Ap[j]; i < Ap[j + 1]; i++)
     {
       if (Ai[i] == j)
       {
         found = SUNTRUE;
-        break;
-      }
+        Ax[i] = ONE + c * Ax[i];
+      } else { Ax[i] *= c; }
     }
     /* if no diagonal found, increment necessary storage counter */
-    if (!found) { newvals += 1; }
+    if (!found) { newvals++; }
   }
 
-  /* If extra nonzeros required, check whether matrix has sufficient storage
-     space for new nonzero entries  (so I can be inserted into existing storage)
-   */
-  newmat = SUNFALSE; /* no reallocation needed */
-  if (newvals > (SM_NNZ_S(A) - Ap[N])) { newmat = SUNTRUE; }
+  /* At this point, A has the correctly updated values except for any new
+   * diagonal elements that need to be added (of which there are newvals). Now,
+   * we allocate additional storage if needed */
+  const sunindextype new_nnz = Ap[N] + newvals;
+  if (new_nnz > SM_NNZ_S(A)) {
+    SUNCheckCall(SUNSparseMatrix_Reallocate(A, new_nnz));
+    Ap = SM_INDEXPTRS_S(A);
+    Ai = SM_INDEXVALS_S(A);
+    Ax = SM_DATA_S(A);
+  }
 
-  /* perform operation based on existing/necessary structure */
-
-  /*   case 1: A already contains a diagonal */
-  if (newvals == 0)
-  {
-    /* iterate through columns, adding 1.0 to diagonal */
-    for (j = 0; j < SUNMIN(M, N); j++)
+  for (sunindextype j = N - 1; j >= 0 && newvals > 0; j--) {
+    sunbooleantype found = SUNFALSE;
+    for (sunindextype i = Ap[j + 1] - 1; i >= Ap[j]; i--)
     {
-      for (i = Ap[j]; i < Ap[j + 1]; i++)
+      if (Ai[i] == j)
       {
-        if (Ai[i] == j) { Ax[i] = ONE + c * Ax[i]; }
-        else { Ax[i] = c * Ax[i]; }
+        found = SUNTRUE;
       }
+
+      /* Shift elements to make room for diagonal elements */
+      Ai[i + newvals] = Ai[i];
+      Ax[i + newvals] = Ax[i];
     }
 
-    /*   case 2: A has sufficient storage, but does not already contain a
-     * diagonal */
-  }
-  else if (!newmat)
-  {
-    /* create work arrays for nonzero row (column) indices and values in a
-     * single column (row) */
-    w = (sunindextype*)malloc(M * sizeof(sunindextype));
-    SUNAssert(w, SUN_ERR_MALLOC_FAIL);
-    x = (sunrealtype*)malloc(M * sizeof(sunrealtype));
-    SUNAssert(x, SUN_ERR_MALLOC_FAIL);
-
-    /* determine storage location where last column (row) should end */
-    nz = Ap[N] + newvals;
-
-    /* store pointer past last column (row) from original A,
-       and store updated value in revised A */
-    cend  = Ap[N];
-    Ap[N] = nz;
-
-    /* iterate through columns (rows) backwards */
-    for (j = N - 1; j >= 0; j--)
-    {
-      /* reset diagonal entry, in case it's not in A */
-      x[j] = ZERO;
-
-      /* iterate down column (row) of A, collecting nonzeros */
-      for (p = Ap[j], i = 0; p < cend; p++, i++)
-      {
-        w[i]     = Ai[p];     /* collect row (column) index */
-        x[Ai[p]] = c * Ax[p]; /* collect/scale value */
-      }
-
-      /* NNZ in this column (row) */
-      nw = cend - Ap[j];
-
-      /* add identity to this column (row) */
-      if (j < M) { x[j] += ONE; /* update value */ }
-
-      /* fill entries of A with this column's (row's) data */
-      /* fill entries past diagonal */
-      for (i = nw - 1; i >= 0 && w[i] > j; i--)
-      {
-        Ai[--nz] = w[i];
-        Ax[nz]   = x[w[i]];
-      }
-      /* fill diagonal if applicable */
-      if (i < 0 /* empty or insert at front */ ||
-          w[i] != j /* insert behind front */)
-      {
-        Ai[--nz] = j;
-        Ax[nz]   = x[j];
-      }
-      /* fill entries before diagonal */
-      for (; i >= 0; i--)
-      {
-        Ai[--nz] = w[i];
-        Ax[nz]   = x[w[i]];
-      }
-
-      /* store ptr past this col (row) from orig A, update value for new A */
-      cend  = Ap[j];
-      Ap[j] = nz;
+    Ap[j + 1] += newvals;
+    if (!found) {
+      /* This column (row) needs a diagonal element added */
+      newvals--;
+      Ai[Ap[j] + newvals] = j;
+      Ax[Ap[j] + newvals] = ONE;
     }
-
-    /* clean up */
-    free(w);
-    free(x);
-
-    /*   case 3: A must be reallocated with sufficient storage */
   }
-  else
-  {
-    /* create work array for nonzero values in a single column (row) */
-    x = (sunrealtype*)malloc(M * sizeof(sunrealtype));
 
-    /* create new matrix for sum */
-    C = SUNSparseMatrix(SM_ROWS_S(A), SM_COLUMNS_S(A), Ap[N] + newvals,
-                        SM_SPARSETYPE_S(A), A->sunctx);
-    SUNCheckLastErr();
-
-    /* access data from CSR structures (return if failure) */
-    Cp = NULL;
-    Ci = NULL;
-    Cx = NULL;
-    Cp = SM_INDEXPTRS_S(C);
-    SUNAssert(Cp, SUN_ERR_ARG_CORRUPT);
-    Ci = SM_INDEXVALS_S(C);
-    SUNAssert(Ci, SUN_ERR_ARG_CORRUPT);
-    Cx = SM_DATA_S(C);
-    SUNAssert(Cx, SUN_ERR_ARG_CORRUPT);
-
-    /* initialize total nonzero count */
-    nz = 0;
-
-    /* iterate through columns (rows for CSR) */
-    for (j = 0; j < N; j++)
-    {
-      /* set current column (row) pointer to current # nonzeros */
-      Cp[j] = nz;
-
-      /* reset diagonal entry, in case it's not in A */
-      x[j] = ZERO;
-
-      /* iterate down column (along row) of A, collecting nonzeros */
-      for (p = Ap[j]; p < Ap[j + 1]; p++)
-      {
-        x[Ai[p]] = c * Ax[p]; /* collect/scale value */
-      }
-
-      /* add identity to this column (row) */
-      if (j < M) { x[j] += ONE; /* update value */ }
-
-      /* fill entries of C with this column's (row's) data */
-      /* fill entries before diagonal */
-      for (p = Ap[j]; p < Ap[j + 1] && Ai[p] < j; p++)
-      {
-        Ci[nz]   = Ai[p];
-        Cx[nz++] = x[Ai[p]];
-      }
-      /* fill diagonal if applicable */
-      if (p >= Ap[j + 1] /* empty or insert at end */ ||
-          Ai[p] != j /* insert before end */)
-      {
-        Ci[nz]   = j;
-        Cx[nz++] = x[j];
-      }
-      /* fill entries past diagonal */
-      for (; p < Ap[j + 1]; p++)
-      {
-        Ci[nz]   = Ai[p];
-        Cx[nz++] = x[Ai[p]];
-      }
-    }
-
-    /* indicate end of data */
-    Cp[N] = nz;
-
-    /* update A's structure with C's values; nullify C's pointers */
-    SM_NNZ_S(A) = SM_NNZ_S(C);
-
-    if (SM_DATA_S(A)) { free(SM_DATA_S(A)); }
-    SM_DATA_S(A) = SM_DATA_S(C);
-    SM_DATA_S(C) = NULL;
-
-    if (SM_INDEXVALS_S(A)) { free(SM_INDEXVALS_S(A)); }
-    SM_INDEXVALS_S(A) = SM_INDEXVALS_S(C);
-    SM_INDEXVALS_S(C) = NULL;
-
-    if (SM_INDEXPTRS_S(A)) { free(SM_INDEXPTRS_S(A)); }
-    SM_INDEXPTRS_S(A) = SM_INDEXPTRS_S(C);
-    SM_INDEXPTRS_S(C) = NULL;
-
-    /* clean up */
-    SUNMatDestroy_Sparse(C);
-    free(x);
-  }
   return SUN_SUCCESS;
 }
 

--- a/src/sunmatrix/sparse/sunmatrix_sparse.c
+++ b/src/sunmatrix/sparse/sunmatrix_sparse.c
@@ -626,6 +626,8 @@ SUNErrCode SUNMatScaleAddI_Sparse(sunrealtype c, SUNMatrix A)
   SUNFunctionBegin(A->sunctx);
   const sunindextype N = SM_SPARSETYPE_S(A) == CSC_MAT ? SM_COLUMNS_S(A)
                                                        : SM_ROWS_S(A);
+  const sunindextype M = SM_SPARSETYPE_S(A) == CSC_MAT ? SM_ROWS_S(A)
+                                                       : SM_COLUMNS_S(A);
 
   sunindextype* Ap = SM_INDEXPTRS_S(A);
   SUNAssert(Ap, SUN_ERR_ARG_CORRUPT);
@@ -648,8 +650,9 @@ SUNErrCode SUNMatScaleAddI_Sparse(sunrealtype c, SUNMatrix A)
       }
       else { Ax[i] *= c; }
     }
-    /* if no diagonal found, increment necessary storage counter */
-    if (!found) { newvals++; }
+    /* If no diagonal element found and the current column (row) can actually
+     * contain a diagonal element, increment the storage counter */
+    if (!found && j < M) { newvals++; }
   }
 
   /* At this point, A has the correctly updated values except for any new
@@ -677,7 +680,7 @@ SUNErrCode SUNMatScaleAddI_Sparse(sunrealtype c, SUNMatrix A)
     }
 
     Ap[j + 1] += newvals;
-    if (!found)
+    if (!found && j < M)
     {
       /* This column (row) needs a diagonal element added */
       newvals--;


### PR DESCRIPTION
Fixes https://github.com/LLNL/sundials/issues/581

The new implementation eliminates all temporary storage/mallocs and only traverses the matrix entries once when diagonal elements don't need to be added. The sparse matrix example shows about a 1.5x speedup on 50000x50000 matrices.