### PR TITLE
spack v1.0 support: `%foo +bar` -> `+bar %foo`

### DIFF
--- a/docker/sundials-ci/e4s-quarterly/int32-double/spack.yaml
+++ b/docker/sundials-ci/e4s-quarterly/int32-double/spack.yaml
@@ -10,16 +10,16 @@ spack:
       compiler:
       - gcc@9.4.0
   specs:
-  - cmake %gcc@9.4.0 arch=x86_64
-  - hypre~int64~internal-superlu %gcc@9.4.0 arch=x86_64
-  - petsc+double~int64~superlu-dist %gcc@9.4.0 arch=x86_64
-  - openmpi %gcc@9.4.0 arch=x86_64
-  - openblas~ilp64 %gcc@9.4.0 arch=x86_64
-  - suite-sparse %gcc@9.4.0 arch=x86_64
-  - superlu-mt~int64~blas %gcc@9.4.0 arch=x86_64
-  - superlu-dist~int64 ^parmetis~int64 %gcc@9.4.0 arch=x86_64
-  - trilinos+tpetra gotype=int %gcc@9.4.0 arch=x86_64
-  - xbraid %gcc@9.4.0 arch=x86_64
+  - cmake arch=x86_64 %gcc@9.4.0
+  - hypre~int64~internal-superlu arch=x86_64 %gcc@9.4.0
+  - petsc+double~int64~superlu-dist arch=x86_64 %gcc@9.4.0
+  - openmpi arch=x86_64 %gcc@9.4.0
+  - openblas~ilp64 arch=x86_64 %gcc@9.4.0
+  - suite-sparse arch=x86_64 %gcc@9.4.0
+  - superlu-mt~int64~blas arch=x86_64 %gcc@9.4.0
+  - superlu-dist~int64 ^parmetis~int64 arch=x86_64 %gcc@9.4.0
+  - trilinos+tpetra gotype=int arch=x86_64 %gcc@9.4.0
+  - xbraid arch=x86_64 %gcc@9.4.0
   config:
     install_tree: /opt/software
   mirrors:

--- a/docker/sundials-ci/e4s-quarterly/int32-extended/spack.yaml
+++ b/docker/sundials-ci/e4s-quarterly/int32-extended/spack.yaml
@@ -8,8 +8,8 @@ spack:
       compiler:
       - gcc@9.4.0
   specs:
-  - cmake %gcc@9.4.0 arch=x86_64
-  - openmpi %gcc@9.4.0 arch=x86_64
+  - cmake arch=x86_64 %gcc@9.4.0
+  - openmpi arch=x86_64 %gcc@9.4.0
   config:
     install_tree: /opt/software
   mirrors:

--- a/docker/sundials-ci/e4s-quarterly/int32-single/spack.yaml
+++ b/docker/sundials-ci/e4s-quarterly/int32-single/spack.yaml
@@ -10,12 +10,12 @@ spack:
       compiler:
       - gcc@9.4.0
   specs:
-  - cmake %gcc@9.4.0 arch=x86_64
-  - petsc~double~int64~superlu-dist~hypre ^openblas %gcc@9.4.0 arch=x86_64
-  - openmpi %gcc@9.4.0 arch=x86_64
-  - openblas %gcc@9.4.0 arch=x86_64
-  - superlu-mt~int64~blas %gcc@9.4.0 arch=x86_64
-  - trilinos+float+tpetra gotype=int ^openblas %gcc@9.4.0 arch=x86_64
+  - cmake arch=x86_64 %gcc@9.4.0
+  - petsc~double~int64~superlu-dist~hypre ^openblas arch=x86_64 %gcc@9.4.0
+  - openmpi arch=x86_64 %gcc@9.4.0
+  - openblas arch=x86_64 %gcc@9.4.0
+  - superlu-mt~int64~blas arch=x86_64 %gcc@9.4.0
+  - trilinos+float+tpetra gotype=int ^openblas arch=x86_64 %gcc@9.4.0
   config:
     install_tree: /opt/software
   mirrors:

--- a/docker/sundials-ci/e4s-quarterly/int64-double/spack.yaml
+++ b/docker/sundials-ci/e4s-quarterly/int64-double/spack.yaml
@@ -10,16 +10,16 @@ spack:
       compiler:
       - gcc@9.4.0
   specs:
