### PR TITLE
Mustafa-contributor

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ David J. Gardner, Alan C. Hindmarsh, Daniel R. Reynolds, Steven B. Roberts, and
 Carol S. Woodward. We thank Radu Serban for significant and critical past
 contributions.
 
-Other contributors to SUNDIALS include: James Almgren-Bell, Lawrence E. Banks,
+Other contributors to SUNDIALS include: Mustafa Aggul, James Almgren-Bell, Lawrence E. Banks,
 Peter N. Brown, George Byrne, Rujeko Chinomona, Scott D. Cohen, Aaron Collier,
 Keith E. Grant, Steven L. Lee, Shelby L. Lockhart, John Loffeld, Daniel McGreer,
 Yu Pan, Slaven Peles, Cosmin Petra, H. Hunter Schwartz, Jean M. Sexton,

--- a/doc/arkode/guide/source/Landing.rst
+++ b/doc/arkode/guide/source/Landing.rst
@@ -20,7 +20,7 @@
    Woodward. We thank Radu Serban for significant and critical past
    contributions.
 
-   Other contributors to SUNDIALS include: James Almgren-Bell,
+   Other contributors to SUNDIALS include: Mustafa Aggul, James Almgren-Bell,
    Lawrence E. Banks, Peter N. Brown, George Byrne, Rujeko Chinomona,
    Scott D. Cohen, Aaron Collier, Keith E. Grant, Steven L. Lee,
    Shelby L. Lockhart, John Loffeld, Daniel McGreer, Yu Pan, Slaven Peles,

--- a/doc/arkode/guide/source/conf.py
+++ b/doc/arkode/guide/source/conf.py
@@ -51,7 +51,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'User Documentation for ARKODE'
-copyright = u"""2012-{year}, Daniel R. Reynolds, David J. Gardner, Carol S. Woodward, Rujeko Chinomona, and Cody J. Balos""".format(year = year)
+copyright = u"""2012-{year}, Daniel R. Reynolds, David J. Gardner, Carol S. Woodward, Cody J. Balos, Rujeko Chinomona, and Mustafa Aggul""".format(year = year)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -217,8 +217,9 @@ tex_author = r'''
     Daniel R. Reynolds$^1$,
     David J. Gardner$^2$,
     Carol S. Woodward$^2$,
+    Cody J. Balos$^2$
     Rujeko Chinomona$^3$, and
-    Cody J. Balos$^2$ \\
+    Mustafa Aggul$^1$ \\
     \\
     {\em $^1$Department of Mathematics, Southern Methodist University} \\
     {\em $^2$Center for Applied Scientific Computing, Lawrence Livermore National Laboratory} \\
@@ -275,7 +276,7 @@ latex_elements = {
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('index', 'ARKODE', u'ARKODE Documentation',
-     [u'Daniel R. Reynolds, David J. Gardner, Carol S. Woodward, Rujeko Chinomona, and Cody J. Balos'], 1)
+     [u'Daniel R. Reynolds, David J. Gardner, Carol S. Woodward, Cody J. Balos, Rujeko Chinomona, and Mustafa Aggul'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -289,7 +290,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
   ('index', 'ARKODE', u'ARKODE Documentation',
-   u'Daniel R. Reynolds, David J. Gardner, Carol S. Woodward, Rujeko Chinomona, and Cody J. Balos', 'ARKODE',
+   u'Daniel R. Reynolds, David J. Gardner, Carol S. Woodward, Cody J. Balos, Rujeko Chinomona, and Mustafa Aggul', 'ARKODE',
    'Time integration package for multi-rate systems of ordinary differential equations.',
    'Miscellaneous'),
 ]

--- a/doc/shared/latex/cover_pages.tex.txt
+++ b/doc/shared/latex/cover_pages.tex.txt
@@ -80,7 +80,7 @@ Carol S. Woodward. We thank Radu Serban for significant and critical past
 contributions.\\
 \vskip 2em%
 \noindent
-Other contributors to SUNDIALS include: James Almgren-Bell, Lawrence E. Banks,
+Other contributors to SUNDIALS include: Mustafa Aggul, James Almgren-Bell, Lawrence E. Banks,
 Peter N. Brown, George Byrne, Rujeko Chinomona, Scott D. Cohen, Aaron Collier,
 Keith E. Grant, Steven L. Lee, Shelby L. Lockhart, John Loffeld, Daniel McGreer,
 Yu Pan, Slaven Peles, Cosmin Petra, Steven B. Roberts, H. Hunter Schwartz,

--- a/doc/superbuild/source/index.rst
+++ b/doc/superbuild/source/index.rst
@@ -143,7 +143,7 @@ contributors. The current SUNDIALS team consists of Cody J.  Balos,
 David J. Gardner, Alan C. Hindmarsh, Daniel R. Reynolds, and Carol S.
 Woodward. We thank Radu Serban for significant and critical past contributions.
 
-Other contributors to SUNDIALS include: James Almgren-Bell, Lawrence E. Banks,
+Other contributors to SUNDIALS include: Mustafa Aggul, James Almgren-Bell, Lawrence E. Banks,
 Peter N. Brown, George Byrne, Rujeko Chinomona, Scott D. Cohen, Aaron Collier,
 Keith E. Grant, Steven L. Lee, Shelby L. Lockhart, John Loffeld, Daniel McGreer,
 Yu Pan, Slaven Peles, Cosmin Petra, Steven B. Roberts, H. Hunter Schwartz,


### PR DESCRIPTION
This PR rectifies an omission from our last release, where we forgot to update the lists of SUNDIALS contributors to include Mustafa Aggul (who contributed the ARKODE LSRKStep module).

