### PR TITLE
Bugfix: Memory leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,10 @@ not include contributions from the fast right-hand side function. With this fix,
 will see one additional fast right-hand side function evaluation per slow step with the
 Hermite interpolation option.
 
+Fixed potential memory leaks and out of bounds array accesses that could occur
+in the ARKODE Lagrange interpolation module when changing the method order or
+polynomial degree after re-initializing an integrator.
+
 Fixed a CMake configuration issue related to aliasing an `ALIAS` target when
 using `ENABLE_KLU=ON` in combination with a static-only build of SuiteSparse.
 

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -108,6 +108,10 @@ not include contributions from the fast right-hand side function. With this fix,
 will see one additional fast right-hand side function evaluation per slow step with the
 Hermite interpolation option.
 
+Fixed potential memory leaks and out of bounds array accesses that could occur
+in the ARKODE Lagrange interpolation module when changing the method order or
+polynomial degree after re-initializing an integrator.
+
 Fixed a CMake configuration issue related to aliasing an ``ALIAS`` target when
 using ``ENABLE_KLU=ON`` in combination with a static-only build of SuiteSparse.
 

--- a/examples/arkode/F2003_serial/ark_roberts_dns_f2003.f90
+++ b/examples/arkode/F2003_serial/ark_roberts_dns_f2003.f90
@@ -435,6 +435,7 @@ program main
   retval = FSUNLinSolFree(sunlinsol_LS)
   call FSUNMatDestroy(sunmat_A)
   call FN_VDestroy(sunvec_y)
+  call FN_VDestroy(sunvec_f)
   call FN_VDestroy(sunvec_dky)
   call FN_VDestroy(sunvec_av)
   retval = FSUNContext_Free(sunctx)