-  - cmake %gcc@9.4.0 arch=x86_64
-  - hypre+int64~internal-superlu %gcc@9.4.0 arch=x86_64
-  - petsc+double+int64~superlu-dist~hypre %gcc@9.4.0 arch=x86_64
-  - openmpi %gcc@9.4.0 arch=x86_64
-  - openblas+ilp64 %gcc@9.4.0 arch=x86_64
-  - suite-sparse %gcc@9.4.0 arch=x86_64
-  - superlu-mt+int64~blas %gcc@9.4.0 arch=x86_64
+  - cmake arch=x86_64 %gcc@9.4.0
+  - hypre+int64~internal-superlu arch=x86_64 %gcc@9.4.0
+  - petsc+double+int64~superlu-dist~hypre arch=x86_64 %gcc@9.4.0
+  - openmpi arch=x86_64 %gcc@9.4.0
+  - openblas+ilp64 arch=x86_64 %gcc@9.4.0
+  - suite-sparse arch=x86_64 %gcc@9.4.0
+  - superlu-mt+int64~blas arch=x86_64 %gcc@9.4.0
   # - superlu-dist+int64 ^parmetis+int64 ^netlib-lapack %gcc@9.4.0 arch=x86_64 # TODO(CJB): enable this once we can use the conretizer option when_possible
-  - trilinos+tpetra gotype=long_long %gcc@9.4.0 arch=x86_64
-  - xbraid %gcc@9.4.0 arch=x86_64
+  - trilinos+tpetra gotype=long_long arch=x86_64 %gcc@9.4.0
+  - xbraid arch=x86_64 %gcc@9.4.0
   config:
     install_tree: /opt/software
   mirrors:

--- a/docker/sundials-ci/e4s-quarterly/int64-extended/spack.yaml
+++ b/docker/sundials-ci/e4s-quarterly/int64-extended/spack.yaml
@@ -8,8 +8,8 @@ spack:
       compiler:
       - gcc@9.4.0
   specs:
-  - cmake %gcc@9.4.0 arch=x86_64
-  - openmpi %gcc@9.4.0 arch=x86_64
+  - cmake arch=x86_64 %gcc@9.4.0
+  - openmpi arch=x86_64 %gcc@9.4.0
   config:
     install_tree: /opt/software
   mirrors:

--- a/docker/sundials-ci/e4s-quarterly/int64-single/spack.yaml
+++ b/docker/sundials-ci/e4s-quarterly/int64-single/spack.yaml
@@ -10,10 +10,10 @@ spack:
       compiler:
       - gcc@9.4.0
   specs:
-  - cmake %gcc@9.4.0 arch=x86_64
-  - openmpi %gcc@9.4.0 arch=x86_64
-  - openblas+ilp64 %gcc@9.4.0 arch=x86_64
-  - superlu-mt+int64~blas %gcc@9.4.0 arch=x86_64
+  - cmake arch=x86_64 %gcc@9.4.0
+  - openmpi arch=x86_64 %gcc@9.4.0
+  - openblas+ilp64 arch=x86_64 %gcc@9.4.0
+  - superlu-mt+int64~blas arch=x86_64 %gcc@9.4.0
   config:
     install_tree: /opt/software
   mirrors:

--- a/docker/sundials-ci/spack-nightly/int32-double/spack.yaml
+++ b/docker/sundials-ci/spack-nightly/int32-double/spack.yaml
@@ -10,16 +10,16 @@ spack:
       compiler:
       - gcc@9.4.0
   specs:
