### PR TITLE
Bugfix: Add missing int32 fortran functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,12 @@ not include contributions from the fast right-hand side function. With this fix,
 will see one additional fast right-hand side function evaluation per slow step with the
 Hermite interpolation option.
 
+Fixed a bug in the 32-bit ``sunindextype`` Fortran interfaces to
+``N_VGetSubvectorArrayPointer_ManyVector``,
+``N_VGetSubvectorArrayPointer_MPIManyVector``, ``SUNBandMatrix_Column`` and
+``SUNDenseMatrix_Column`` where 64-bit ``sunindextype`` interface functions were
+used.
+
 Fixed a CMake configuration issue related to aliasing an `ALIAS` target when
 using `ENABLE_KLU=ON` in combination with a static-only build of SuiteSparse.
 

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -108,6 +108,12 @@ not include contributions from the fast right-hand side function. With this fix,
 will see one additional fast right-hand side function evaluation per slow step with the
 Hermite interpolation option.
 
+Fixed a bug in the 32-bit ``sunindextype`` Fortran interfaces to
+:c:func:`N_VGetSubvectorArrayPointer_ManyVector`,
+:c:func:`N_VGetSubvectorArrayPointer_MPIManyVector`,
+:c:func:`SUNBandMatrix_Column` and :c:func:`SUNDenseMatrix_Column` where 64-bit
+``sunindextype`` interface functions were used.
+
 Fixed a CMake configuration issue related to aliasing an ``ALIAS`` target when
 using ``ENABLE_KLU=ON`` in combination with a static-only build of SuiteSparse.
 

