### PR TITLE
fix default value of eta fixed step upper bound in arkode math section

### DIFF
--- a/doc/arkode/guide/source/Mathematics.rst
+++ b/doc/arkode/guide/source/Mathematics.rst
@@ -1203,7 +1203,8 @@ expensive, and where convergence can be seriously hindered through use
 of an inaccurate matrix.  To accommodate these scenarios, the step is
 left unchanged when :math:`\eta \in [\eta_L, \eta_U]`.  The default
 values for this interval are :math:`\eta_L = 1` and :math:`\eta_U =
-1.5`, and may be modified by the user.
+1.0` (so small step size adjustments are possible), and may be m
+modified by the user.
 
 We note that any choices for :math:`\eta` (or equivalently,
 :math:`h'`) are subsequently constrained by the optional user-supplied

--- a/doc/arkode/guide/source/Mathematics.rst
+++ b/doc/arkode/guide/source/Mathematics.rst
@@ -1203,7 +1203,7 @@ expensive, and where convergence can be seriously hindered through use
 of an inaccurate matrix.  To accommodate these scenarios, the step is
 left unchanged when :math:`\eta \in [\eta_L, \eta_U]`.  The default
 values for this interval are :math:`\eta_L = 1` and :math:`\eta_U =
-1.0` (so small step size adjustments are possible), and may be m
+1.0` (so small step size adjustments are possible), and may be
 modified by the user.
 
 We note that any choices for :math:`\eta` (or equivalently,


### PR DESCRIPTION
The default value was changed to `1.0` in v6.3.0 according to [here](https://sundials.readthedocs.io/en/latest/arkode/Usage/User_callable.html#c.ARKodeSetFixedStepBounds). [Code link](https://github.com/LLNL/sundials/blob/main/src/arkode/arkode_adapt_impl.h#L44).