### PR TITLE
Enable more warning flags which caught a couple small bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@ inner stepper object, `ARKodeCreateMRIStepInnerStepper`.
 
 ### Bug Fixes
 
+Fixed a bug where `CVodeSetProjFailEta` would ignore the `eta` parameter.
+
+Fixed a bug in the SPTFQMR linear solver where recoverable preconditioner errors
+were reported as unrecoverable.
+
 Fixed a [bug](https://github.com/LLNL/sundials/issues/581) in the sparse matrix
 implementation of `SUNMatScaleAddI` which caused out of bounds writes unless
 `indexvals` were in ascending order for each row/column.

--- a/benchmarks/advection_reaction_3D/raja/advection_reaction_3D.cpp
+++ b/benchmarks/advection_reaction_3D/raja/advection_reaction_3D.cpp
@@ -483,7 +483,7 @@ int SetupProblem(int argc, char* argv[], UserData* udata, UserOptions* uopt,
   uopt->fused     = 0;  /* use fused vector ops     */
   uopt->save      = 1;  /* save solution to disk    */
   uopt->nout      = 10; /* number of output times   */
-  uopt->outputdir = (char*)"."; /* output directory         */
+  uopt->outputdir = "."; /* output directory         */
 
   /* Parse CLI args and set udata/uopt appropriately */
   int retval = ParseArgs(argc, argv, udata, uopt);

--- a/benchmarks/advection_reaction_3D/raja/advection_reaction_3D.hpp
+++ b/benchmarks/advection_reaction_3D/raja/advection_reaction_3D.hpp
@@ -57,7 +57,7 @@ struct UserOptions
   int fused;         /* use fused vector ops          */
   int nout;          /* number of outputs             */
   int save;          /* save solution to disk         */
-  char* outputdir;
+  const char* outputdir;
 };
 
 /*

--- a/benchmarks/advection_reaction_3D/raja/arkode_driver.cpp
+++ b/benchmarks/advection_reaction_3D/raja/arkode_driver.cpp
@@ -58,7 +58,6 @@ int EvolveProblemDIRK(N_Vector y, UserData* udata, UserOptions* uopt)
   long int nfe, nfi;          /* RHS stats                    */
   long int nni, ncnf;         /* nonlinear solver stats       */
   long int nli, npsol;        /* linear solver stats          */
-  char fname[MXSTR];
 
   /* Additively split methods should not add the advection and reaction terms */
   udata->add_reactions = true;
@@ -248,7 +247,6 @@ int EvolveProblemIMEX(N_Vector y, UserData* udata, UserOptions* uopt)
   long int nfe, nfi;          /* RHS stats                    */
   long int nni, ncnf;         /* nonlinear solver stats       */
   long int nli, npsol;        /* linear solver stats          */
-  char fname[MXSTR];
 
   /* Additively split methods should not add the advection and reaction terms */
   udata->add_reactions = false;
@@ -449,7 +447,6 @@ int EvolveProblemExplicit(N_Vector y, UserData* udata, UserOptions* uopt)
   int iout;                   /* output counter                */
   long int nst, nst_a, netf;  /* step stats                    */
   long int nfe;               /* RHS stats                     */
-  char fname[MXSTR];
 
   /* Additively split methods should not add the advection and reaction terms */
   udata->add_reactions = true;

--- a/cmake/SundialsSetupCompilers.cmake
+++ b/cmake/SundialsSetupCompilers.cmake
@@ -86,6 +86,8 @@ if(ENABLE_ALL_WARNINGS)
       "-Wno-unknown-warning-option -Wall -Wpedantic -Wextra -Wshadow \
 -Wwrite-strings -Wcast-align -Wdisabled-optimization -Wvla -Walloca \
 -Wduplicated-cond -Wduplicated-branches")
+  # TODO(SBR): Try to add -Wredundant-decls once SuperLU version is updated in
+  # CI tests
 
   # Avoid numerous warnings from printf
   if(SUNDIALS_PRECISION MATCHES "EXTENDED")

--- a/cmake/SundialsSetupCompilers.cmake
+++ b/cmake/SundialsSetupCompilers.cmake
@@ -85,7 +85,7 @@ if(ENABLE_ALL_WARNINGS)
   set(WARNING_FLAGS
       "-Wno-unknown-warning-option -Wall -Wpedantic -Wextra -Wshadow \
 -Wwrite-strings -Wcast-align -Wdisabled-optimization -Wvla -Walloca \
--Wredundant-decls -Wduplicated-cond -Wduplicated-branches")
+-Wduplicated-cond -Wduplicated-branches")
 
   # Avoid numerous warnings from printf
   if(SUNDIALS_PRECISION MATCHES "EXTENDED")

