### PR TITLE
Fixed erroneous deprecation warnings

### DIFF
--- a/include/arkode/arkode_erkstep.h
+++ b/include/arkode/arkode_erkstep.h
@@ -109,7 +109,7 @@ SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetMaxGrowth instead")
 int ERKStepSetMaxGrowth(void* arkode_mem, sunrealtype mx_growth);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetMinReduction instead")
 int ERKStepSetMinReduction(void* arkode_mem, sunrealtype eta_min);
-SUNDIALS_DEPRECATED_EXPORT_MSG("use ERKStepSetFiARKodeBounds instead")
+SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetFixedStepBounds instead")
 int ERKStepSetFixedStepBounds(void* arkode_mem, sunrealtype lb, sunrealtype ub);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use SUNAdaptController instead")
 int ERKStepSetAdaptivityMethod(void* arkode_mem, int imethod, int idefault,
@@ -128,15 +128,15 @@ SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetMaxErrTestFails instead")
 int ERKStepSetMaxErrTestFails(void* arkode_mem, int maxnef);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetConstraints instead")
 int ERKStepSetConstraints(void* arkode_mem, N_Vector constraints);
-SUNDIALS_DEPRECATED_EXPORT_MSG("use ERKStepSetMaxARKodes instead")
+SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetMaxNumSteps instead")
 int ERKStepSetMaxNumSteps(void* arkode_mem, long int mxsteps);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetMaxHnilWarns instead")
 int ERKStepSetMaxHnilWarns(void* arkode_mem, int mxhnil);
-SUNDIALS_DEPRECATED_EXPORT_MSG("use ERKStepSetIARKode instead")
+SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetInitStep instead")
 int ERKStepSetInitStep(void* arkode_mem, sunrealtype hin);
-SUNDIALS_DEPRECATED_EXPORT_MSG("use ERKStepSetARKode instead")
+SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetMinStep instead")
 int ERKStepSetMinStep(void* arkode_mem, sunrealtype hmin);
-SUNDIALS_DEPRECATED_EXPORT_MSG("use ERKStepSetARKode instead")
+SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetMaxStep instead")
 int ERKStepSetMaxStep(void* arkode_mem, sunrealtype hmax);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetInterpolateStopTime instead")
 int ERKStepSetInterpolateStopTime(void* arkode_mem, sunbooleantype interp);
@@ -144,7 +144,7 @@ SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetStopTime instead")
 int ERKStepSetStopTime(void* arkode_mem, sunrealtype tstop);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeClearStopTime instead")
 int ERKStepClearStopTime(void* arkode_mem);
-SUNDIALS_DEPRECATED_EXPORT_MSG("use ERKStepSetFiARKode instead")
+SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetFixedStep instead")
 int ERKStepSetFixedStep(void* arkode_mem, sunrealtype hfixed);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetMaxNumConstrFails instead")
 int ERKStepSetMaxNumConstrFails(void* arkode_mem, int maxfails);
@@ -154,7 +154,7 @@ SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetNoInactiveRootWarn instead")
 int ERKStepSetNoInactiveRootWarn(void* arkode_mem);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetUserData instead")
 int ERKStepSetUserData(void* arkode_mem, void* user_data);
-SUNDIALS_DEPRECATED_EXPORT_MSG("use ERKStepSetPostprocARKodeFn instead")
+SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetPostprocessStepFn instead")
 int ERKStepSetPostprocessStepFn(void* arkode_mem, ARKPostProcessFn ProcessStep);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetPostprocessStageFn instead")
 int ERKStepSetPostprocessStageFn(void* arkode_mem, ARKPostProcessFn ProcessStage);
@@ -163,11 +163,11 @@ int ERKStepEvolve(void* arkode_mem, sunrealtype tout, N_Vector yout,
                   sunrealtype* tret, int itask);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetDky instead")
 int ERKStepGetDky(void* arkode_mem, sunrealtype t, int k, N_Vector dky);
-SUNDIALS_DEPRECATED_EXPORT_MSG("use ERKStepGetNumARKodes instead")
+SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumExpSteps instead")
 int ERKStepGetNumExpSteps(void* arkode_mem, long int* expsteps);
-SUNDIALS_DEPRECATED_EXPORT_MSG("use ERKStepGetNumARKodes instead")
+SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumAccSteps instead")
 int ERKStepGetNumAccSteps(void* arkode_mem, long int* accsteps);
-SUNDIALS_DEPRECATED_EXPORT_MSG("use ERKStepGetARKodeAttempts instead")
+SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumStepAttempts instead")
 int ERKStepGetNumStepAttempts(void* arkode_mem, long int* step_attempts);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumErrTestFails instead")
 int ERKStepGetNumErrTestFails(void* arkode_mem, long int* netfails);
@@ -175,13 +175,13 @@ SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetEstLocalErrors instead")
 int ERKStepGetEstLocalErrors(void* arkode_mem, N_Vector ele);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetWorkSpace instead")
 int ERKStepGetWorkSpace(void* arkode_mem, long int* lenrw, long int* leniw);
-SUNDIALS_DEPRECATED_EXPORT_MSG("use ERKStepGetARKodes instead")
+SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumSteps instead")
 int ERKStepGetNumSteps(void* arkode_mem, long int* nsteps);
-SUNDIALS_DEPRECATED_EXPORT_MSG("use ERKStepGetActualIARKode instead")
+SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetActualInitStep instead")
 int ERKStepGetActualInitStep(void* arkode_mem, sunrealtype* hinused);
-SUNDIALS_DEPRECATED_EXPORT_MSG("use ERKStepGetLARKode instead")
+SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetLastStep instead")
 int ERKStepGetLastStep(void* arkode_mem, sunrealtype* hlast);
-SUNDIALS_DEPRECATED_EXPORT_MSG("use ERKStepGetCurrARKode instead")
+SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetCurrentStep instead")
 int ERKStepGetCurrentStep(void* arkode_mem, sunrealtype* hcur);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetCurrentTime instead")
 int ERKStepGetCurrentTime(void* arkode_mem, sunrealtype* tcur);
@@ -206,7 +206,7 @@ int ERKStepWriteParameters(void* arkode_mem, FILE* fp);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "use ERKStepGetCurrentButcherTable and ARKodeButcherTable_Write instead")
 int ERKStepWriteButcher(void* arkode_mem, FILE* fp);
