### PR TITLE
Bugfix: RHS eval logic with certain IMEX methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 Fixed a bug in ARKStep where an extra right-hand side evaluation would occur
 each time step when enabling the ``ARKodeSetAutonomous`` option and using an
-IMEX method where the DIRK table has an implicit first and is not stiffly
+IMEX method where the DIRK table has an implicit first stage and is not stiffly
 accurate.
 
 ### Deprecation Notices

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 ### Bug Fixes
 
 Fixed a bug in ARKStep where an extra right-hand side evaluation would occur
-each time step when enabling the :c:func:`ARKodeSetAutonomous` option and using
-an IMEX method where the DIRK table has an implicit first and is not stiffly
+each time step when enabling the ``ARKodeSetAutonomous`` option and using an
+IMEX method where the DIRK table has an implicit first and is not stiffly
 accurate.
 
 ### Deprecation Notices

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 ### Bug Fixes
 
+Fixed a bug in ARKStep where an extra right-hand side evaluation would occur
+each time step when enabling the :c:func:`ARKodeSetAutonomous` option and using
+an IMEX method where the DIRK table has an implicit first and is not stiffly
+accurate.
+
 ### Deprecation Notices
 
 ## Changes to SUNDIALS in release 7.2.0

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -4,4 +4,9 @@
 
 **Bug Fixes**
 
+Fixed a bug in ARKStep where an extra right-hand side evaluation would occur
+each time step when enabling the ``ARKodeSetAutonomous`` option and using an
+IMEX method where the DIRK table has an implicit first and is not stiffly
+accurate.
+
 **Deprecation Notices**

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -6,7 +6,7 @@
 
 Fixed a bug in ARKStep where an extra right-hand side evaluation would occur
 each time step when enabling the :c:func:`ARKodeSetAutonomous` option and using
-an IMEX method where the DIRK table has an implicit first and is not stiffly
+an IMEX method where the DIRK table has an implicit first stage and is not stiffly
 accurate.
 
 **Deprecation Notices**

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -5,8 +5,8 @@
 **Bug Fixes**
 
 Fixed a bug in ARKStep where an extra right-hand side evaluation would occur
-each time step when enabling the ``ARKodeSetAutonomous`` option and using an
-IMEX method where the DIRK table has an implicit first and is not stiffly
+each time step when enabling the :c:func:`ARKodeSetAutonomous` option and using
+an IMEX method where the DIRK table has an implicit first and is not stiffly
 accurate.
 
 **Deprecation Notices**

--- a/src/arkode/arkode_arkstep.c
+++ b/src/arkode/arkode_arkstep.c
@@ -1751,11 +1751,8 @@ int arkStep_TakeStep_Z(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
     }
   }
 
-  /* For a stiffly accurate implicit or ImEx method with an implicit first
-     stage, save f(tn, yn) if using Hermite interpolation as Fi[0] will be
-     overwritten during the implicit solve */
-  save_fn_for_interp = implicit_stage && stiffly_accurate &&
-                       ark_mem->interp_type == ARK_INTERP_HERMITE;
+  /* Save f(tn, yn) for Hermite interpolation */
+  save_fn_for_interp = ark_mem->interp_type == ARK_INTERP_HERMITE;
 
   /* For an implicit or ImEx method using the trivial predictor with an
      autonomous problem with an identity or fixed mass matrix, save fi(tn, yn)
@@ -1778,7 +1775,7 @@ int arkStep_TakeStep_Z(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
     /* If saving the RHS evaluation for reuse in the residual, call the full RHS
        for all implicit methods or for ImEx methods with an explicit first
        stage. ImEx methods with an implicit first stage may not need to evaluate
-       fe depending on the interpolation type. */
+       fe depending on the interpolation type (covered by save_fn_for_interp) */
     sunbooleantype res_full_rhs = save_fn_for_residual && implicit_stage &&
                                   !imex_method;
 

--- a/test/unit_tests/arkode/CXX_serial/ark_test_dahlquist_ark.cpp
+++ b/test/unit_tests/arkode/CXX_serial/ark_test_dahlquist_ark.cpp
@@ -803,13 +803,6 @@ int expected_rhs_evals(ProblemOptions& prob_opts, int stages, int order,
         nfe_expected += nst;
       }
     }
-
-    if (prob_opts.i_type != interp_type::hermite && save_fn_for_residual &&
-        !explicit_first_stage)
-    {
-      if (stiffly_accurate) { nfe_expected++; }
-      else { nfe_expected += nst; }
-    }
   }
 
   // Expected number of implicit functions evaluations


### PR DESCRIPTION
Fix a bug in ARKStep where an extra right-hand side evaluation occurs each time step when enabling the ``ARKodeSetAutonomous`` option and using an IMEX method where the DIRK table has an implicit first and is not stiffly accurate. Fix a bug in counting the number of explicit RHS evaluations in the ARKStep Dahlquist unit test. 