### PR TITLE
Bug fix for helper function return value when resizing MRI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Improved the efficiency of default ARKODE methods with the following changes:
 
 ### Bug Fixes
 
+Fixed bug in `ARKodeResize` which caused it return an error for MRI methods.
+
 Removed error floors from the `SUNAdaptController` implementations which could
 unnecessarily limit the time size growth, particularly after the first step.
 

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -44,6 +44,8 @@ Improved the efficiency of default ARKODE methods with the following changes:
 
 **Bug Fixes**
 
+Fixed bug in ``ARKodeResize`` which caused it return an error for MRI methods.
+
 Removed error floors from the :c:type:`SUNAdaptController` implementations
 which could unnecessarily limit the time size growth, particularly after the
 first step.

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -44,7 +44,8 @@ Improved the efficiency of default ARKODE methods with the following changes:
 
 **Bug Fixes**
 
-Fixed bug in ``ARKodeResize`` which caused it return an error for MRI methods.
+Fixed bug in :c:func:`ARKodeResize` which caused it return an error for MRI
+methods.
 
 Removed error floors from the :c:type:`SUNAdaptController` implementations
 which could unnecessarily limit the time size growth, particularly after the

--- a/src/arkode/arkode_mristep.c
+++ b/src/arkode/arkode_mristep.c
@@ -4767,10 +4767,12 @@ int mriStepInnerStepper_Resize(MRIStepInnerStepper stepper, ARKVecResizeFn resiz
 
   if (stepper == NULL) { return ARK_ILL_INPUT; }
 
-  retval = arkResizeVecArray(resize, resize_data, stepper->nforcing_allocated,
-                             tmpl, &(stepper->forcing), lrw_diff,
-                             &(stepper->lrw), liw_diff, &(stepper->liw));
-  if (retval != ARK_SUCCESS) { return (ARK_MEM_FAIL); }
+  if (!arkResizeVecArray(resize, resize_data, stepper->nforcing_allocated, tmpl,
+                         &(stepper->forcing), lrw_diff, &(stepper->lrw),
+                         liw_diff, &(stepper->liw)))
+  {
+    return (ARK_MEM_FAIL);
+  }
 
   return (ARK_SUCCESS);
 }

--- a/src/arkode/arkode_mristep.c
+++ b/src/arkode/arkode_mristep.c
@@ -4763,8 +4763,6 @@ int mriStepInnerStepper_Resize(MRIStepInnerStepper stepper, ARKVecResizeFn resiz
                                void* resize_data, sunindextype lrw_diff,
                                sunindextype liw_diff, N_Vector tmpl)
 {
-  int retval;
-
   if (stepper == NULL) { return ARK_ILL_INPUT; }
 
   if (!arkResizeVecArray(resize, resize_data, stepper->nforcing_allocated, tmpl,


### PR DESCRIPTION
A user identified that trying to resize an MRI method leads to the following error: `.../arkode_mristep.c:516][mriStep_Resize] Unable to resize vector`. The `arkResizeVecArray` returns a boolean for success or failure but it was being treated as a `SUNErrorCode`. It slipped though the cracks due to implicit conversions. I think this calls for more testing of resize, but for now here's a fix.