### PR TITLE
fix: correct parameter order in declaration of arkCheckConstraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,9 @@ variables. It is currently an alias for `long int`.
 
 #### ARKODE
 
+Fixed a bug in the declaration of `arkCheckConstraints` by reordering parameters
+to match its definition.
+
 Fixed bug in `ARKodeResize` which caused it return an error for MRI methods.
 
 Removed error floors from the `SUNAdaptController` implementations which could

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -157,6 +157,9 @@ counter variables. It is currently an alias for ``long int``.
 
 *ARKODE*
 
+Fixed a bug in the declaration of :c:func:`arkCheckConstraints` by reordering
+parameters to match its definition.
+
 Fixed bug in :c:func:`ARKodeResize` which caused it return an error for MRI
 methods.
 

--- a/src/arkode/arkode_impl.h
+++ b/src/arkode/arkode_impl.h
@@ -660,7 +660,7 @@ int arkPredict_Bootstrap(ARKodeMem ark_mem, sunrealtype hj, sunrealtype tau,
                          int nvec, sunrealtype* cvals, N_Vector* Xvecs,
                          N_Vector yguess);
 int arkCheckConvergence(ARKodeMem ark_mem, int* nflagPtr, int* ncfPtr);
-int arkCheckConstraints(ARKodeMem ark_mem, int* nflag, int* constrfails);
+int arkCheckConstraints(ARKodeMem ark_mem, int* constrfails, int* nflag);
 int arkCheckTemporalError(ARKodeMem ark_mem, int* nflagPtr, int* nefPtr,
                           sunrealtype dsm);
 int arkAccessHAdaptMem(void* arkode_mem, const char* fname, ARKodeMem* ark_mem,


### PR DESCRIPTION

### Problem
The function declaration of `arkCheckConstraints` in `arkode_impl.h` had a parameter order that was inconsistent with its definition in the source file.

Specifically, the `nflag` and `constrfails` parameters were swapped. This inconsistency can lead to undefined behavior when the function is used across multiple translation units.

### Fix
Reordered the parameters in the function declaration to match the definition.

### Impact
Ensures consistency between the function's declaration and its implementation, preventing misuse and potential compilation/linking issues.
