### PR TITLE
Bugfix: Initialize yerr to zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,9 @@ not include contributions from the fast right-hand side function. With this fix,
 will see one additional fast right-hand side function evaluation per slow step with the
 Hermite interpolation option.
 
+Fixed a bug in SPRKStep when using compensated summations where the error vector
+was not initialized to zero.
+
 Fixed a CMake configuration issue related to aliasing an `ALIAS` target when
 using `ENABLE_KLU=ON` in combination with a static-only build of SuiteSparse.
 

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -108,6 +108,9 @@ not include contributions from the fast right-hand side function. With this fix,
 will see one additional fast right-hand side function evaluation per slow step with the
 Hermite interpolation option.
 
+Fixed a bug in SPRKStep when using compensated summations where the error vector
+was not initialized to zero.
+
 Fixed a CMake configuration issue related to aliasing an ``ALIAS`` target when
 using ``ENABLE_KLU=ON`` in combination with a static-only build of SuiteSparse.
 

--- a/src/arkode/arkode_sprkstep.c
+++ b/src/arkode/arkode_sprkstep.c
@@ -114,6 +114,8 @@ void* SPRKStepCreate(ARKRhsFn f1, ARKRhsFn f2, sunrealtype t0, N_Vector y0,
       ARKodeFree((void**)&ark_mem);
       return (NULL);
     }
+    /* Zero yerr for compensated summation */
+    N_VConst(ZERO, step_mem->yerr);
   }
   else { step_mem->yerr = NULL; }
   ark_mem->step_init            = sprkStep_Init;
@@ -146,9 +148,6 @@ void* SPRKStepCreate(ARKRhsFn f1, ARKRhsFn f2, sunrealtype t0, N_Vector y0,
   step_mem->nf1    = 0;
   step_mem->nf2    = 0;
   step_mem->istage = 0;
-
-  /* Zero yerr for compensated summation */
-  if (ark_mem->use_compensated_sums) { N_VConst(ZERO, step_mem->yerr); }
 
   /* SPRKStep uses Lagrange interpolation by default, since Hermite is
      less compatible with these methods. */
@@ -286,6 +285,8 @@ int sprkStep_Resize(ARKodeMem ark_mem, N_Vector y0,
                       "Unable to resize vector");
       return (ARK_MEM_FAIL);
     }
+    /* Zero yerr for compensated summation */
+    N_VConst(ZERO, step_mem->yerr);
   }
 
   return (ARK_SUCCESS);
@@ -430,6 +431,9 @@ int sprkStep_Init(ARKodeMem ark_mem, SUNDIALS_MAYBE_UNUSED sunrealtype tout,
        solution values are returned at the time interval end points */
     ark_mem->interp_degree = 1;
   }
+
+  /* Zero yerr for compensated summation */
+  if (ark_mem->use_compensated_sums) { N_VConst(ZERO, step_mem->yerr); }
 
   return (ARK_SUCCESS);
 }

--- a/src/arkode/arkode_sprkstep_io.c
+++ b/src/arkode/arkode_sprkstep_io.c
@@ -58,6 +58,8 @@ int SPRKStepSetUseCompensatedSums(void* arkode_mem, sunbooleantype onoff)
       {
         return ARK_MEM_FAIL;
       }
+      /* Zero yerr for compensated summation */
+      N_VConst(ZERO, step_mem->yerr);
     }
   }
   else


### PR DESCRIPTION
Fix a bug in SPRKStep where `yerr` was not initialized to zero when using compensated summations