### PR TITLE
add sundials-downloads-tracker status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # SUNDIALS: SUite of Nonlinear and DIfferential/ALgebraic equation Solvers #
+
+[![track SUNDIALS downloads](https://github.com/sundials-codes/sundials-download-tracker/actions/workflows/nightly.yml/badge.svg)](https://github.com/sundials-codes/sundials-download-tracker/actions/workflows/nightly.yml)
+
 ### Version 7.2.1 (Dec 2024) ###
 
 **Center for Applied Scientific Computing, Lawrence Livermore National Laboratory**


### PR DESCRIPTION
Adding a status badge for the workflow that tracks our downloads in https://github.com/sundials-codes/sundials-download-tracker. This will make it readily apparent to us when there is an issue tracking downloads so we can minimize data loss. 

See https://github.com/sundials-codes/sundials-download-tracker/issues/1. 