### PR TITLE
CI: Add jobs to test PDF doc builds

### DIFF
--- a/.github/workflows/docs-pdfs.yml
+++ b/.github/workflows/docs-pdfs.yml
@@ -22,6 +22,10 @@ jobs:
       max-parallel: 2
       matrix:
         package: [arkode, cvode, cvodes, ida, idas, kinsol]
+        # TODO(DJG): when all user guides and example docs use sphinx remove
+        # the example documentation jobs below and use the alternative lines
+        # commented out in this job
+        # type: [guide, examples]
 
     steps:
       - name: Install latex
@@ -46,6 +50,7 @@ jobs:
 
       - name: Build docs
         run: cd doc/${{matrix.package}}/guide && make latexpdf
+        # run: cd doc/${{matrix.package}}/${{matrix.type}} && make latexpdf
 
       - name: Archive files from failed build
         uses: actions/upload-artifact@v4
@@ -53,4 +58,85 @@ jobs:
         with:
           name: latex_build_files
           path: |
-            ${{ github.workspace }}/doc/${{matrix.package}}/guide/build/latex
+            ${{github.workspace}}/doc/${{matrix.package}}/guide/build/latex
+          # path: |
+          # ${{github.workspace}}/doc/${{matrix.package}}/${{matrix.type}}/build/latex
+
+  # Sphinx examples documentation PDFs
+  docs_examples_pdf:
+    runs-on: ubuntu-latest
+
+    strategy:
+      max-parallel: 2
+      matrix:
+        package: [arkode]
+
+    steps:
+      - name: Install latex
+        run: |
+          sudo apt update
+          sudo apt install -y --no-install-recommends \
+            fonts-texgyre \
+            latexmk \
+            tex-gyre \
+            texlive-latex-extra \
+            texlive-fonts-recommended \
+            texlive-plain-generic
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install sphinx
+        run: |
+          pip install -r doc/requirements.txt
+
+      - name: Build docs
+        run: cd doc/${{matrix.package}}/examples && make latexpdf
+
+      - name: Archive files from failed build
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: latex_build_files
+          path: |
+            ${{github.workspace}}/doc/${{matrix.package}}/examples/build/latex
+
+  # Latex examples documentation PDFs
+  docs_examples_latex_pdf:
+    runs-on: ubuntu-latest
+
+    strategy:
+      max-parallel: 2
+      matrix:
+        package: [cvode, cvodes, ida, idas, kinsol]
+
+    steps:
+      - name: Install latex
+        run: |
+          sudo apt update
+          sudo apt install -y --no-install-recommends \
+            fonts-texgyre \
+            latexmk \
+            tex-gyre \
+            texlive-latex-extra \
+            texlive-fonts-recommended \
+            texlive-plain-generic
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Build docs
+        run: cd doc/${{matrix.package}} && make ex
+
+      - name: Archive files from failed build
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: latex_build_files
+          path: |
+            ${{github.workspace}}/doc/${{matrix.package}}
+            !${{github.workspace}}/doc/${{matrix.package}}/guide

--- a/.github/workflows/docs-pdfs.yml
+++ b/.github/workflows/docs-pdfs.yml
@@ -29,6 +29,10 @@ jobs:
         with:
           submodules: true
 
+      - name: Install sphinx
+        run: |
+          pip install -r doc/requirements.txt
+
       - name: Build docs
         run: cd doc/${{matrix.package}}/guide && make latexpdf
 

--- a/.github/workflows/docs-pdfs.yml
+++ b/.github/workflows/docs-pdfs.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - develop
-      - ci/pdf-docs
   pull_request:
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/docs-pdfs.yml
+++ b/.github/workflows/docs-pdfs.yml
@@ -15,7 +15,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  docs_user_guide_pdf:
+  docs_install_guide_pdf:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install latex
+        run: |
+          sudo apt update
+          sudo apt install -y --no-install-recommends \
+            fonts-texgyre \
+            latexmk \
+            tex-gyre \
+            texlive-latex-extra \
+            texlive-fonts-recommended \
+            texlive-plain-generic
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install sphinx
+        run: |
+          pip install -r doc/requirements.txt
+
+      - name: Build docs
+        run: cd doc/install_guide && make latexpdf
+
+      - name: Archive files from failed build
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: latex_build_files
+          path: |
+            ${{github.workspace}}/doc/install_guide/build/latex
+
+  docs_package_pdf:
     runs-on: ubuntu-latest
 
     strategy:
