### PR TITLE
Removed 'sanity check' since it only applies to serial runs, although…

### DIFF
--- a/examples/utilities/plot_data_2d.py
+++ b/examples/utilities/plot_data_2d.py
@@ -395,10 +395,6 @@ def read_header(args):
         print("ERROR: nt != nrows", info["nt"], np.shape(data)[0])
         sys.exit()
 
-    if (info["nvar"] * info["nx"] * info["ny"]) != (np.shape(data)[1] - 1):
-        print("ERROR: nvar * nx * ny != ncols - 1")
-        sys.exit()
-
     # check x-dimension lower and upper bounds
     if info["xl"] is None:
         print("WARNING: xl not provided, using xl = 0")


### PR DESCRIPTION
This PR removes an incorrect "sanity check" from this python plotting utility script.  The script purports to support parallel output, but this check automatically fails for all parallel data files (since the first data file only contains a subdomain).  

After removing this incorrect check, the script runs correctly for parallel output (e.g., from `benchmarks/diffusion_2D`), while still running correctly for serial output.
