### PR TITLE
CUDA extended precision

### DIFF
--- a/cmake/SundialsSetupCuda.cmake
+++ b/cmake/SundialsSetupCuda.cmake
@@ -54,6 +54,15 @@ if((CMAKE_CXX_COMPILER_ID MATCHES GNU)
 endif()
 
 # ===============================================================
+# Prohibit CUDA interface when using extended precision.
+# ===============================================================
+
+if(SUNDIALS_PRECISION MATCHES "EXTENDED")
+  message(
+    FATAL_ERROR "CUDA interfaces are incompatible with extended precision.")
+endif()
+
+# ===============================================================
 # Enable CUDA lang and find the CUDA libraries.
 # ===============================================================
 


### PR DESCRIPTION
Updated CMake to prohibit CUDA interfaces when sunrealtype is set to extended precision.  Currently, this configuration just results in build failures later on, so this PR heads this off with a clear error message.

