### PR TITLE
Fix /autofix command

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -6,6 +6,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -6,9 +6,6 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  contents: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
@@ -19,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/llnl/sundials_spack_cache:llvm-17.0.4-h4lflucc3v2vage45opbo2didtcuigsn.spack
+    permissions:
+      contents: write
     steps:
       - name: Install git
         run: |

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -16,8 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/llnl/sundials_spack_cache:llvm-17.0.4-h4lflucc3v2vage45opbo2didtcuigsn.spack
-    permissions:
-      contents: write
     steps:
       - name: Install git
         run: |
@@ -84,6 +82,8 @@ jobs:
     if: ${{ always() && contains(join(needs.*.result, ','), 'failure') && (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/autofix')) }}
     needs: format_check
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       # Checkout the GitHub created reference for the PR.
       # The only way to do this is by using the "issue" number

--- a/.github/workflows/check-spelling.yml
+++ b/.github/workflows/check-spelling.yml
@@ -6,6 +6,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true

--- a/.github/workflows/check-spelling.yml
+++ b/.github/workflows/check-spelling.yml
@@ -6,9 +6,6 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  contents: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
@@ -65,6 +62,8 @@ jobs:
     if: ${{ always() && contains(join(needs.*.result, ','), 'failure') && (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/autofix')) }}
     needs: spelling_check
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       # Checkout the GitHub created reference for the PR.
       # The only way to do this is by using the "issue" number

--- a/.github/workflows/check-swig.yml
+++ b/.github/workflows/check-swig.yml
@@ -6,6 +6,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true

--- a/.github/workflows/check-swig.yml
+++ b/.github/workflows/check-swig.yml
@@ -6,9 +6,6 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  contents: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
@@ -73,6 +70,8 @@ jobs:
     if: ${{ always() && contains(join(needs.*.result, ','), 'failure') && (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/autofix')) }}
     needs: swig_check
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       # Checkout the GitHub created reference for the PR.
       # The only way to do this is by using the "issue" number


### PR DESCRIPTION
Currently, our `/autofix` command does not work because the jobs don't have the 'write' permission.  This will fix it, but not until the change ends up in `main`.

This permission can be set globally too, but this is more secure.