--- a/cmake/SundialsSetupCompilers.cmake
+++ b/cmake/SundialsSetupCompilers.cmake
@@ -85,8 +85,7 @@ if(ENABLE_ALL_WARNINGS)
   set(WARNING_FLAGS
       "-Wno-unknown-warning-option -Wall -Wpedantic -Wextra -Wshadow \
 -Wwrite-strings -Wcast-align -Wdisabled-optimization -Wvla -Walloca \
--Wredundant-decls -Wduplicated-cond -Wduplicated-branches"
-  )
+-Wredundant-decls -Wduplicated-cond -Wduplicated-branches")
 
   # Avoid numerous warnings from printf
   if(SUNDIALS_PRECISION MATCHES "EXTENDED")

--- a/cmake/SundialsSetupCompilers.cmake
+++ b/cmake/SundialsSetupCompilers.cmake
@@ -79,26 +79,32 @@ endif()
 if(ENABLE_ALL_WARNINGS)
   message(STATUS "Enabling all compiler warnings")
 
+  # Some warning flags are not supported by all compilers so ignore unknown
+  # flags with -Wno-unknown-warning-option. Ironically, this is not supported by
+  # some compilers.
+  set(WARNING_FLAGS
+      "-Wno-unknown-warning-option -Wall -Wpedantic -Wextra -Wshadow \
+-Wwrite-strings -Wcast-align -Wdisabled-optimization -Wvla -Walloca \
+-Wredundant-decls -Wduplicated-cond -Wduplicated-branches"
+  )
+
   # Avoid numerous warnings from printf
   if(SUNDIALS_PRECISION MATCHES "EXTENDED")
-    set(CMAKE_C_FLAGS "-Wdouble-promotion ${CMAKE_C_FLAGS}")
-    set(CMAKE_CXX_FLAGS "-Wdouble-promotion ${CMAKE_CXX_FLAGS}")
+    set(WARNING_FLAGS "-Wdouble-promotion ${WARNING_FLAGS}")
   endif()
 
   if((SUNDIALS_PRECISION MATCHES "DOUBLE") AND (SUNDIALS_INDEX_SIZE MATCHES "32"
                                                ))
-    set(CMAKE_C_FLAGS "-Wconversion -Wno-sign-conversion ${CMAKE_C_FLAGS}")
-    set(CMAKE_CXX_FLAGS "-Wconversion -Wno-sign-conversion ${CMAKE_CXX_FLAGS}")
+    set(WARNING_FLAGS "-Wconversion -Wno-sign-conversion ${WARNING_FLAGS}")
   endif()
 
   # Avoid numerous warnings from SWIG generated functions
   if(NOT BUILD_FORTRAN_MODULE_INTERFACE)
-    set(CMAKE_C_FLAGS "-Wmissing-declarations -Wcast-qual ${CMAKE_C_FLAGS}")
-    set(CMAKE_CXX_FLAGS "-Wmissing-declarations -Wcast-qual ${CMAKE_CXX_FLAGS}")
+    set(WARNING_FLAGS "-Wmissing-declarations -Wcast-qual ${WARNING_FLAGS}")
   endif()
 
-  set(CMAKE_C_FLAGS "-Wall -Wpedantic -Wextra -Wshadow ${CMAKE_C_FLAGS}")
-  set(CMAKE_CXX_FLAGS "-Wall -Wpedantic -Wextra -Wshadow ${CMAKE_CXX_FLAGS}")
+  set(CMAKE_C_FLAGS "${WARNING_FLAGS} ${CMAKE_C_FLAGS}")
+  set(CMAKE_CXX_FLAGS "${WARNING_FLAGS} ${CMAKE_CXX_FLAGS}")
 
   # TODO(DJG): Add -fcheck=all,no-pointer,no-recursion once Jenkins is updated
   # to use gfortran > 5.5 which segfaults with -fcheck=array-temps,bounds,do,mem

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -63,6 +63,12 @@ inner stepper object, :c:func:`ARKodeCreateMRIStepInnerStepper`.
 
 **Bug Fixes**
 
