### PR TITLE
Maintenance: Rename set function

### DIFF
--- a/doc/arkode/guide/source/Usage/LSRKStep/User_callable.rst
+++ b/doc/arkode/guide/source/Usage/LSRKStep/User_callable.rst
@@ -245,7 +245,7 @@ Allowable Method Families
    set to :math:`1.01`. Calling this function with ``dom_eig_safety < 1`` resets the default value.
 
 
-.. c:function:: int LSRKStepSetSSPStageNum(void* arkode_mem, int num_of_stages);
+.. c:function:: int LSRKStepSetNumSSPStages(void* arkode_mem, int num_of_stages);
 
    Sets the number of stages, ``s`` in ``SSP(s, p)`` methods. This input is only utilized by SSPRK methods.
 
@@ -262,7 +262,7 @@ Allowable Method Families
       * *ARKLS_MEM_NULL* if ``arkode_mem`` was ``NULL``.
       * *ARK_ILL_INPUT* if an argument had an illegal value (e.g. SSP method is not declared)
 
-.. note:: If LSRKStepSetSSPStageNum routine is not called, then the default ``num_of_stages`` is
+.. note:: If LSRKStepSetNumSSPStages routine is not called, then the default ``num_of_stages`` is
    set. Calling this function with ``num_of_stages <= 0`` resets the default values:
 
    * ``num_of_stages = 10`` for :c:enumerator:`ARKODE_LSRK_SSP_S_2`

--- a/examples/arkode/CXX_manyvector/ark_sod_lsrk.cpp
+++ b/examples/arkode/CXX_manyvector/ark_sod_lsrk.cpp
@@ -112,8 +112,8 @@ int main(int argc, char* argv[])
     // Select number of SSPRK stages
     if (uopts.stages > 0)
     {
-      flag = LSRKStepSetSSPStageNum(arkode_mem, uopts.stages);
-      if (check_flag(flag, "LSRKStepSetSSPStageNum")) { return 1; }
+      flag = LSRKStepSetNumSSPStages(arkode_mem, uopts.stages);
+      if (check_flag(flag, "LSRKStepSetNumSSPStages")) { return 1; }
     }
   }
   else

--- a/examples/arkode/C_serial/ark_analytic_ssprk.c
+++ b/examples/arkode/C_serial/ark_analytic_ssprk.c
@@ -133,8 +133,8 @@ int main(void)
   if (check_flag(&flag, "LSRKStepSetSSPMethod", 1)) { return 1; }
 
   /* Specify the SSP number of stages */
-  flag = LSRKStepSetSSPStageNum(arkode_mem, 9);
-  if (check_flag(&flag, "LSRKStepSetSSPStageNum", 1)) { return 1; }
+  flag = LSRKStepSetNumSSPStages(arkode_mem, 9);
+  if (check_flag(&flag, "LSRKStepSetNumSSPStages", 1)) { return 1; }
 
   /* Open output stream for results, output comment line */
   UFID = fopen("solution.txt", "w");

--- a/include/arkode/arkode_lsrkstep.h
+++ b/include/arkode/arkode_lsrkstep.h
@@ -83,7 +83,7 @@ SUNDIALS_EXPORT int LSRKStepSetMaxNumStages(void* arkode_mem,
 SUNDIALS_EXPORT int LSRKStepSetDomEigSafetyFactor(void* arkode_mem,
                                                   sunrealtype dom_eig_safety);
 
-SUNDIALS_EXPORT int LSRKStepSetSSPStageNum(void* arkode_mem, int num_of_stages);
+SUNDIALS_EXPORT int LSRKStepSetNumSSPStages(void* arkode_mem, int num_of_stages);
 
 /* Optional output functions */
 

--- a/src/arkode/arkode_lsrkstep_io.c
+++ b/src/arkode/arkode_lsrkstep_io.c
@@ -320,7 +320,7 @@ int LSRKStepSetDomEigSafetyFactor(void* arkode_mem, sunrealtype dom_eig_safety)
 }
 
 /*---------------------------------------------------------------
-  LSRKStepSetSSPStageNum sets the number of stages in the following
+  LSRKStepSetNumSSPStages sets the number of stages in the following
   SSP methods:
 
       ARKODE_LSRK_SSP_S_2  -- num_of_stages must be greater than or equal to 2
@@ -332,7 +332,7 @@ int LSRKStepSetDomEigSafetyFactor(void* arkode_mem, sunrealtype dom_eig_safety)
 
    Calling this function with num_of_stages =< 0 resets the default value.
   ---------------------------------------------------------------*/