@@ -63,7 +98,7 @@ jobs:
           # ${{github.workspace}}/doc/${{matrix.package}}/${{matrix.type}}/build/latex
 
   # Sphinx examples documentation PDFs
-  docs_examples_pdf:
+  docs_examples_sphinx_pdf:
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/docs-pdfs.yml
+++ b/.github/workflows/docs-pdfs.yml
@@ -111,6 +111,9 @@ jobs:
           name: ${{matrix.package}}_user_guide
           path: |
             ${{github.workspace}}/doc/${{matrix.package}}/guide/build/latex/*_guide.pdf
+          # name: ${{matrix.package}}_${{matrix.type}}
+          # path: |
+          #   ${{github.workspace}}/doc/${{matrix.package}}/${{matrix.type}}/build/latex/*_${{matrix.type}}.pdf
 
   # Sphinx examples documentation PDFs
   docs_examples_sphinx_pdf:

--- a/.github/workflows/docs-pdfs.yml
+++ b/.github/workflows/docs-pdfs.yml
@@ -1,0 +1,41 @@
+name: Docs - PDFs
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - ci/pdf-docs
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  docs_user_guide_pdf:
+    runs-on: ubuntu-latest
+
+    strategy:
+      max-parallel: 2
+      matrix:
+        package: [arkode, cvode, cvodes, ida, idas, kinsol]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Build docs
+        run: cd doc/${{matrix.package}}/guide && make latexpdf
+
+      - name: Archive files from failed build
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: latex_build_files
+          path: |
+            ${{ github.workspace }}/doc/${{matrix.package}}/guide/build/latex

--- a/.github/workflows/docs-pdfs.yml
+++ b/.github/workflows/docs-pdfs.yml
@@ -24,6 +24,17 @@ jobs:
         package: [arkode, cvode, cvodes, ida, idas, kinsol]
 
     steps:
+      - name: Install latex
+        run: |
+          sudo apt update
+          sudo apt install -y --no-install-recommends \
+            fonts-texgyre \
+            latexmk \
+            tex-gyre \
+            texlive-latex-extra \
+            texlive-fonts-recommended \
+            texlive-plain-generic
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/docs-pdfs.yml
+++ b/.github/workflows/docs-pdfs.yml
@@ -50,6 +50,14 @@ jobs:
           path: |
             ${{github.workspace}}/doc/install_guide/build/latex
 
+      - name: Archive PDF from successful build
+        uses: actions/upload-artifact@v4
+        if: success()
+        with:
+          name: install_guide
+          path: |
+            ${{github.workspace}}/doc/install_guide/build/latex/INSTALL_GUIDE.pdf
+
   docs_package_pdf:
     runs-on: ubuntu-latest
 
@@ -97,6 +105,14 @@ jobs:
           # path: |
           # ${{github.workspace}}/doc/${{matrix.package}}/${{matrix.type}}/build/latex
 
+      - name: Archive PDFs from successful build
+        uses: actions/upload-artifact@v4
+        if: success()
+        with:
+          name: ${{matrix.package}}_user_guide
+          path: |
+            ${{github.workspace}}/doc/${{matrix.package}}/guide/build/latex/*_guide.pdf
+
   # Sphinx examples documentation PDFs
   docs_examples_sphinx_pdf:
     runs-on: ubuntu-latest
@@ -138,6 +154,14 @@ jobs:
           path: |
             ${{github.workspace}}/doc/${{matrix.package}}/examples/build/latex
 
+      - name: Archive PDFs from successful build
+        uses: actions/upload-artifact@v4
+        if: success()
+        with:
+          name: ${{matrix.package}}_examples_docs
+          path: |
+            ${{github.workspace}}/doc/${{matrix.package}}/examples/build/latex/*_examples.pdf
+
   # Latex examples documentation PDFs
   docs_examples_latex_pdf:
     runs-on: ubuntu-latest
@@ -175,3 +199,11 @@ jobs:
           path: |
             ${{github.workspace}}/doc/${{matrix.package}}
             !${{github.workspace}}/doc/${{matrix.package}}/guide
+
+      - name: Archive PDFs from successful build
+        uses: actions/upload-artifact@v4
+        if: success()
+        with:
+          name: ${{matrix.package}}_examples_docs
+          path: |
+            ${{github.workspace}}/doc/${{matrix.package}}/*_examples.pdf


### PR DESCRIPTION
Add CI jobs to build PDFs for the user guides, example docs, and install guide