--- a/src/arkode/arkode_impl.h
+++ b/src/arkode/arkode_impl.h
@@ -659,7 +659,8 @@ int arkCheckTemporalError(ARKodeMem ark_mem, int* nflagPtr, int* nefPtr,
 int arkAccessHAdaptMem(void* arkode_mem, const char* fname, ARKodeMem* ark_mem,
                        ARKodeHAdaptMem* hadapt_mem);
 
-int arkReplaceAdaptController(ARKodeMem ark_mem, SUNAdaptController C);
+int arkReplaceAdaptController(ARKodeMem ark_mem, SUNAdaptController C,
+                              sunbooleantype take_ownership);
 int arkSetAdaptivityMethod(void* arkode_mem, int imethod, int idefault, int pq,
                            sunrealtype adapt_params[3]);
 int arkSetAdaptivityFn(void* arkode_mem, ARKAdaptFn hfun, void* h_data);

--- a/src/arkode/arkode_interp.c
+++ b/src/arkode/arkode_interp.c
@@ -909,7 +909,7 @@ void arkInterpFree_Lagrange(ARKodeMem ark_mem, ARKInterp I)
   {
     if (LINT_YHIST(I) != NULL)
     {
-      for (i = 0; i < LINT_NMAX(I); i++)
+      for (i = 0; i < LINT_NMAXALLOC(I); i++)
       {
         if (LINT_YJ(I, i) != NULL)
         {
@@ -1039,7 +1039,7 @@ int arkInterpInit_Lagrange(ARKodeMem ark_mem, ARKInterp I, sunrealtype tnew)
     }
     if (LINT_YHIST(I) != NULL)
     {
-      for (i = 0; i < LINT_NMAX(I); i++)
+      for (i = 0; i < LINT_NMAXALLOC(I); i++)
       {
         if (LINT_YJ(I, i) != NULL)
         {

--- a/src/arkode/arkode_io.c
+++ b/src/arkode/arkode_io.c
@@ -3239,8 +3239,7 @@ int arkReplaceAdaptController(ARKodeMem ark_mem, SUNAdaptController C,
     }
     ark_mem->hadapt_mem->owncontroller = SUNTRUE;
   }
-  else if (take_ownership) { ark_mem->hadapt_mem->owncontroller = SUNTRUE; }
-  else { ark_mem->hadapt_mem->owncontroller = SUNFALSE; }
+  else { ark_mem->hadapt_mem->owncontroller = take_ownership; }
 
   /* Attach new SUNAdaptController object */
   retval = SUNAdaptController_Space(C, &lenrw, &leniw);

--- a/src/arkode/arkode_io.c
+++ b/src/arkode/arkode_io.c
@@ -915,7 +915,7 @@ int ARKodeSetAdaptController(void* arkode_mem, SUNAdaptController C)
   }
 
   /* Otherwise, call a utility routine to replace the current controller object */
-  return (arkReplaceAdaptController(ark_mem, C));
+  return (arkReplaceAdaptController(ark_mem, C, SUNFALSE));
 }
 
 /*---------------------------------------------------------------
@@ -3197,7 +3197,8 @@ int ARKodeWriteParameters(void* arkode_mem, FILE* fp)
   object. If a NULL-valued SUNAdaptController is input, the
   default will be re-enabled.
   ---------------------------------------------------------------*/
-int arkReplaceAdaptController(ARKodeMem ark_mem, SUNAdaptController C)
+int arkReplaceAdaptController(ARKodeMem ark_mem, SUNAdaptController C,
+                              sunbooleantype take_ownership)
 {
   int retval;
   long int lenrw, leniw;
@@ -3238,6 +3239,7 @@ int arkReplaceAdaptController(ARKodeMem ark_mem, SUNAdaptController C)
     }
     ark_mem->hadapt_mem->owncontroller = SUNTRUE;
   }
+  else if (take_ownership) { ark_mem->hadapt_mem->owncontroller = SUNTRUE; }
   else { ark_mem->hadapt_mem->owncontroller = SUNFALSE; }
 
   /* Attach new SUNAdaptController object */

--- a/src/arkode/arkode_mristep_io.c
+++ b/src/arkode/arkode_mristep_io.c
@@ -266,12 +266,13 @@ int mriStep_SetAdaptController(ARKodeMem ark_mem, SUNAdaptController C)
   /* If this does not have MRI type, then just pass to ARKODE */
   if (ctype != SUN_ADAPTCONTROLLER_MRI_H_TOL)
   {
-    return (arkReplaceAdaptController(ark_mem, C));
+    return (arkReplaceAdaptController(ark_mem, C, SUNFALSE));
   }
 
-  /* Create the mriStepControl wrapper, and pass that to ARKODE */
+  /* Create the mriStepControl wrapper, pass that to ARKODE, and give ownership
+     of the wrapper to ARKODE */
   SUNAdaptController Cwrapper = SUNAdaptController_MRIStep(ark_mem, C);
-  return (arkReplaceAdaptController(ark_mem, Cwrapper));
+  return (arkReplaceAdaptController(ark_mem, Cwrapper, SUNTRUE));
 }
 
 /*---------------------------------------------------------------

--- a/test/unit_tests/arkode/CXX_serial/ark_test_accumerror_brusselator.cpp
+++ b/test/unit_tests/arkode/CXX_serial/ark_test_accumerror_brusselator.cpp
@@ -491,8 +491,7 @@ static int fixed_run(void* arkode_mem, N_Vector y, sunrealtype T0, sunrealtype T
   sunrealtype abstol = SUN_RCONST(1.e-12);
   N_Vector y2        = N_VClone(y);
   N_Vector ewt       = N_VClone(y);
-  ;
-  N_Vector vtemp = N_VClone(y);
+  N_Vector vtemp     = N_VClone(y);
 
   // Set array of fixed step sizes to use, storage for corresponding errors/orders
   sunrealtype hmax = (Tf - T0) / 400;
@@ -657,6 +656,7 @@ static int fixed_run(void* arkode_mem, N_Vector y, sunrealtype T0, sunrealtype T
 
   N_VDestroy(y2);
   N_VDestroy(ewt);
+  N_VDestroy(vtemp);
   return (0);
 }
 

--- a/test/unit_tests/arkode/CXX_serial/ark_test_accumerror_kpr.cpp
+++ b/test/unit_tests/arkode/CXX_serial/ark_test_accumerror_kpr.cpp
@@ -635,6 +635,7 @@ static int fixed_run(void* arkode_mem, N_Vector y, sunrealtype T0,
 
   N_VDestroy(y2);
   N_VDestroy(ewt);
+  N_VDestroy(vtemp);
   return (0);
 }
 

--- a/test/unit_tests/arkode/CXX_serial/ark_test_brusselator_mriadapt.cpp
+++ b/test/unit_tests/arkode/CXX_serial/ark_test_brusselator_mriadapt.cpp
@@ -792,6 +792,7 @@ int main(int argc, char* argv[])
 
   // Clean up and return
   N_VDestroy(y);
+  N_VDestroy(yref);
   MRIStepCoupling_Free(C);
   if (As) { SUNMatDestroy(As); }
   if (LSs) { SUNLinSolFree(LSs); }

--- a/test/unit_tests/arkode/CXX_serial/ark_test_kpr_mriadapt.cpp
+++ b/test/unit_tests/arkode/CXX_serial/ark_test_kpr_mriadapt.cpp
@@ -791,6 +791,7 @@ int main(int argc, char* argv[])
 
   // Clean up and return
   N_VDestroy(y);
+  N_VDestroy(yref);
   MRIStepCoupling_Free(C);
   if (As) { SUNMatDestroy(As); }
   if (LSs) { SUNLinSolFree(LSs); }


### PR DESCRIPTION
* Fix memory leak when attaching an H-Tol controller to MRIStep
* Fix memory leak / out of bound array access in Lagrange interpolation module
* Fix memory leaks in unit tests
