### PR TITLE
CI: Add concurrency in format/swig/spelling checks

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -6,6 +6,10 @@ on:
   issue_comment:
     types: [created]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   format_check:
     if: ${{ github.event_name != 'issue_comment' || (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/autofix')) }}

--- a/.github/workflows/check-spelling.yml
+++ b/.github/workflows/check-spelling.yml
@@ -6,6 +6,10 @@ on:
   issue_comment:
     types: [created]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   spelling_check:
     if: ${{ github.event_name != 'issue_comment' || (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/autofix')) }}

--- a/.github/workflows/check-swig.yml
+++ b/.github/workflows/check-swig.yml
@@ -6,6 +6,10 @@ on:
   issue_comment:
     types: [created]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   swig_check:
     if: ${{ github.event_name != 'issue_comment' || (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/autofix')) }}


### PR DESCRIPTION
Cancel running formatting, swing, and spelling checks on new pushes to prevent redundant failure messages