+Fixed a bug where :c:func:`CVodeSetProjFailEta` would ignore the `eta`
+parameter.
+
+Fixed a bug in the SPTFQMR linear solver where recoverable preconditioner errors
+were reported as unrecoverable.
+
 Fixed a `bug <https://github.com/LLNL/sundials/issues/581>`__ in the sparse
 matrix implementation of :c:func:`SUNMatScaleAddI` which caused out of bounds
 writes unless ``indexvals`` were in ascending order for each row/column.

--- a/examples/arkode/CXX_parallel/ark_brusselator1D.h
+++ b/examples/arkode/CXX_parallel/ark_brusselator1D.h
@@ -118,7 +118,7 @@ struct UserOptions
   int nout;      /* number of outputs            */
   int monitor;   /* print solution to screen     */
   int printtime; /* print timing information     */
-  char* outputdir;
+  const char* outputdir;
 };
 
 /*

--- a/examples/arkode/CXX_parallel/ark_brusselator1D_task_local_nls.cpp
+++ b/examples/arkode/CXX_parallel/ark_brusselator1D_task_local_nls.cpp
@@ -1416,18 +1416,18 @@ int SetupProblem(int argc, char* argv[], UserData* udata, UserOptions* uopt,
   udata->WFID = NULL;
 
   /* set default integrator options */
-  uopt->order     = 3;          /* method order             */
-  uopt->expl      = 0;          /* imex or explicit         */
-  uopt->t0        = 0.0;        /* initial time             */
-  uopt->tf        = 10.0;       /* final time               */
-  uopt->rtol      = 1.0e-6;     /* relative tolerance       */
-  uopt->atol      = 1.0e-9;     /* absolute tolerance       */
-  uopt->global    = 0;          /* use global NLS           */
-  uopt->fused     = 0;          /* use fused vector ops     */
-  uopt->monitor   = 0;          /* print solution to screen */
-  uopt->printtime = 0;          /* print timing             */
-  uopt->nout      = 40;         /* number of output times   */
-  uopt->outputdir = (char*)"."; /* output directory         */
+  uopt->order     = 3;      /* method order             */
+  uopt->expl      = 0;      /* imex or explicit         */
+  uopt->t0        = 0.0;    /* initial time             */
+  uopt->tf        = 10.0;   /* final time               */
+  uopt->rtol      = 1.0e-6; /* relative tolerance       */
+  uopt->atol      = 1.0e-9; /* absolute tolerance       */
+  uopt->global    = 0;      /* use global NLS           */
+  uopt->fused     = 0;      /* use fused vector ops     */
+  uopt->monitor   = 0;      /* print solution to screen */
+  uopt->printtime = 0;      /* print timing             */
+  uopt->nout      = 40;     /* number of output times   */
+  uopt->outputdir = ".";    /* output directory         */
 
   /* check for input args */
   if (argc > 1)

