### PR TITLE
Maintenance: Ignore python formatting in blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -8,3 +8,5 @@ cc6960349aa92e2bcad9168a6dacff99b21c329c
 b578eabccd77b7642b04ddda9d8530f05890d1b4
 # Apply formatting to CMake files
 c6b9a02f24a27081c471d63dfc524684a9f5a9e3
+# Update formatting for Python files
+b166f03e29852a17fec5747cb64c4c986f24d42b


### PR DESCRIPTION
Ignore formatting updates from #699 in blame
