### PR TITLE
Bugfix: Rootfinding with Fixed Step Size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,11 @@ provided.
 
 Fixed the loading of ARKStep's default first order explicit method.
 
+Fixed a bug in ARKODE when enabling rootfinding with fixed step sizes and the
+initial value of the rootfinding function is zero. In this case, uninitialized
+right-hand side data was used to compute a state value near the initial
+condition to determine if any rootfinding functions are initially active.
+
 Fixed a CMake bug regarding usage of missing "print_warning" macro
 that was only triggered when the deprecated `CUDA_ARCH` option was used.
 

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -90,6 +90,11 @@ of ``0`` was provided.
 
 Fixed the loading of ARKStep's default first order explicit method.
 
+Fixed a bug in ARKODE when enabling rootfinding with fixed step sizes and the
+initial value of the rootfinding function is zero. In this case, uninitialized
+right-hand side data was used to compute a state value near the initial
+condition to determine if any rootfinding functions are initially active.
+
 Fixed a CMake bug regarding usage of missing "print_warning" macro
 that was only triggered when the deprecated ``CUDA_ARCH`` option was used.
 

--- a/examples/arkode/C_serial/ark_kepler_--stepper_SPRK_--step-mode_fixed_--count-orbits_--use-compensated-sums.out
+++ b/examples/arkode/C_serial/ark_kepler_--stepper_SPRK_--step-mode_fixed_--count-orbits_--use-compensated-sums.out
@@ -135,5 +135,5 @@ Initial step size            = 0.01
 Last step size               = 0.01
 Current step size            = 0.01
 Root fn evals                = 10280
-f1 RHS fn evals              = 40031
-f2 RHS fn evals              = 40031
+f1 RHS fn evals              = 40032
+f2 RHS fn evals              = 40032

--- a/src/arkode/arkode.c
+++ b/src/arkode/arkode.c
@@ -2138,13 +2138,7 @@ int arkInitialSetup(ARKodeMem ark_mem, sunrealtype tout)
     if (ark_mem->root_mem->nrtfn > 0)
     {
       retval = arkRootCheck1((void*)ark_mem);
-
-      if (retval == ARK_RTFUNC_FAIL)
-      {
-        arkProcessError(ark_mem, ARK_RTFUNC_FAIL, __LINE__, __func__, __FILE__,
-                        MSG_ARK_RTFUNC_FAILED, ark_mem->tcur);
-        return (ARK_RTFUNC_FAIL);
-      }
+      if (retval != ARK_SUCCESS) { return retval; }
     }
   }
 

--- a/src/arkode/arkode_root.c
+++ b/src/arkode/arkode_root.c
@@ -459,8 +459,8 @@ int arkRootCheck1(void* arkode_mem)
                                    ark_mem->fn, ARK_FULLRHS_START);
     if (retval)
     {
-      arkProcessError(ark_mem, ARK_RHSFUNC_FAIL, __LINE__, __func__,
-                      __FILE__, MSG_ARK_RHSFUNC_FAILED, ark_mem->tcur);
+      arkProcessError(ark_mem, ARK_RHSFUNC_FAIL, __LINE__, __func__, __FILE__,
+                      MSG_ARK_RHSFUNC_FAILED, ark_mem->tcur);
       return ARK_RHSFUNC_FAIL;
     }
     ark_mem->fn_is_current = SUNTRUE;


### PR DESCRIPTION
Fix a bug when enabling rootfinding with fixed step sizes and the initial value of the rootfinding function is zero. In this case, uninitialized right-hand side data (`fn`) is used to compute a forward Euler step to get a state near the initial condition to determine if any rootfinding functions are active at the initial condition.