### PR TITLE
Bugfix: SUNDIALS_ENABLE_ERROR_CHECKS default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Bug Fixes
 
+Fixed the behavior of `SUNDIALS_ENABLE_ERROR_CHECKS` so additional runtime error
+checks are disabled by default with all release build types. Previously,
+`MinSizeRel` builds enabled additional error checking by default.
+
 Fixed bug in the ARKODE SPRKStep `SPRKStepReInit` function and `ARKodeReset` function
 with SPRKStep that could cause a segmentation fault when compensated summation is not
 used.

--- a/cmake/SundialsBuildOptionsPre.cmake
+++ b/cmake/SundialsBuildOptionsPre.cmake
@@ -76,10 +76,10 @@ endif()
 # Option to enable/disable error checking
 # ---------------------------------------------------------------
 
-if(CMAKE_BUILD_TYPE MATCHES "Release|RelWithDebInfo")
-  set(_default_err_checks OFF)
-else()
+if(CMAKE_BUILD_TYPE MATCHES "Debug")
   set(_default_err_checks ON)
+else()
+  set(_default_err_checks OFF)
 endif()
 
 set(DOCSTR

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -4,6 +4,10 @@
 
 **Bug Fixes**
 
+Fixed the behavior of :cmakeop:`SUNDIALS_ENABLE_ERROR_CHECKS` so additional
+runtime error checks are disabled by default with all release build types.
+Previously, ``MinSizeRel`` builds enabled additional error checking by default.
+
 Fixed bug in the ARKODE SPRKStep :c:func:`SPRKStepReInit` function and
 :c:func:`ARKodeReset` function with SPRKStep that could cause a segmentation
 fault when compensated summation is not used.


### PR DESCRIPTION
Fix the behavior of `SUNDIALS_ENABLE_ERROR_CHECKS` so additional runtime error checks are disabled by default with all release build types. Previously, `MinSizeRel` builds enabled additional error checking by default.