-  - cmake %gcc@9.4.0 arch=x86_64
-  - hypre~int64~internal-superlu %gcc@9.4.0 arch=x86_64
-  - petsc+double~int64~superlu-dist %gcc@9.4.0 arch=x86_64
-  - openmpi %gcc@9.4.0 arch=x86_64
-  - openblas~ilp64 %gcc@9.4.0 arch=x86_64
-  - suite-sparse %gcc@9.4.0 arch=x86_64
-  - superlu-mt~int64~blas %gcc@9.4.0 arch=x86_64
-  - superlu-dist~int64 ^parmetis~int64 %gcc@9.4.0 arch=x86_64
-  - trilinos+tpetra gotype=int %gcc@9.4.0 arch=x86_64
-  - xbraid %gcc@9.4.0 arch=x86_64
+  - cmake arch=x86_64 %gcc@9.4.0
+  - hypre~int64~internal-superlu arch=x86_64 %gcc@9.4.0
+  - petsc+double~int64~superlu-dist arch=x86_64 %gcc@9.4.0
+  - openmpi arch=x86_64 %gcc@9.4.0
+  - openblas~ilp64 arch=x86_64 %gcc@9.4.0
+  - suite-sparse arch=x86_64 %gcc@9.4.0
+  - superlu-mt~int64~blas arch=x86_64 %gcc@9.4.0
+  - superlu-dist~int64 ^parmetis~int64 arch=x86_64 %gcc@9.4.0
+  - trilinos+tpetra gotype=int arch=x86_64 %gcc@9.4.0
+  - xbraid arch=x86_64 %gcc@9.4.0
   config:
     install_tree: /opt/software
   mirrors:

--- a/docker/sundials-ci/spack-nightly/int64-double/spack.yaml
+++ b/docker/sundials-ci/spack-nightly/int64-double/spack.yaml
@@ -10,16 +10,16 @@ spack:
       compiler:
       - gcc@9.4.0
   specs:
-  - cmake %gcc@9.4.0 arch=x86_64
-  - hypre+int64~internal-superlu %gcc@9.4.0 arch=x86_64
-  - petsc+double+int64~superlu-dist~hypre %gcc@9.4.0 arch=x86_64
-  - openmpi %gcc@9.4.0 arch=x86_64
-  - openblas+ilp64 %gcc@9.4.0 arch=x86_64
-  - suite-sparse %gcc@9.4.0 arch=x86_64
-  - superlu-mt+int64~blas %gcc@9.4.0 arch=x86_64
-  - superlu-dist+int64 ^parmetis+int64 ^netlib-lapack %gcc@9.4.0 arch=x86_64
-  - trilinos+tpetra gotype=long_long %gcc@9.4.0 arch=x86_64
-  - xbraid %gcc@9.4.0 arch=x86_64
+  - cmake arch=x86_64 %gcc@9.4.0
+  - hypre+int64~internal-superlu arch=x86_64 %gcc@9.4.0
+  - petsc+double+int64~superlu-dist~hypre arch=x86_64 %gcc@9.4.0
+  - openmpi arch=x86_64 %gcc@9.4.0
+  - openblas+ilp64 arch=x86_64 %gcc@9.4.0
+  - suite-sparse arch=x86_64 %gcc@9.4.0
+  - superlu-mt+int64~blas arch=x86_64 %gcc@9.4.0
+  - superlu-dist+int64 ^parmetis+int64 ^netlib-lapack arch=x86_64 %gcc@9.4.0
+  - trilinos+tpetra gotype=long_long arch=x86_64 %gcc@9.4.0
+  - xbraid arch=x86_64 %gcc@9.4.0
   config:
     install_tree: /opt/software
   mirrors:


### PR DESCRIPTION
Spack v1.0 will parse `pkg %gcc +foo` as "pkg with direct dependency gcc
with variant foo enabled" instead of "pkg with variant foo enabled and compiler
gcc". Reorder as `pkg +foo %gcc` to be compatible with Spack v0.x and
v1.0.


<!-- SUNDIALS developers only: remove the checklist before opening a PR and refer to the developer's guide instructions. -->
<!-- Thank you for your interest in contributing to SUNDIALS. A pull request to SUNDIALS requires the following steps to be completed: -->

- [ ] Please target the `develop` branch not `main`.
- [ ] Review our [Contributing Guide](https://github.com/LLNL/sundials/blob/main/CONTRIBUTING.md), and ensure that you sign your last commit (at minimum) as per the guide.
- [ ] Provide a concise description of what your pull request does, and why it is needed/benefical.
- [ ] Add a note about your change to the `CHANGELOG.md` and `docs/shared/RecentChanges.rst` files. Notice that the former is a markdown file and the latter is reStructuredText, so the formatting is slightly different.
- [ ] After your PR is opened, ensure that all of the tests are passing (a SUNDIALS developer will have to allow the testing to run).