-int LSRKStepSetSSPStageNum(void* arkode_mem, int num_of_stages)
+int LSRKStepSetNumSSPStages(void* arkode_mem, int num_of_stages)
 {
   ARKodeMem ark_mem;
   ARKodeLSRKStepMem step_mem;

--- a/src/arkode/fmod_int32/farkode_lsrkstep_mod.c
+++ b/src/arkode/fmod_int32/farkode_lsrkstep_mod.c
@@ -414,7 +414,7 @@ SWIGEXPORT int _wrap_FLSRKStepSetDomEigSafetyFactor(void *farg1, double const *f
 }
 
 
-SWIGEXPORT int _wrap_FLSRKStepSetSSPStageNum(void *farg1, int const *farg2) {
+SWIGEXPORT int _wrap_FLSRKStepSetNumSSPStages(void *farg1, int const *farg2) {
   int fresult ;
   void *arg1 = (void *) 0 ;
   int arg2 ;
@@ -422,7 +422,7 @@ SWIGEXPORT int _wrap_FLSRKStepSetSSPStageNum(void *farg1, int const *farg2) {
   
   arg1 = (void *)(farg1);
   arg2 = (int)(*farg2);
-  result = (int)LSRKStepSetSSPStageNum(arg1,arg2);
+  result = (int)LSRKStepSetNumSSPStages(arg1,arg2);
   fresult = (int)(result);
   return fresult;
 }

--- a/src/arkode/fmod_int32/farkode_lsrkstep_mod.f90
+++ b/src/arkode/fmod_int32/farkode_lsrkstep_mod.f90
@@ -52,7 +52,7 @@ module farkode_lsrkstep_mod
  public :: FLSRKStepSetDomEigFrequency
  public :: FLSRKStepSetMaxNumStages
  public :: FLSRKStepSetDomEigSafetyFactor
- public :: FLSRKStepSetSSPStageNum
+ public :: FLSRKStepSetNumSSPStages
  public :: FLSRKStepGetNumDomEigUpdates
  public :: FLSRKStepGetMaxNumStages
 
@@ -176,8 +176,8 @@ real(C_DOUBLE), intent(in) :: farg2
 integer(C_INT) :: fresult
 end function
 
-function swigc_FLSRKStepSetSSPStageNum(farg1, farg2) &
-bind(C, name="_wrap_FLSRKStepSetSSPStageNum") &
+function swigc_FLSRKStepSetNumSSPStages(farg1, farg2) &
+bind(C, name="_wrap_FLSRKStepSetNumSSPStages") &
 result(fresult)
 use, intrinsic :: ISO_C_BINDING
 type(C_PTR), value :: farg1
@@ -444,7 +444,7 @@ fresult = swigc_FLSRKStepSetDomEigSafetyFactor(farg1, farg2)
 swig_result = fresult
 end function
 
-function FLSRKStepSetSSPStageNum(arkode_mem, num_of_stages) &
+function FLSRKStepSetNumSSPStages(arkode_mem, num_of_stages) &
 result(swig_result)
 use, intrinsic :: ISO_C_BINDING
 integer(C_INT) :: swig_result
@@ -456,7 +456,7 @@ integer(C_INT) :: farg2
 
 farg1 = arkode_mem
 farg2 = num_of_stages
-fresult = swigc_FLSRKStepSetSSPStageNum(farg1, farg2)
+fresult = swigc_FLSRKStepSetNumSSPStages(farg1, farg2)
 swig_result = fresult
 end function
 

--- a/src/arkode/fmod_int64/farkode_lsrkstep_mod.c
+++ b/src/arkode/fmod_int64/farkode_lsrkstep_mod.c
@@ -414,7 +414,7 @@ SWIGEXPORT int _wrap_FLSRKStepSetDomEigSafetyFactor(void *farg1, double const *f
 }
 
 
-SWIGEXPORT int _wrap_FLSRKStepSetSSPStageNum(void *farg1, int const *farg2) {
+SWIGEXPORT int _wrap_FLSRKStepSetNumSSPStages(void *farg1, int const *farg2) {
   int fresult ;
   void *arg1 = (void *) 0 ;
   int arg2 ;
@@ -422,7 +422,7 @@ SWIGEXPORT int _wrap_FLSRKStepSetSSPStageNum(void *farg1, int const *farg2) {
   
   arg1 = (void *)(farg1);
   arg2 = (int)(*farg2);
-  result = (int)LSRKStepSetSSPStageNum(arg1,arg2);
+  result = (int)LSRKStepSetNumSSPStages(arg1,arg2);
   fresult = (int)(result);
   return fresult;
 }

--- a/src/arkode/fmod_int64/farkode_lsrkstep_mod.f90
+++ b/src/arkode/fmod_int64/farkode_lsrkstep_mod.f90
@@ -52,7 +52,7 @@ module farkode_lsrkstep_mod
  public :: FLSRKStepSetDomEigFrequency
  public :: FLSRKStepSetMaxNumStages
  public :: FLSRKStepSetDomEigSafetyFactor
- public :: FLSRKStepSetSSPStageNum
+ public :: FLSRKStepSetNumSSPStages
  public :: FLSRKStepGetNumDomEigUpdates
  public :: FLSRKStepGetMaxNumStages
 
@@ -176,8 +176,8 @@ real(C_DOUBLE), intent(in) :: farg2
 integer(C_INT) :: fresult
 end function
 
-function swigc_FLSRKStepSetSSPStageNum(farg1, farg2) &
-bind(C, name="_wrap_FLSRKStepSetSSPStageNum") &
+function swigc_FLSRKStepSetNumSSPStages(farg1, farg2) &
+bind(C, name="_wrap_FLSRKStepSetNumSSPStages") &
 result(fresult)
 use, intrinsic :: ISO_C_BINDING
 type(C_PTR), value :: farg1
@@ -444,7 +444,7 @@ fresult = swigc_FLSRKStepSetDomEigSafetyFactor(farg1, farg2)
 swig_result = fresult
 end function
 
-function FLSRKStepSetSSPStageNum(arkode_mem, num_of_stages) &
+function FLSRKStepSetNumSSPStages(arkode_mem, num_of_stages) &
 result(swig_result)
 use, intrinsic :: ISO_C_BINDING
 integer(C_INT) :: swig_result
@@ -456,7 +456,7 @@ integer(C_INT) :: farg2
 
 farg1 = arkode_mem
 farg2 = num_of_stages
-fresult = swigc_FLSRKStepSetSSPStageNum(farg1, farg2)
+fresult = swigc_FLSRKStepSetNumSSPStages(farg1, farg2)
 swig_result = fresult
 end function
 


### PR DESCRIPTION
Update set function name to be consistent with `SetNum` naming convention 