--- a/examples/arkode/CXX_parallel/ark_brusselator1D_task_local_nls.cpp
+++ b/examples/arkode/CXX_parallel/ark_brusselator1D_task_local_nls.cpp
@@ -1090,7 +1090,6 @@ int TaskLocalNewton_GetNumConvFails(SUNNonlinearSolver NLS, long int* nconvfails
 
 SUNNonlinearSolver TaskLocalNewton(SUNContext ctx, N_Vector y)
 {
-  void* tmp_comm;
   SUNNonlinearSolver NLS;
   TaskLocalNewton_Content content;
 

--- a/examples/arkode/C_parallel/ark_brusselator1D_task_local_nls.c
+++ b/examples/arkode/C_parallel/ark_brusselator1D_task_local_nls.c
@@ -106,7 +106,7 @@ typedef struct
   FILE* UFID;    /* solution output file pointer */
   FILE* VFID;
   FILE* WFID;
-  char* outputdir;
+  const char* outputdir;
 }* UserOptions;
 
 /*

--- a/examples/cvodes/C_openmp/cvsAdvDiff_bnd_omp.c
+++ b/examples/cvodes/C_openmp/cvsAdvDiff_bnd_omp.c
@@ -113,7 +113,7 @@ static void PrintFinalStats(void* cvode_mem);
 
 /* Private function to check function return values */
 
-static int check_retval(void* returnvalue, char* funcname, int opt);
+static int check_retval(void* returnvalue, const char* funcname, int opt);
 
 /* Functions Called by the Solver */
 
@@ -461,7 +461,7 @@ static void PrintFinalStats(void* cvode_mem)
      opt == 2 means function allocates memory so check if returned
               NULL pointer */
 
-static int check_retval(void* returnvalue, char* funcname, int opt)
+static int check_retval(void* returnvalue, const char* funcname, int opt)
 {
   int* retval;
 

--- a/examples/ida/C_openmp/idaFoodWeb_bnd_omp.c
+++ b/examples/ida/C_openmp/idaFoodWeb_bnd_omp.c
@@ -189,7 +189,7 @@ static void Fweb(sunrealtype tcalc, N_Vector cc, N_Vector crate,
 static void WebRates(sunrealtype xx, sunrealtype yy, sunrealtype* cxy,
                      sunrealtype* ratesxy, UserData webdata);
 static sunrealtype dotprod(sunindextype size, sunrealtype* x1, sunrealtype* x2);
-static int check_retval(void* returnvalue, char* funcname, int opt);
+static int check_retval(void* returnvalue, const char* funcname, int opt);
 
 /*
  *--------------------------------------------------------------------
@@ -726,7 +726,7 @@ static sunrealtype dotprod(sunindextype size, sunrealtype* x1, sunrealtype* x2)
  *            NULL pointer
  */
 
-static int check_retval(void* returnvalue, char* funcname, int opt)
+static int check_retval(void* returnvalue, const char* funcname, int opt)
 {
   int* retval;
 

--- a/examples/ida/C_openmp/idaFoodWeb_kry_omp.c
+++ b/examples/ida/C_openmp/idaFoodWeb_kry_omp.c
@@ -204,7 +204,7 @@ static void Fweb(sunrealtype tcalc, N_Vector cc, N_Vector crate,
 static void WebRates(sunrealtype xx, sunrealtype yy, sunrealtype* cxy,
                      sunrealtype* ratesxy, UserData webdata);
 static sunrealtype dotprod(sunindextype size, sunrealtype* x1, sunrealtype* x2);
-static int check_retval(void* returnvalue, char* funcname, int opt);
+static int check_retval(void* returnvalue, const char* funcname, int opt);
 
 /*
  *--------------------------------------------------------------------
@@ -864,7 +864,7 @@ static sunrealtype dotprod(sunindextype size, sunrealtype* x1, sunrealtype* x2)
  *            NULL pointer
  */
 
-static int check_retval(void* returnvalue, char* funcname, int opt)
+static int check_retval(void* returnvalue, const char* funcname, int opt)
 {
   int* retval;
 

--- a/examples/ida/serial/idaFoodWeb_kry.c
+++ b/examples/ida/serial/idaFoodWeb_kry.c
@@ -182,7 +182,7 @@ static void Fweb(sunrealtype tcalc, N_Vector cc, N_Vector crate,
 static void WebRates(sunrealtype xx, sunrealtype yy, sunrealtype* cxy,
                      sunrealtype* ratesxy, UserData webdata);
 static sunrealtype dotprod(sunindextype size, sunrealtype* x1, sunrealtype* x2);
-static int check_retval(void* returnvalue, char* funcname, int opt);
+static int check_retval(void* returnvalue, const char* funcname, int opt);
 
 /*
  *--------------------------------------------------------------------
@@ -823,7 +823,7 @@ static sunrealtype dotprod(sunindextype size, sunrealtype* x1, sunrealtype* x2)
  *            NULL pointer
  */
 
-static int check_retval(void* returnvalue, char* funcname, int opt)
+static int check_retval(void* returnvalue, const char* funcname, int opt)
 {
   int* retval;
 

--- a/examples/idas/C_openmp/idasFoodWeb_bnd_omp.c
+++ b/examples/idas/C_openmp/idasFoodWeb_bnd_omp.c
@@ -189,7 +189,7 @@ static void Fweb(sunrealtype tcalc, N_Vector cc, N_Vector crate,
 static void WebRates(sunrealtype xx, sunrealtype yy, sunrealtype* cxy,
                      sunrealtype* ratesxy, UserData webdata);
 static sunrealtype dotprod(sunindextype size, sunrealtype* x1, sunrealtype* x2);
-static int check_retval(void* returnvalue, char* funcname, int opt);
+static int check_retval(void* returnvalue, const char* funcname, int opt);
 
 /*
  *--------------------------------------------------------------------
@@ -727,7 +727,7 @@ static sunrealtype dotprod(sunindextype size, sunrealtype* x1, sunrealtype* x2)
  *            NULL pointer
  */
 
-static int check_retval(void* returnvalue, char* funcname, int opt)
+static int check_retval(void* returnvalue, const char* funcname, int opt)
 {
   int* retval;
 

--- a/examples/idas/C_openmp/idasFoodWeb_kry_omp.c
+++ b/examples/idas/C_openmp/idasFoodWeb_kry_omp.c
@@ -204,7 +204,7 @@ static void Fweb(sunrealtype tcalc, N_Vector cc, N_Vector crate,
 static void WebRates(sunrealtype xx, sunrealtype yy, sunrealtype* cxy,
                      sunrealtype* ratesxy, UserData webdata);
 static sunrealtype dotprod(sunindextype size, sunrealtype* x1, sunrealtype* x2);
-static int check_retval(void* returnvalue, char* funcname, int opt);
+static int check_retval(void* returnvalue, const char* funcname, int opt);
 
 /*
  *--------------------------------------------------------------------
@@ -862,7 +862,7 @@ static sunrealtype dotprod(sunindextype size, sunrealtype* x1, sunrealtype* x2)
  *            NULL pointer
  */
 
-static int check_retval(void* returnvalue, char* funcname, int opt)
+static int check_retval(void* returnvalue, const char* funcname, int opt)
 {
   int* retval;
 

--- a/examples/idas/serial/idasRoberts_ASAi_klu.c
+++ b/examples/idas/serial/idasRoberts_ASAi_klu.c
@@ -122,7 +122,7 @@ static int rhsQB(sunrealtype tt, N_Vector yy, N_Vector yp, N_Vector yyB,
 /* Prototypes of private functions */
 static void PrintOutput(sunrealtype tfinal, N_Vector yB, N_Vector ypB,
                         N_Vector qB);
-static int check_retval(void* returnvalue, char* funcname, int opt);
+static int check_retval(void* returnvalue, const char* funcname, int opt);
 
 /*
  *--------------------------------------------------------------------
@@ -808,7 +808,7 @@ static void PrintOutput(sunrealtype tfinal, N_Vector yB, N_Vector ypB, N_Vector 
  *             NULL pointer
  */
 
-static int check_retval(void* returnvalue, char* funcname, int opt)
+static int check_retval(void* returnvalue, const char* funcname, int opt)
 {
   int* retval;
 

--- a/examples/idas/serial/idasRoberts_ASAi_sps.c
+++ b/examples/idas/serial/idasRoberts_ASAi_sps.c
@@ -122,7 +122,7 @@ static int rhsQB(sunrealtype tt, N_Vector yy, N_Vector yp, N_Vector yyB,
 /* Prototypes of private functions */
 static void PrintOutput(sunrealtype tfinal, N_Vector yB, N_Vector ypB,
                         N_Vector qB);
-static int check_retval(void* returnvalue, char* funcname, int opt);
+static int check_retval(void* returnvalue, const char* funcname, int opt);
 
 /*
  *--------------------------------------------------------------------
@@ -809,7 +809,7 @@ static void PrintOutput(sunrealtype tfinal, N_Vector yB, N_Vector ypB, N_Vector 
  *             NULL pointer
  */
 
-static int check_retval(void* returnvalue, char* funcname, int opt)
+static int check_retval(void* returnvalue, const char* funcname, int opt)
 {
   int* retval;
 

--- a/examples/idas/serial/idasRoberts_FSA_klu.c
+++ b/examples/idas/serial/idasRoberts_FSA_klu.c
@@ -113,7 +113,7 @@ static void PrintSensOutput(N_Vector* uS);
 
 static void PrintFinalStats(void* ida_mem, sunbooleantype sensi);
 
-static int check_retval(void* returnvalue, char* funcname, int opt);
+static int check_retval(void* returnvalue, const char* funcname, int opt);
 
 /*
  *--------------------------------------------------------------------
@@ -840,7 +840,7 @@ static void PrintFinalStats(void* ida_mem, sunbooleantype sensi)
  *             NULL pointer
  */
 
-static int check_retval(void* returnvalue, char* funcname, int opt)
+static int check_retval(void* returnvalue, const char* funcname, int opt)
 {
   int* retval;
 

--- a/examples/idas/serial/idasRoberts_FSA_sps.c
+++ b/examples/idas/serial/idasRoberts_FSA_sps.c
@@ -113,7 +113,7 @@ static void PrintSensOutput(N_Vector* uS);
 
 static void PrintFinalStats(void* ida_mem, sunbooleantype sensi);
 
-static int check_retval(void* returnvalue, char* funcname, int opt);
+static int check_retval(void* returnvalue, const char* funcname, int opt);
 
 /*
  *--------------------------------------------------------------------
@@ -841,7 +841,7 @@ static void PrintFinalStats(void* ida_mem, sunbooleantype sensi)
  *             NULL pointer
  */
 
-static int check_retval(void* returnvalue, char* funcname, int opt)
+static int check_retval(void* returnvalue, const char* funcname, int opt)
 {
   int* retval;
 

--- a/src/arkode/arkode_arkstep_impl.h
+++ b/src/arkode/arkode_arkstep_impl.h
@@ -272,16 +272,6 @@ int arkStep_NlsLSolve(N_Vector delta, void* arkode_mem);
 int arkStep_NlsConvTest(SUNNonlinearSolver NLS, N_Vector y, N_Vector del,
                         sunrealtype tol, N_Vector ewt, void* arkode_mem);
 
-/* private functions for interfacing with MRIStep */
-int arkStep_SetInnerForcing(ARKodeMem arkode_mem, sunrealtype tshift,
-                            sunrealtype tscale, N_Vector* f, int nvecs);
-int arkStep_MRIStepInnerEvolve(MRIStepInnerStepper stepper, sunrealtype t0,
-                               sunrealtype tout, N_Vector y);
-int arkStep_MRIStepInnerFullRhs(MRIStepInnerStepper stepper, sunrealtype t,
-                                N_Vector y, N_Vector f, int mode);
-int arkStep_MRIStepInnerReset(MRIStepInnerStepper stepper, sunrealtype tR,
-                              N_Vector yR);
-
 /* private functions for relaxation */
 int arkStep_SetRelaxFn(ARKodeMem ark_mem, ARKRelaxFn rfn, ARKRelaxJacFn rjac);
 int arkStep_RelaxDeltaE(ARKodeMem ark_mem, ARKRelaxJacFn relax_jac_fn,

--- a/src/arkode/arkode_ls.c
+++ b/src/arkode/arkode_ls.c
@@ -769,7 +769,7 @@ int ARKodeSetJacEvalFrequency(void* arkode_mem, long int msbj)
   if (retval != ARK_SUCCESS) { return (retval); }
 
   /* store input and return */
-  arkls_mem->msbj = (msbj <= ZERO) ? ARKLS_MSBJ : msbj;
+  arkls_mem->msbj = (msbj <= 0) ? ARKLS_MSBJ : msbj;
 
   return (ARKLS_SUCCESS);
 }

--- a/src/cvode/cvode_proj.c
+++ b/src/cvode/cvode_proj.c
@@ -218,7 +218,7 @@ int CVodeSetProjFailEta(void* cvode_mem, sunrealtype eta)
   else
   {
     /* Update the eta value */
-    proj_mem->eta_pfail = PROJ_FAIL_ETA;
+    proj_mem->eta_pfail = eta;
   }
 
   return (CV_SUCCESS);

--- a/src/cvodes/cvodes_proj.c
+++ b/src/cvodes/cvodes_proj.c
@@ -218,7 +218,7 @@ int CVodeSetProjFailEta(void* cvode_mem, sunrealtype eta)
   else
   {
     /* Update the eta value */
-    proj_mem->eta_pfail = PROJ_FAIL_ETA;
+    proj_mem->eta_pfail = eta;
   }
 
   return (CV_SUCCESS);

--- a/src/ida/ida.c
+++ b/src/ida/ida.c
@@ -2485,7 +2485,7 @@ static int IDAStep(IDAMem IDA_mem)
   saved_t = IDA_mem->ida_tn;
   ncf = nef = 0;
 
-  if (IDA_mem->ida_nst == ZERO)
+  if (IDA_mem->ida_nst == 0)
   {
     IDA_mem->ida_kk     = 1;
     IDA_mem->ida_kused  = 0;

--- a/src/idas/idas.c
+++ b/src/idas/idas.c
@@ -5890,7 +5890,7 @@ static int IDAStep(IDAMem IDA_mem)
   saved_t = IDA_mem->ida_tn;
   ncf = nef = 0;
 
-  if (IDA_mem->ida_nst == ZERO)
+  if (IDA_mem->ida_nst == 0)
   {
     IDA_mem->ida_kk     = 1;
     IDA_mem->ida_kused  = 0;

--- a/src/sundials/sundials_logger.c
+++ b/src/sundials/sundials_logger.c
@@ -38,7 +38,7 @@ void sunCreateLogMessage(SUNLogLevel lvl, int rank, const char* scope,
                          const char* label, const char* txt, va_list args,
                          char** log_msg)
 {
-  char* prefix;
+  const char* prefix;
   char* formatted_txt;
   int msg_length;
 
@@ -53,10 +53,10 @@ void sunCreateLogMessage(SUNLogLevel lvl, int rank, const char* scope,
     fprintf(stderr, "[FATAL LOGGER ERROR] %s\n", "message size too large");
   }
 
-  if (lvl == SUN_LOGLEVEL_DEBUG) { prefix = (char*)"DEBUG"; }
-  else if (lvl == SUN_LOGLEVEL_WARNING) { prefix = (char*)"WARNING"; }
-  else if (lvl == SUN_LOGLEVEL_INFO) { prefix = (char*)"INFO"; }
-  else if (lvl == SUN_LOGLEVEL_ERROR) { prefix = (char*)"ERROR"; }
+  if (lvl == SUN_LOGLEVEL_DEBUG) { prefix = "DEBUG"; }
+  else if (lvl == SUN_LOGLEVEL_WARNING) { prefix = "WARNING"; }
+  else if (lvl == SUN_LOGLEVEL_INFO) { prefix = "INFO"; }
+  else if (lvl == SUN_LOGLEVEL_ERROR) { prefix = "ERROR"; }
 
   msg_length = sunsnprintf(NULL, 0, "[%s][rank %d][%s][%s] %s\n", prefix, rank,
                            scope, label, formatted_txt);

--- a/src/sunlinsol/sptfqmr/sunlinsol_sptfqmr.c
+++ b/src/sunlinsol/sptfqmr/sunlinsol_sptfqmr.c
@@ -702,7 +702,7 @@ int SUNLinSolSolve_SPTFQMR(SUNLinearSolver S, SUNDIALS_MAYBE_UNUSED SUNMatrix A,
           {
             *zeroguess  = SUNFALSE;
             LASTFLAG(S) = (status < 0) ? SUNLS_PSOLVE_FAIL_UNREC
-                                       : SUNLS_PSOLVE_FAIL_UNREC;
+                                       : SUNLS_PSOLVE_FAIL_REC;
             return (LASTFLAG(S));
           }
           N_VScale(ONE, vtemp2, vtemp1);
@@ -905,7 +905,7 @@ int SUNLinSolSolve_SPTFQMR(SUNLinearSolver S, SUNDIALS_MAYBE_UNUSED SUNMatrix A,
       {
         *zeroguess  = SUNFALSE;
         LASTFLAG(S) = (status < 0) ? SUNLS_PSOLVE_FAIL_UNREC
-                                   : SUNLS_PSOLVE_FAIL_UNREC;
+                                   : SUNLS_PSOLVE_FAIL_REC;
         return (LASTFLAG(S));
       }
       N_VScale(ONE, vtemp1, x);

--- a/src/sunmatrix/sparse/sunmatrix_sparse.c
+++ b/src/sunmatrix/sparse/sunmatrix_sparse.c
@@ -390,21 +390,21 @@ void SUNSparseMatrix_Print(SUNMatrix A, FILE* outfile)
 {
   SUNFunctionBegin(A->sunctx);
   sunindextype i, j;
-  char* matrixtype;
-  char* indexname;
+  const char* matrixtype;
+  const char* indexname;
 
   SUNAssertVoid(SUNMatGetID(A) == SUNMATRIX_SPARSE, SUN_ERR_ARG_WRONGTYPE);
 
   /* perform operation */
   if (SM_SPARSETYPE_S(A) == CSC_MAT)
   {
-    indexname  = (char*)"col";
-    matrixtype = (char*)"CSC";
+    indexname  = "col";
+    matrixtype = "CSC";
   }
   else
   {
-    indexname  = (char*)"row";
-    matrixtype = (char*)"CSR";
+    indexname  = "row";
+    matrixtype = "CSR";
   }
   fprintf(outfile, "\n");
   fprintf(outfile, "%ld by %ld %s matrix, NNZ: %ld \n", (long int)SM_ROWS_S(A),


### PR DESCRIPTION
Tested new warning flags on gcc and clang. Not sure if this will work on Windows compilers (if that's something we intend to support)