### PR TITLE
Simplify addressing of CI errors

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -64,7 +64,7 @@ jobs:
           ./scripts/format.sh CMakeLists.txt benchmarks cmake examples include src test
 
       - name: Run git diff to see if anything changed
-        run: /usr/bin/git diff --name-only --exit-code
+        run: /usr/bin/git diff --exit-code
 
       - name: Run git diff if we failed
         if: failure()

--- a/.github/workflows/check-spelling.yml
+++ b/.github/workflows/check-spelling.yml
@@ -44,7 +44,7 @@ jobs:
           ./scripts/spelling.sh
 
       - name: Run git diff to see if anything changed
-        run: /usr/bin/git diff --name-only --exit-code
+        run: /usr/bin/git diff --exit-code
 
       - name: Run git diff if we failed
         if: failure()

--- a/.github/workflows/check-swig.yml
+++ b/.github/workflows/check-swig.yml
@@ -52,7 +52,7 @@ jobs:
           make all64
 
       - name: Run git diff to see if anything changed
-        run: /usr/bin/git diff --name-only --exit-code
+        run: /usr/bin/git diff --exit-code
 
       - name: Run git diff if we failed
         if: failure()

--- a/.github/workflows/test-address-sanitizer.yml
+++ b/.github/workflows/test-address-sanitizer.yml
@@ -21,6 +21,7 @@ jobs:
       image: ghcr.io/llnl/sundials-ci-int${{ matrix.indexsize }}-${{ matrix.precision }}:latest
       options: --user root
     strategy:
+      fail-fast: false
       max-parallel: 2
       matrix:
         indexsize: [32, 64]
@@ -46,7 +47,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: build_files
+          name: build_files_${{ matrix.indexsize }}_${{ matrix.precision }}_${{ matrix.buildtype }}_${{ matrix.tpls }}
           path: |
             ${{ github.workspace }}/test/build_*
             !${{ github.workspace }}/test/build_*/Testing/output
@@ -54,6 +55,6 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: output_files
+          name: output_files_${{ matrix.indexsize }}_${{ matrix.precision }}_${{ matrix.buildtype }}_${{ matrix.tpls }}
           path: |
             ${{ github.workspace }}/test/build_*/Testing/

--- a/.github/workflows/ubuntu-clang-latest.yml
+++ b/.github/workflows/ubuntu-clang-latest.yml
@@ -61,7 +61,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: failure()
       with:
-        name: build_files
+        name: build_files_logging_level_${{ matrix.logging_level }}
         path: |
           ${{ github.workspace }}/build
           !${{ github.workspace }}/build/Testing/output
@@ -70,7 +70,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: failure()
       with:
-        name: output_files
+        name: output_files_logging_level_${{ matrix.logging_level }}
         path: |
           ${{ github.workspace }}/build/Testing/
 
@@ -104,7 +104,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: failure()
       with:
-        name: build_files
+        name: build_files_profiling_${{ matrix.profiling }}
         path: |
           ${{ github.workspace }}/build
           !${{ github.workspace }}/build/Testing/output
@@ -113,6 +113,6 @@ jobs:
       uses: actions/upload-artifact@v4
       if: failure()
       with:
-        name: output_files
+        name: output_files_profiling_${{ matrix.profiling }}
         path: |
           ${{ github.workspace }}/build/Testing/

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -21,6 +21,7 @@ jobs:
       image: ghcr.io/llnl/sundials-ci-int${{ matrix.indexsize }}-${{ matrix.precision }}:latest
       options: --user root
     strategy:
+      fail-fast: false
       max-parallel: 2
       matrix:
         indexsize: [32, 64]
@@ -57,7 +58,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: build_files
+          name: build_files_${{ matrix.indexsize }}_${{ matrix.precision }}_${{ matrix.buildtype }}_${{ matrix.tpls }}
           path: |
             ${{ github.workspace }}/test/build_*
             !${{ github.workspace }}/test/build_*/Testing/output
@@ -65,6 +66,6 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: output_files
+          name: output_files_${{ matrix.indexsize }}_${{ matrix.precision }}_${{ matrix.buildtype }}_${{ matrix.tpls }}
           path: |
             ${{ github.workspace }}/test/build_*/Testing/


### PR DESCRIPTION
Uniquely names artifacts for a matrix of jobs to so there's no conflicts like https://github.com/LLNL/sundials/actions/runs/13020815131/job/36320839738#step:7:16
The changes will allow us to get out files across all logging levels and precisions with on run rather than repeated runs and updates. That's been quite tedious on a couple recent PRs.

Any reason we can't remove limits like this:
https://github.com/LLNL/sundials/blob/2de70893c6360b0bb5047e86f3b0b882324c03fa/.github/workflows/ubuntu-latest.yml#L25