### PR TITLE
Correct time label in log parser

### DIFF
--- a/tools/suntools/logs.py
+++ b/tools/suntools/logs.py
@@ -383,7 +383,7 @@ def get_history(log, key, step_status=None, time_range=None, step_range=None):
     for entry in log:
 
         step = np.longlong(entry["step"])
-        time = np.double(entry["t_n"])
+        time = np.double(entry["tn"])
 
         if time_range is not None:
             if time < time_range[0] or time > time_range[1]:


### PR DESCRIPTION
Not sure when this changed. Perhaps this is a sign we should have a test for the log parser.