--- a/src/nvector/manyvector/fmod_int32/fnvector_manyvector_mod.c
+++ b/src/nvector/manyvector/fmod_int32/fnvector_manyvector_mod.c
@@ -991,6 +991,20 @@ SWIGEXPORT int _wrap_FN_VEnableDotProdMultiLocal_ManyVector(N_Vector farg1, int 
 
 
 
+#ifdef SUNDIALS_INT32_T
+SWIGEXPORT double * _wrap_FN_VGetSubvectorArrayPointer_ManyVector(N_Vector farg1, int32_t const *farg2) {
+  double * fresult ;
+  N_Vector arg1 = (N_Vector) 0 ;
+  sunindextype arg2 ;
+  sunrealtype *result = 0 ;
+
+  arg1 = (N_Vector)(farg1);
+  arg2 = (sunindextype)(*farg2);
+  result = (sunrealtype *)N_VGetSubvectorArrayPointer_ManyVector(arg1,arg2);
+  fresult = result;
+  return fresult;
+}
+#else
 SWIGEXPORT double * _wrap_FN_VGetSubvectorArrayPointer_ManyVector(N_Vector farg1, int64_t const *farg2) {
   double * fresult ;
   N_Vector arg1 = (N_Vector) 0 ;
@@ -1003,5 +1017,6 @@ SWIGEXPORT double * _wrap_FN_VGetSubvectorArrayPointer_ManyVector(N_Vector farg1
   fresult = result;
   return fresult;
 }
+#endif
 
 

--- a/src/nvector/manyvector/fmod_int32/fnvector_mpimanyvector_mod.c
+++ b/src/nvector/manyvector/fmod_int32/fnvector_mpimanyvector_mod.c
@@ -1151,6 +1151,20 @@ SWIGEXPORT int _wrap_FN_VEnableDotProdMultiLocal_MPIManyVector(N_Vector farg1, i
 
 
 
+#ifdef SUNDIALS_INT32_T
+SWIGEXPORT double * _wrap_FN_VGetSubvectorArrayPointer_MPIManyVector(N_Vector farg1, int32_t const *farg2) {
+  double * fresult ;
+  N_Vector arg1 = (N_Vector) 0 ;
+  sunindextype arg2 ;
+  sunrealtype *result = 0 ;
+
+  arg1 = (N_Vector)(farg1);
+  arg2 = (sunindextype)(*farg2);
+  result = (sunrealtype *)N_VGetSubvectorArrayPointer_MPIManyVector(arg1,arg2);
+  fresult = result;
+  return fresult;
+}
+#else
 SWIGEXPORT double * _wrap_FN_VGetSubvectorArrayPointer_MPIManyVector(N_Vector farg1, int64_t const *farg2) {
   double * fresult ;
   N_Vector arg1 = (N_Vector) 0 ;
@@ -1163,5 +1177,6 @@ SWIGEXPORT double * _wrap_FN_VGetSubvectorArrayPointer_MPIManyVector(N_Vector fa
   fresult = result;
   return fresult;
 }
+#endif
 
 

--- a/src/nvector/manyvector/fmod_int64/fnvector_manyvector_mod.c
+++ b/src/nvector/manyvector/fmod_int64/fnvector_manyvector_mod.c
@@ -991,6 +991,20 @@ SWIGEXPORT int _wrap_FN_VEnableDotProdMultiLocal_ManyVector(N_Vector farg1, int 
 
 
 
+#ifdef SUNDIALS_INT32_T
+SWIGEXPORT double * _wrap_FN_VGetSubvectorArrayPointer_ManyVector(N_Vector farg1, int32_t const *farg2) {
+  double * fresult ;
+  N_Vector arg1 = (N_Vector) 0 ;
+  sunindextype arg2 ;
+  sunrealtype *result = 0 ;
+
+  arg1 = (N_Vector)(farg1);
+  arg2 = (sunindextype)(*farg2);
+  result = (sunrealtype *)N_VGetSubvectorArrayPointer_ManyVector(arg1,arg2);
+  fresult = result;
+  return fresult;
+}
+#else
 SWIGEXPORT double * _wrap_FN_VGetSubvectorArrayPointer_ManyVector(N_Vector farg1, int64_t const *farg2) {
   double * fresult ;
   N_Vector arg1 = (N_Vector) 0 ;
@@ -1003,5 +1017,6 @@ SWIGEXPORT double * _wrap_FN_VGetSubvectorArrayPointer_ManyVector(N_Vector farg1
   fresult = result;
   return fresult;
 }
+#endif
 
 

--- a/src/nvector/manyvector/fmod_int64/fnvector_mpimanyvector_mod.c
+++ b/src/nvector/manyvector/fmod_int64/fnvector_mpimanyvector_mod.c
@@ -1151,6 +1151,20 @@ SWIGEXPORT int _wrap_FN_VEnableDotProdMultiLocal_MPIManyVector(N_Vector farg1, i
 
 
 
+#ifdef SUNDIALS_INT32_T
+SWIGEXPORT double * _wrap_FN_VGetSubvectorArrayPointer_MPIManyVector(N_Vector farg1, int32_t const *farg2) {
+  double * fresult ;
+  N_Vector arg1 = (N_Vector) 0 ;
+  sunindextype arg2 ;
+  sunrealtype *result = 0 ;
+
+  arg1 = (N_Vector)(farg1);
+  arg2 = (sunindextype)(*farg2);
+  result = (sunrealtype *)N_VGetSubvectorArrayPointer_MPIManyVector(arg1,arg2);
+  fresult = result;
+  return fresult;
+}
+#else
 SWIGEXPORT double * _wrap_FN_VGetSubvectorArrayPointer_MPIManyVector(N_Vector farg1, int64_t const *farg2) {
   double * fresult ;
   N_Vector arg1 = (N_Vector) 0 ;
@@ -1163,5 +1177,6 @@ SWIGEXPORT double * _wrap_FN_VGetSubvectorArrayPointer_MPIManyVector(N_Vector fa
   fresult = result;
   return fresult;
 }
+#endif
 
 

--- a/src/sunmatrix/band/fmod_int32/fsunmatrix_band_mod.c
+++ b/src/sunmatrix/band/fmod_int32/fsunmatrix_band_mod.c
@@ -484,6 +484,20 @@ SWIGEXPORT double * _wrap_FSUNBandMatrix_Data(SUNMatrix farg1) {
   return fresult;
 }
 
+#ifdef SUNDIALS_INT32_T
+SWIGEXPORT double * _wrap_FSUNBandMatrix_Column(SUNMatrix farg1, int32_t const *farg2) {
+  double * fresult ;
+  SUNMatrix arg1 = (SUNMatrix) 0 ;
+  sunindextype arg2 ;
+  sunrealtype *result = 0 ;
+
+  arg1 = (SUNMatrix)(farg1);
+  arg2 = (sunindextype)(*farg2);
+  result = (sunrealtype *)SUNBandMatrix_Column(arg1,arg2);
+  fresult = result;
+  return fresult;
+}
+#else
 SWIGEXPORT double * _wrap_FSUNBandMatrix_Column(SUNMatrix farg1, int64_t const *farg2) {
   double * fresult ;
   SUNMatrix arg1 = (SUNMatrix) 0 ;
@@ -496,5 +510,6 @@ SWIGEXPORT double * _wrap_FSUNBandMatrix_Column(SUNMatrix farg1, int64_t const *
   fresult = result;
   return fresult;
 }
+#endif
 
 

--- a/src/sunmatrix/band/fmod_int64/fsunmatrix_band_mod.c
+++ b/src/sunmatrix/band/fmod_int64/fsunmatrix_band_mod.c
@@ -484,6 +484,20 @@ SWIGEXPORT double * _wrap_FSUNBandMatrix_Data(SUNMatrix farg1) {
   return fresult;
 }
 
+#ifdef SUNDIALS_INT32_T
+SWIGEXPORT double * _wrap_FSUNBandMatrix_Column(SUNMatrix farg1, int32_t const *farg2) {
+  double * fresult ;
+  SUNMatrix arg1 = (SUNMatrix) 0 ;
+  sunindextype arg2 ;
+  sunrealtype *result = 0 ;
+
+  arg1 = (SUNMatrix)(farg1);
+  arg2 = (sunindextype)(*farg2);
+  result = (sunrealtype *)SUNBandMatrix_Column(arg1,arg2);
+  fresult = result;
+  return fresult;
+}
+#else
 SWIGEXPORT double * _wrap_FSUNBandMatrix_Column(SUNMatrix farg1, int64_t const *farg2) {
   double * fresult ;
   SUNMatrix arg1 = (SUNMatrix) 0 ;
@@ -496,5 +510,6 @@ SWIGEXPORT double * _wrap_FSUNBandMatrix_Column(SUNMatrix farg1, int64_t const *
   fresult = result;
   return fresult;
 }
+#endif
 
 

--- a/src/sunmatrix/dense/fmod_int32/fsunmatrix_dense_mod.c
+++ b/src/sunmatrix/dense/fmod_int32/fsunmatrix_dense_mod.c
@@ -414,6 +414,20 @@ SWIGEXPORT double * _wrap_FSUNDenseMatrix_Data(SUNMatrix farg1) {
   return fresult;
 }
 
+#ifdef SUNDIALS_INT32_T
+SWIGEXPORT double * _wrap_FSUNDenseMatrix_Column(SUNMatrix farg1, int32_t const *farg2) {
+  double * fresult ;
+  SUNMatrix arg1 = (SUNMatrix) 0 ;
+  sunindextype arg2 ;
+  sunrealtype *result = 0 ;
+
+  arg1 = (SUNMatrix)(farg1);
+  arg2 = (sunindextype)(*farg2);
+  result = (sunrealtype *)SUNDenseMatrix_Column(arg1,arg2);
+  fresult = result;
+  return fresult;
+}
+#else
 SWIGEXPORT double * _wrap_FSUNDenseMatrix_Column(SUNMatrix farg1, int64_t const *farg2) {
   double * fresult ;
   SUNMatrix arg1 = (SUNMatrix) 0 ;
@@ -426,5 +440,6 @@ SWIGEXPORT double * _wrap_FSUNDenseMatrix_Column(SUNMatrix farg1, int64_t const 
   fresult = result;
   return fresult;
 }
+#endif
 
 

--- a/src/sunmatrix/dense/fmod_int64/fsunmatrix_dense_mod.c
+++ b/src/sunmatrix/dense/fmod_int64/fsunmatrix_dense_mod.c
@@ -414,6 +414,20 @@ SWIGEXPORT double * _wrap_FSUNDenseMatrix_Data(SUNMatrix farg1) {
   return fresult;
 }
 
+#ifdef SUNDIALS_INT32_T
+SWIGEXPORT double * _wrap_FSUNDenseMatrix_Column(SUNMatrix farg1, int32_t const *farg2) {
+  double * fresult ;
+  SUNMatrix arg1 = (SUNMatrix) 0 ;
+  sunindextype arg2 ;
+  sunrealtype *result = 0 ;
+
+  arg1 = (SUNMatrix)(farg1);
+  arg2 = (sunindextype)(*farg2);
+  result = (sunrealtype *)SUNDenseMatrix_Column(arg1,arg2);
+  fresult = result;
+  return fresult;
+}
+#else
 SWIGEXPORT double * _wrap_FSUNDenseMatrix_Column(SUNMatrix farg1, int64_t const *farg2) {
   double * fresult ;
   SUNMatrix arg1 = (SUNMatrix) 0 ;
@@ -426,5 +440,6 @@ SWIGEXPORT double * _wrap_FSUNDenseMatrix_Column(SUNMatrix farg1, int64_t const 
   fresult = result;
   return fresult;
 }
+#endif
 
 

--- a/swig/nvector/fnvector_manyvector_mod.i
+++ b/swig/nvector/fnvector_manyvector_mod.i
@@ -31,6 +31,20 @@
 %include "nvector/nvector_manyvector.h"
 
 %insert("wrapper") %{
+#ifdef SUNDIALS_INT32_T
+SWIGEXPORT double * _wrap_FN_VGetSubvectorArrayPointer_ManyVector(N_Vector farg1, int32_t const *farg2) {
+  double * fresult ;
+  N_Vector arg1 = (N_Vector) 0 ;
+  sunindextype arg2 ;
+  sunrealtype *result = 0 ;
+
+  arg1 = (N_Vector)(farg1);
+  arg2 = (sunindextype)(*farg2);
+  result = (sunrealtype *)N_VGetSubvectorArrayPointer_ManyVector(arg1,arg2);
+  fresult = result;
+  return fresult;
+}
+#else
 SWIGEXPORT double * _wrap_FN_VGetSubvectorArrayPointer_ManyVector(N_Vector farg1, int64_t const *farg2) {
   double * fresult ;
   N_Vector arg1 = (N_Vector) 0 ;
@@ -43,6 +57,7 @@ SWIGEXPORT double * _wrap_FN_VGetSubvectorArrayPointer_ManyVector(N_Vector farg1
   fresult = result;
   return fresult;
 }
+#endif
 %}
 
 %insert("fdecl") %{

--- a/swig/nvector/fnvector_mpimanyvector_mod.i
+++ b/swig/nvector/fnvector_mpimanyvector_mod.i
@@ -31,6 +31,20 @@
 %include "nvector/nvector_mpimanyvector.h"
 
 %insert("wrapper") %{
+#ifdef SUNDIALS_INT32_T
+SWIGEXPORT double * _wrap_FN_VGetSubvectorArrayPointer_MPIManyVector(N_Vector farg1, int32_t const *farg2) {
+  double * fresult ;
+  N_Vector arg1 = (N_Vector) 0 ;
+  sunindextype arg2 ;
+  sunrealtype *result = 0 ;
+
+  arg1 = (N_Vector)(farg1);
+  arg2 = (sunindextype)(*farg2);
+  result = (sunrealtype *)N_VGetSubvectorArrayPointer_MPIManyVector(arg1,arg2);
+  fresult = result;
+  return fresult;
+}
+#else
 SWIGEXPORT double * _wrap_FN_VGetSubvectorArrayPointer_MPIManyVector(N_Vector farg1, int64_t const *farg2) {
   double * fresult ;
   N_Vector arg1 = (N_Vector) 0 ;
@@ -43,6 +57,7 @@ SWIGEXPORT double * _wrap_FN_VGetSubvectorArrayPointer_MPIManyVector(N_Vector fa
   fresult = result;
   return fresult;
 }
+#endif
 %}
 
 %insert("fdecl") %{

--- a/swig/sunmatrix/fsunmatrix_band_mod.i
+++ b/swig/sunmatrix/fsunmatrix_band_mod.i
@@ -45,6 +45,20 @@ SWIGEXPORT double * _wrap_FSUNBandMatrix_Data(SUNMatrix farg1) {
   return fresult;
 }
 
+#ifdef SUNDIALS_INT32_T
+SWIGEXPORT double * _wrap_FSUNBandMatrix_Column(SUNMatrix farg1, int32_t const *farg2) {
+  double * fresult ;
+  SUNMatrix arg1 = (SUNMatrix) 0 ;
+  sunindextype arg2 ;
+  sunrealtype *result = 0 ;
+
+  arg1 = (SUNMatrix)(farg1);
+  arg2 = (sunindextype)(*farg2);
+  result = (sunrealtype *)SUNBandMatrix_Column(arg1,arg2);
+  fresult = result;
+  return fresult;
+}
+#else
 SWIGEXPORT double * _wrap_FSUNBandMatrix_Column(SUNMatrix farg1, int64_t const *farg2) {
   double * fresult ;
   SUNMatrix arg1 = (SUNMatrix) 0 ;
@@ -57,6 +71,7 @@ SWIGEXPORT double * _wrap_FSUNBandMatrix_Column(SUNMatrix farg1, int64_t const *
   fresult = result;
   return fresult;
 }
+#endif
 %}
 
 %insert("fdecl") %{

--- a/swig/sunmatrix/fsunmatrix_dense_mod.i
+++ b/swig/sunmatrix/fsunmatrix_dense_mod.i
@@ -45,6 +45,20 @@ SWIGEXPORT double * _wrap_FSUNDenseMatrix_Data(SUNMatrix farg1) {
   return fresult;
 }
 
+#ifdef SUNDIALS_INT32_T
+SWIGEXPORT double * _wrap_FSUNDenseMatrix_Column(SUNMatrix farg1, int32_t const *farg2) {
+  double * fresult ;
+  SUNMatrix arg1 = (SUNMatrix) 0 ;
+  sunindextype arg2 ;
+  sunrealtype *result = 0 ;
+
+  arg1 = (SUNMatrix)(farg1);
+  arg2 = (sunindextype)(*farg2);
+  result = (sunrealtype *)SUNDenseMatrix_Column(arg1,arg2);
+  fresult = result;
+  return fresult;
+}
+#else
 SWIGEXPORT double * _wrap_FSUNDenseMatrix_Column(SUNMatrix farg1, int64_t const *farg2) {
   double * fresult ;
   SUNMatrix arg1 = (SUNMatrix) 0 ;
@@ -57,6 +71,7 @@ SWIGEXPORT double * _wrap_FSUNDenseMatrix_Column(SUNMatrix farg1, int64_t const 
   fresult = result;
   return fresult;
 }
+#endif
 %}
 
 %insert("fdecl") %{


### PR DESCRIPTION
Add missing 32-bit ``sunindextype`` Fortran interface functions for

* ``N_VGetSubvectorArrayPointer_ManyVector``
* ``N_VGetSubvectorArrayPointer_MPIManyVector``
* ``SUNBandMatrix_Column``
* ``SUNDenseMatrix_Column``