-SUNDIALS_DEPRECATED_EXPORT_MSG("use ERKStepARKodeStats instead")
+SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetStepStats instead")
 int ERKStepGetStepStats(void* arkode_mem, long int* nsteps, sunrealtype* hinused,
                         sunrealtype* hlast, sunrealtype* hcur, sunrealtype* tcur);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeFree instead")

--- a/include/arkode/arkode_mristep.h
+++ b/include/arkode/arkode_mristep.h
@@ -223,7 +223,7 @@ SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetLinear instead")
 int MRIStepSetLinear(void* arkode_mem, int timedepend);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetNonlinear instead")
 int MRIStepSetNonlinear(void* arkode_mem);
-SUNDIALS_DEPRECATED_EXPORT_MSG("use MRIStepSetMaxARKodes instead")
+SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetMaxNumSteps instead")
 int MRIStepSetMaxNumSteps(void* arkode_mem, long int mxsteps);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetNonlinCRDown instead")
 int MRIStepSetNonlinCRDown(void* arkode_mem, sunrealtype crdown);
@@ -247,7 +247,7 @@ SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetStopTime instead")
 int MRIStepSetStopTime(void* arkode_mem, sunrealtype tstop);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeClearStopTime instead")
 int MRIStepClearStopTime(void* arkode_mem);
-SUNDIALS_DEPRECATED_EXPORT_MSG("use MRIStepSetFiARKode instead")
+SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetFixedStep instead")
 int MRIStepSetFixedStep(void* arkode_mem, sunrealtype hsfixed);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetRootDirection instead")
 int MRIStepSetRootDirection(void* arkode_mem, int* rootdir);
@@ -255,7 +255,7 @@ SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetNoInactiveRootWarn instead")
 int MRIStepSetNoInactiveRootWarn(void* arkode_mem);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetUserData instead")
 int MRIStepSetUserData(void* arkode_mem, void* user_data);
-SUNDIALS_DEPRECATED_EXPORT_MSG("use MRIStepSetPostprocARKodeFn instead")
+SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetPostprocessStepFn instead")
 int MRIStepSetPostprocessStepFn(void* arkode_mem, ARKPostProcessFn ProcessStep);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetPostprocessStageFn instead")
 int MRIStepSetPostprocessStageFn(void* arkode_mem, ARKPostProcessFn ProcessStage);
@@ -294,9 +294,9 @@ SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumLinSolvSetups instead")
 int MRIStepGetNumLinSolvSetups(void* arkode_mem, long int* nlinsetups);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetWorkSpace instead")
 int MRIStepGetWorkSpace(void* arkode_mem, long int* lenrw, long int* leniw);
-SUNDIALS_DEPRECATED_EXPORT_MSG("use MRIStepGetARKodes instead")
+SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumSteps instead")
 int MRIStepGetNumSteps(void* arkode_mem, long int* nssteps);
-SUNDIALS_DEPRECATED_EXPORT_MSG("use MRIStepGetLARKode instead")
+SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetLastStep instead")
 int MRIStepGetLastStep(void* arkode_mem, sunrealtype* hlast);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetCurrentTime instead")
 int MRIStepGetCurrentTime(void* arkode_mem, sunrealtype* tcur);
@@ -335,13 +335,13 @@ int MRIStepGetNumNonlinSolvConvFails(void* arkode_mem, long int* nnfails);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNonlinSolvStats instead")
 int MRIStepGetNonlinSolvStats(void* arkode_mem, long int* nniters,
                               long int* nnfails);
-SUNDIALS_DEPRECATED_EXPORT_MSG("use MRIStepGetARKodeSolveFails instead")
+SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumStepSolveFails instead")
 int MRIStepGetNumStepSolveFails(void* arkode_mem, long int* nncfails);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetJac instead")
 int MRIStepGetJac(void* arkode_mem, SUNMatrix* J);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetJacTime instead")
 int MRIStepGetJacTime(void* arkode_mem, sunrealtype* t_J);
-SUNDIALS_DEPRECATED_EXPORT_MSG("use MRIStepGetJacARKodes instead")
+SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetJacNumSteps instead")
 int MRIStepGetJacNumSteps(void* arkode_mem, long* nst_J);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetLinWorkSpace instead")
 int MRIStepGetLinWorkSpace(void* arkode_mem, long int* lenrwLS,


### PR DESCRIPTION
When moving the ARKODE user interface to a shared level and adding deprecation warnings to stepper-specific routines, some of the deprecation warnings seemed to have search/replace issues.  This PR fixes those.
