### PR TITLE
Small fixes for discrete adjoint study

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### New Features and Enhancements
 
+Added an option to enable compensated summation of the time accumulator for all of ARKODE. This
+was previously only an option for the SPRKStep module. The new function to call to enable this
+is `ARKodeSetUseCompensatedSums`. 
+
 ### Bug Fixes
 
 Fixed segfaults in `CVodeAdjInit` and `IDAAdjInit` when called after adjoint
@@ -13,7 +17,13 @@ memory has been freed.
 
 Fixed a CMake bug that would cause the Caliper compile test to fail at configure time.
 
+`SUNAdjointStepper_PrintAllStats` was reporting the wrong quantity for the number of "recompute passes"
+and has been fixed.
+
 ### Deprecation Notices
+
+The `SPRKStepSetUseCompensatedSums` function has been deprecated. Use the
+`ARKodeSetUseCompensatedSums` function instead.
 
 ## Changes to SUNDIALS in release 7.3.0
 

--- a/doc/arkode/guide/source/Usage/SPRKStep/User_callable.rst
+++ b/doc/arkode/guide/source/Usage/SPRKStep/User_callable.rst
@@ -501,6 +501,10 @@ Optional inputs for IVP method selection
    :retval ARK_MEM_NULL: if the SPRKStep memory is ``NULL``
    :retval ARK_ILL_INPUT: if an argument had an illegal value
 
+   .. deprecated:: x.y.z
+
+      Use :c:func:`ARKodeSetUseCompensatedSums` instead.
+
 
 
 .. _ARKODE.Usage.SPRKStep.SPRKStepRootfindingInput:

--- a/doc/arkode/guide/source/Usage/User_callable.rst
+++ b/doc/arkode/guide/source/Usage/User_callable.rst
@@ -1480,11 +1480,11 @@ Set the checkpointing step index (for adjoint)     :c:func:`ARKodeSetAdjointChec
    5 per time step. It also requires one extra vector to be stored. However, it
    is significantly more robust to roundoff error accumulation.
 
-   :param arkode_mem: pointer to the SPRKStep memory block.
+   :param arkode_mem: pointer to the ARKODE memory block.
    :param onoff: should compensated summation be used (1) or not (0)
 
    :retval ARK_SUCCESS: if successful
-   :retval ARK_MEM_NULL: if the SPRKStep memory is ``NULL``
+   :retval ARK_MEM_NULL: if the ARKODE memory is ``NULL``
    :retval ARK_ILL_INPUT: if an argument had an illegal value
 
 

--- a/doc/arkode/guide/source/Usage/User_callable.rst
+++ b/doc/arkode/guide/source/Usage/User_callable.rst
@@ -1472,7 +1472,7 @@ Set the checkpointing step index (for adjoint)     :c:func:`ARKodeSetAdjointChec
 .. c:function:: int ARKodeSetUseCompensatedSums(void* arkode_mem, sunbooleantype onoff)
 
    Specifies if compensated summations should be used within ARKODE where supported.
-   Currently, all ARKODE modules support compensated summation of time accumulator.
+   Currently, all ARKODE modules support compensated summation for accumulating time.
 
    SPRKStep also supports an alternative stepping algorithm based on compensated
    summation which will be enabled/disabled by this function. This increases the 

--- a/doc/arkode/guide/source/Usage/User_callable.rst
+++ b/doc/arkode/guide/source/Usage/User_callable.rst
@@ -1452,6 +1452,7 @@ Set the checkpointing step index (for adjoint)     :c:func:`ARKodeSetAdjointChec
 
    .. versionadded:: 6.3.0
 
+
 .. c:function:: int ARKodeSetAdjointCheckpointIndex(void* arkode_mem, suncountertype step_index)
 
    Specifies the step index (that is step number) to insert the next checkpoint at.
@@ -1466,6 +1467,25 @@ Set the checkpointing step index (for adjoint)     :c:func:`ARKodeSetAdjointChec
    :retval ARK_MEM_NULL: ``arkode_mem`` was ``NULL``.
 
    .. versionadded:: 6.3.0
+
+
+.. c:function:: int ARKodeSetUseCompensatedSums(void* arkode_mem, sunbooleantype onoff)
+
+   Specifies if compensated summations should be used within ARKODE where supported.
+   Currently, all ARKODE modules support compensated summation of time accumulator.
+
+   SPRKStep also supports an alternative stepping algorithm based on compensated
+   summation which will be enabled/disabled by this function. This increases the 
+   computational cost by 2 extra vector operations per stage and an additional 
+   5 per time step. It also requires one extra vector to be stored. However, it
+   is significantly more robust to roundoff error accumulation.
+
+   :param arkode_mem: pointer to the SPRKStep memory block.
+   :param onoff: should compensated summation be used (1) or not (0)
+
+   :retval ARK_SUCCESS: if successful
+   :retval ARK_MEM_NULL: if the SPRKStep memory is ``NULL``
+   :retval ARK_ILL_INPUT: if an argument had an illegal value
 
 
 .. _ARKODE.Usage.ARKodeAdaptivityInputTable:

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -5,6 +5,10 @@
 
 **New Features and Enhancements**
 
+Added an option to enable compensated summation of the time accumulator for all of ARKODE. This
+was previously only an option for the SPRKStep module. The new function to call to enable this
+is :c:func:`ARKodeSetUseCompensatedSums`. 
+
 **Bug Fixes**
 
 Fixed segfaults in :c:func:`CVodeAdjInit` and :c:func:`IDAAdjInit` when called
@@ -12,4 +16,10 @@ after adjoint memory has been freed.
 
 Fixed a CMake bug that would cause the Caliper compile test to fail at configure time.
 
+:c:func:`SUNAdjointStepper_PrintAllStats` was reporting the wrong quantity for the number of "recompute passes"
+and has been fixed.
+
 **Deprecation Notices**
+
+The :c:func:`SPRKStepSetUseCompensatedSums` function has been deprecated. Use the
+:c:func:`ARKodeSetUseCompensatedSums` function instead.

--- a/doc/shared/sunadjoint/SUNAdjointStepper.rst
+++ b/doc/shared/sunadjoint/SUNAdjointStepper.rst
@@ -126,7 +126,7 @@ The :c:type:`SUNAdjointStepper` class has the following methods:
 
 .. c:function:: SUNErrCode SUNAdjointStepper_GetNumRecompute(SUNAdjointStepper adj_stepper, suncountertype* num_recompute)
 
-   Retrieves the number of recomputations performed by the adjoint stepper.
+   Retrieves the number of recomputation (in the forward direction) steps performed by the adjoint stepper.
 
    :param adj_stepper: The SUNAdjointStepper object.
    :param num_recompute: Pointer to store the number of recomputations.

--- a/doc/shared/sunadjoint/SUNAdjointStepper.rst
+++ b/doc/shared/sunadjoint/SUNAdjointStepper.rst
@@ -126,7 +126,7 @@ The :c:type:`SUNAdjointStepper` class has the following methods:
 
 .. c:function:: SUNErrCode SUNAdjointStepper_GetNumRecompute(SUNAdjointStepper adj_stepper, suncountertype* num_recompute)
 
-   Retrieves the number of recomputation (in the forward direction) steps performed by the adjoint stepper.
+   Retrieves the number of recomputation steps (in the forward direction) performed by the adjoint stepper.
 
    :param adj_stepper: The SUNAdjointStepper object.
    :param num_recompute: Pointer to store the number of recomputations.

--- a/examples/arkode/C_serial/ark_damped_harmonic_symplectic.c
+++ b/examples/arkode/C_serial/ark_damped_harmonic_symplectic.c
@@ -107,8 +107,8 @@ int main(int argc, char* argv[])
   retval = ARKodeSetOrder(arkode_mem, order);
   if (check_retval(&retval, "ARKodeSetOrder", 1)) { return 1; }
 
-  retval = SPRKStepSetUseCompensatedSums(arkode_mem, use_compsums);
-  if (check_retval(&retval, "SPRKStepSetUseCompensatedSums", 1)) { return 1; }
+  retval = ARKodeSetUseCompensatedSums(arkode_mem, use_compsums);
+  if (check_retval(&retval, "ARKodeSetUseCompensatedSums", 1)) { return 1; }
 
   retval = ARKodeSetFixedStep(arkode_mem, dt);
   if (check_retval(&retval, "ARKodeSetFixedStep", 1)) { return 1; }

--- a/examples/arkode/C_serial/ark_harmonic_symplectic.c
+++ b/examples/arkode/C_serial/ark_harmonic_symplectic.c
@@ -128,8 +128,8 @@ int main(int argc, char* argv[])
   retval = ARKodeSetUserData(arkode_mem, &udata);
   if (check_retval(&retval, "ARKodeSetUserData", 1)) { return 1; }
 
-  retval = SPRKStepSetUseCompensatedSums(arkode_mem, use_compsums);
-  if (check_retval(&retval, "SPRKStepSetUseCompensatedSums", 1)) { return 1; }
+  retval = ARKodeSetUseCompensatedSums(arkode_mem, use_compsums);
+  if (check_retval(&retval, "ARKodeSetUseCompensatedSums", 1)) { return 1; }
 
   retval = ARKodeSetFixedStep(arkode_mem, dt);
   if (check_retval(&retval, "ARKodeSetFixedStep", 1)) { return 1; }

--- a/examples/arkode/C_serial/ark_kepler.c
+++ b/examples/arkode/C_serial/ark_kepler.c
@@ -164,8 +164,8 @@ int SolveProblem(ProgramArgs* args, ProblemResult* result, SUNContext sunctx)
     retval = SPRKStepSetMethodName(arkode_mem, method_name);
     if (check_retval(&retval, "SPRKStepSetMethodName", 1)) { return 1; }
 
-    retval = SPRKStepSetUseCompensatedSums(arkode_mem, use_compsums);
-    if (check_retval(&retval, "SPRKStepSetUseCompensatedSums", 1)) { return 1; }
+    retval = ARKodeSetUseCompensatedSums(arkode_mem, use_compsums);
+    if (check_retval(&retval, "ARKodeSetUseCompensatedSums", 1)) { return 1; }
 
     if (step_mode == 0)
     {

--- a/examples/arkode/C_serial/ark_lotka_volterra_ASA_--check-freq_1.out
+++ b/examples/arkode/C_serial/ark_lotka_volterra_ASA_--check-freq_1.out
@@ -40,5 +40,5 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 0
+Num recompute steps           = 0
 

--- a/examples/arkode/C_serial/ark_lotka_volterra_ASA_--check-freq_5.out
+++ b/examples/arkode/C_serial/ark_lotka_volterra_ASA_--check-freq_5.out
@@ -40,5 +40,5 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 3080
+Num recompute steps           = 8000
 

--- a/include/arkode/arkode.h
+++ b/include/arkode/arkode.h
@@ -316,6 +316,8 @@ int ARKodeSetAdjointCheckpointScheme(void* arkode_mem,
                                      SUNAdjointCheckpointScheme checkpoint_scheme);
 SUNDIALS_EXPORT
 int ARKodeSetAdjointCheckpointIndex(void* arkode_mem, suncountertype step_index);
+SUNDIALS_EXPORT
+int ARKodeSetUseCompensatedSums(void* arkode_mem, sunbooleantype onoff);
 SUNDIALS_EXPORT int ARKodeSetAccumulatedErrorType(void* arkode_mem,
                                                   ARKAccumError accum_type);
 SUNDIALS_EXPORT int ARKodeResetAccumulatedError(void* arkode_mem);

--- a/include/arkode/arkode_sprkstep.h
+++ b/include/arkode/arkode_sprkstep.h
@@ -48,8 +48,8 @@ SUNDIALS_EXPORT int SPRKStepReInit(void* arkode_mem, ARKRhsFn f1, ARKRhsFn f2,
                                    sunrealtype t0, N_Vector y0);
 
 /* Optional input functions -- must be called AFTER SPRKStepCreate */
-SUNDIALS_EXPORT int SPRKStepSetUseCompensatedSums(void* arkode_mem,
-                                                  sunbooleantype onoff);
+SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetUseCompensatedSums instead")
+int SPRKStepSetUseCompensatedSums(void* arkode_mem, sunbooleantype onoff);
 SUNDIALS_EXPORT int SPRKStepSetMethod(void* arkode_mem,
                                       ARKodeSPRKTable sprk_storage);
 SUNDIALS_EXPORT int SPRKStepSetMethodName(void* arkode_mem, const char* method);

--- a/src/arkode/arkode_arkstep.c
+++ b/src/arkode/arkode_arkstep.c
@@ -108,6 +108,7 @@ void* ARKStepCreate(ARKRhsFn fe, ARKRhsFn fi, sunrealtype t0, N_Vector y0,
   ark_mem->step_setuserdata               = arkStep_SetUserData;
   ark_mem->step_printallstats             = arkStep_PrintAllStats;
   ark_mem->step_writeparameters           = arkStep_WriteParameters;
+  ark_mem->step_setusecompensatedsums     = NULL;
   ark_mem->step_resize                    = arkStep_Resize;
   ark_mem->step_free                      = arkStep_Free;
   ark_mem->step_printmem                  = arkStep_PrintMem;

--- a/src/arkode/arkode_erkstep.c
+++ b/src/arkode/arkode_erkstep.c
@@ -90,23 +90,24 @@ void* ERKStepCreate(ARKRhsFn f, sunrealtype t0, N_Vector y0, SUNContext sunctx)
   memset(step_mem, 0, sizeof(struct ARKodeERKStepMemRec));
 
   /* Attach step_mem structure and function pointers to ark_mem */
-  ark_mem->step_init                = erkStep_Init;
-  ark_mem->step_fullrhs             = erkStep_FullRHS;
-  ark_mem->step                     = erkStep_TakeStep;
-  ark_mem->step_printallstats       = erkStep_PrintAllStats;
-  ark_mem->step_writeparameters     = erkStep_WriteParameters;
-  ark_mem->step_resize              = erkStep_Resize;
-  ark_mem->step_free                = erkStep_Free;
-  ark_mem->step_printmem            = erkStep_PrintMem;
-  ark_mem->step_setdefaults         = erkStep_SetDefaults;
-  ark_mem->step_setrelaxfn          = erkStep_SetRelaxFn;
-  ark_mem->step_setorder            = erkStep_SetOrder;
-  ark_mem->step_getnumrhsevals      = erkStep_GetNumRhsEvals;
-  ark_mem->step_getestlocalerrors   = erkStep_GetEstLocalErrors;
-  ark_mem->step_setforcing          = erkStep_SetInnerForcing;
-  ark_mem->step_supports_adaptive   = SUNTRUE;
-  ark_mem->step_supports_relaxation = SUNTRUE;
-  ark_mem->step_mem                 = (void*)step_mem;
+  ark_mem->step_init                  = erkStep_Init;
+  ark_mem->step_fullrhs               = erkStep_FullRHS;
+  ark_mem->step                       = erkStep_TakeStep;
+  ark_mem->step_printallstats         = erkStep_PrintAllStats;
+  ark_mem->step_writeparameters       = erkStep_WriteParameters;
+  ark_mem->step_setusecompensatedsums = NULL;
+  ark_mem->step_resize                = erkStep_Resize;
+  ark_mem->step_free                  = erkStep_Free;
+  ark_mem->step_printmem              = erkStep_PrintMem;
+  ark_mem->step_setdefaults           = erkStep_SetDefaults;
+  ark_mem->step_setrelaxfn            = erkStep_SetRelaxFn;
+  ark_mem->step_setorder              = erkStep_SetOrder;
+  ark_mem->step_getnumrhsevals        = erkStep_GetNumRhsEvals;
+  ark_mem->step_getestlocalerrors     = erkStep_GetEstLocalErrors;
+  ark_mem->step_setforcing            = erkStep_SetInnerForcing;
+  ark_mem->step_supports_adaptive     = SUNTRUE;
+  ark_mem->step_supports_relaxation   = SUNTRUE;
+  ark_mem->step_mem                   = (void*)step_mem;
 
   /* Set default values for optional inputs */
   retval = erkStep_SetDefaults((void*)ark_mem);

--- a/src/arkode/arkode_impl.h
+++ b/src/arkode/arkode_impl.h
@@ -231,7 +231,6 @@ typedef int (*ARKTimestepSetStepDirection)(ARKodeMem ark_mem,
 typedef int (*ARKTimestepSetUseCompensatedSums)(ARKodeMem ark_mem,
                                                 sunbooleantype onoff);
 
-
 /* time stepper interface functions -- temporal adaptivity */
 typedef int (*ARKTimestepGetEstLocalErrors)(ARKodeMem ark_mem, N_Vector ele);
 typedef int (*ARKSetAdaptControllerFn)(ARKodeMem ark_mem, SUNAdaptController C);

--- a/src/arkode/arkode_impl.h
+++ b/src/arkode/arkode_impl.h
@@ -228,6 +228,9 @@ typedef int (*ARKTimestepGetNumRhsEvals)(ARKodeMem ark_mem, int partition_index,
                                          long int* num_rhs_evals);
 typedef int (*ARKTimestepSetStepDirection)(ARKodeMem ark_mem,
                                            sunrealtype stepdir);
+typedef int (*ARKTimestepSetUseCompensatedSums)(ARKodeMem ark_mem,
+                                                sunbooleantype onoff);
+
 
 /* time stepper interface functions -- temporal adaptivity */
 typedef int (*ARKTimestepGetEstLocalErrors)(ARKodeMem ark_mem, N_Vector ele);
@@ -418,6 +421,7 @@ struct ARKodeMemRec
   ARKTimestepSetOrder step_setorder;
   ARKTimestepGetNumRhsEvals step_getnumrhsevals;
   ARKTimestepSetStepDirection step_setstepdirection;
+  ARKTimestepSetUseCompensatedSums step_setusecompensatedsums;
 
   /* Time stepper module -- temporal adaptivity */
   sunbooleantype step_supports_adaptive;

--- a/src/arkode/arkode_io.c
+++ b/src/arkode/arkode_io.c
@@ -2205,6 +2205,35 @@ int ARKodeSetAdjointCheckpointIndex(void* arkode_mem, suncountertype step_index)
   return (ARK_SUCCESS);
 }
 
+int ARKodeSetUseCompensatedSums(void* arkode_mem, sunbooleantype onoff)
+{
+  ARKodeMem ark_mem;
+  if (arkode_mem == NULL)
+  {
+    arkProcessError(NULL, ARK_MEM_NULL, __LINE__, __func__, __FILE__,
+                    MSG_ARK_NO_MEM);
+    return (ARK_MEM_NULL);
+  }
+  ark_mem = (ARKodeMem)arkode_mem;
+
+  ark_mem->use_compensated_sums = onoff;
+
+  /* Call stepper routine (if provided) */
+  if (ark_mem->step_getnumrhsevals)
+  {
+    return ark_mem->step_setusecompensatedsums(arkode_mem, onoff);
+  }
+  else
+  {
+    arkProcessError(ark_mem, ARK_STEPPER_UNSUPPORTED, __LINE__, __func__,
+                    __FILE__,
+                    "time-stepping module does not support this function");
+    return ARK_STEPPER_UNSUPPORTED;
+  }
+
+  return (ARK_SUCCESS);
+}
+
 /*===============================================================
   ARKODE optional output utility functions
   ===============================================================*/

--- a/src/arkode/arkode_io.c
+++ b/src/arkode/arkode_io.c
@@ -2223,13 +2223,6 @@ int ARKodeSetUseCompensatedSums(void* arkode_mem, sunbooleantype onoff)
   {
     return ark_mem->step_setusecompensatedsums(arkode_mem, onoff);
   }
-  else
-  {
-    arkProcessError(ark_mem, ARK_STEPPER_UNSUPPORTED, __LINE__, __func__,
-                    __FILE__,
-                    "time-stepping module does not support this function");
-    return ARK_STEPPER_UNSUPPORTED;
-  }
 
   return (ARK_SUCCESS);
 }

--- a/src/arkode/arkode_io.c
+++ b/src/arkode/arkode_io.c
@@ -2219,7 +2219,7 @@ int ARKodeSetUseCompensatedSums(void* arkode_mem, sunbooleantype onoff)
   ark_mem->use_compensated_sums = onoff;
 
   /* Call stepper routine (if provided) */
-  if (ark_mem->step_getnumrhsevals)
+  if (ark_mem->step_setusecompensatedsums)
   {
     return ark_mem->step_setusecompensatedsums(arkode_mem, onoff);
   }

--- a/src/arkode/arkode_mristep.c
+++ b/src/arkode/arkode_mristep.c
@@ -104,6 +104,7 @@ void* MRIStepCreate(ARKRhsFn fse, ARKRhsFn fsi, sunrealtype t0, N_Vector y0,
   ark_mem->step_setuserdata               = mriStep_SetUserData;
   ark_mem->step_printallstats             = mriStep_PrintAllStats;
   ark_mem->step_writeparameters           = mriStep_WriteParameters;
+  ark_mem->step_setusecompensatedsums     = NULL;
   ark_mem->step_resize                    = mriStep_Resize;
   ark_mem->step_reset                     = mriStep_Reset;
   ark_mem->step_free                      = mriStep_Free;

--- a/src/arkode/arkode_sprkstep.c
+++ b/src/arkode/arkode_sprkstep.c
@@ -108,17 +108,18 @@ void* SPRKStepCreate(ARKRhsFn f1, ARKRhsFn f2, sunrealtype t0, N_Vector y0,
     N_VConst(ZERO, step_mem->yerr);
   }
   else { step_mem->yerr = NULL; }
-  ark_mem->step_init            = sprkStep_Init;
-  ark_mem->step_fullrhs         = sprkStep_FullRHS;
-  ark_mem->step                 = sprkStep_TakeStep;
-  ark_mem->step_printallstats   = sprkStep_PrintAllStats;
-  ark_mem->step_writeparameters = sprkStep_WriteParameters;
-  ark_mem->step_resize          = sprkStep_Resize;
-  ark_mem->step_free            = sprkStep_Free;
-  ark_mem->step_setdefaults     = sprkStep_SetDefaults;
-  ark_mem->step_setorder        = sprkStep_SetOrder;
-  ark_mem->step_getnumrhsevals  = sprkStep_GetNumRhsEvals;
-  ark_mem->step_mem             = (void*)step_mem;
+  ark_mem->step_init                  = sprkStep_Init;
+  ark_mem->step_fullrhs               = sprkStep_FullRHS;
+  ark_mem->step                       = sprkStep_TakeStep;
+  ark_mem->step_printallstats         = sprkStep_PrintAllStats;
+  ark_mem->step_writeparameters       = sprkStep_WriteParameters;
+  ark_mem->step_setusecompensatedsums = sprkStep_SetUseCompensatedSums;
+  ark_mem->step_resize                = sprkStep_Resize;
+  ark_mem->step_free                  = sprkStep_Free;
+  ark_mem->step_setdefaults           = sprkStep_SetDefaults;
+  ark_mem->step_setorder              = sprkStep_SetOrder;
+  ark_mem->step_getnumrhsevals        = sprkStep_GetNumRhsEvals;
+  ark_mem->step_mem                   = (void*)step_mem;
 
   /* Set default values for optional inputs */
   retval = sprkStep_SetDefaults((void*)ark_mem);

--- a/src/arkode/arkode_sprkstep_impl.h
+++ b/src/arkode/arkode_sprkstep_impl.h
@@ -78,6 +78,7 @@ int sprkStep_SetDefaults(ARKodeMem ark_mem);
 int sprkStep_SetOrder(ARKodeMem ark_mem, int ord);
 int sprkStep_PrintAllStats(ARKodeMem ark_mem, FILE* outfile, SUNOutputFormat fmt);
 int sprkStep_WriteParameters(ARKodeMem ark_mem, FILE* fp);
+int sprkStep_SetUseCompensatedSums(ARKodeMem ark_mem, sunbooleantype onoff);
 int sprkStep_Reset(ARKodeMem ark_mem, sunrealtype tR, N_Vector yR);
 int sprkStep_Resize(ARKodeMem ark_mem, N_Vector y0, sunrealtype hscale,
                     sunrealtype t0, ARKVecResizeFn resize, void* resize_data);

--- a/src/arkode/arkode_sprkstep_io.c
+++ b/src/arkode/arkode_sprkstep_io.c
@@ -49,14 +49,8 @@ int SPRKStepSetUseCompensatedSums(void* arkode_mem, sunbooleantype onoff)
                                         &step_mem);
   if (retval != ARK_SUCCESS) { return (retval); }
 
-  if (onoff)
-  {
-    ark_mem->use_compensated_sums = SUNTRUE;
-  }
-  else
-  {
-    ark_mem->use_compensated_sums = SUNFALSE;
-  }
+  if (onoff) { ark_mem->use_compensated_sums = SUNTRUE; }
+  else { ark_mem->use_compensated_sums = SUNFALSE; }
 
   retval = sprkStep_SetUseCompensatedSums(arkode_mem, onoff);
 

--- a/src/arkode/arkode_sprkstep_io.c
+++ b/src/arkode/arkode_sprkstep_io.c
@@ -27,6 +27,7 @@
 #include "arkode/arkode.h"
 #include "arkode/arkode_sprk.h"
 #include "arkode_sprkstep_impl.h"
+#include "arkode_types_impl.h"
 
 /*===============================================================
   Exported optional input functions.
@@ -51,22 +52,13 @@ int SPRKStepSetUseCompensatedSums(void* arkode_mem, sunbooleantype onoff)
   if (onoff)
   {
     ark_mem->use_compensated_sums = SUNTRUE;
-    ark_mem->step                 = sprkStep_TakeStep_Compensated;
-    if (!step_mem->yerr)
-    {
-      if (!arkAllocVec(ark_mem, ark_mem->yn, &(step_mem->yerr)))
-      {
-        return ARK_MEM_FAIL;
-      }
-      /* Zero yerr for compensated summation */
-      N_VConst(ZERO, step_mem->yerr);
-    }
   }
   else
   {
     ark_mem->use_compensated_sums = SUNFALSE;
-    ark_mem->step                 = sprkStep_TakeStep;
   }
+
+  sprkStep_SetUseCompensatedSums(arkode_mem, onoff);
 
   return (retval);
 }
@@ -293,6 +285,33 @@ int sprkStep_WriteParameters(ARKodeMem ark_mem, FILE* fp)
   fprintf(fp, "  Method stages %i\n", step_mem->method->stages);
 
   return (ARK_SUCCESS);
+}
+
+int sprkStep_SetUseCompensatedSums(ARKodeMem ark_mem, sunbooleantype onoff)
+{
+  ARKodeSPRKStepMem step_mem = NULL;
+  int retval                 = 0;
+
+  /* access ARKodeSPRKStepMem structure */
+  retval = sprkStep_AccessStepMem(ark_mem, __func__, &step_mem);
+  if (retval != ARK_SUCCESS) { return (retval); }
+
+  if (onoff)
+  {
+    ark_mem->step = sprkStep_TakeStep_Compensated;
+    if (!step_mem->yerr)
+    {
+      if (!arkAllocVec(ark_mem, ark_mem->yn, &(step_mem->yerr)))
+      {
+        return ARK_MEM_FAIL;
+      }
+      /* Zero yerr for compensated summation */
+      N_VConst(ZERO, step_mem->yerr);
+    }
+  }
+  else { ark_mem->step = sprkStep_TakeStep; }
+
+  return (retval);
 }
 
 /*===============================================================

--- a/src/arkode/arkode_sprkstep_io.c
+++ b/src/arkode/arkode_sprkstep_io.c
@@ -58,7 +58,7 @@ int SPRKStepSetUseCompensatedSums(void* arkode_mem, sunbooleantype onoff)
     ark_mem->use_compensated_sums = SUNFALSE;
   }
 
-  sprkStep_SetUseCompensatedSums(arkode_mem, onoff);
+  retval = sprkStep_SetUseCompensatedSums(arkode_mem, onoff);
 
   return (retval);
 }

--- a/src/arkode/fmod_int32/farkode_mod.c
+++ b/src/arkode/fmod_int32/farkode_mod.c
@@ -1209,6 +1209,20 @@ SWIGEXPORT int _wrap_FARKodeSetAdjointCheckpointIndex(void *farg1, long const *f
 }
 
 
+SWIGEXPORT int _wrap_FARKodeSetUseCompensatedSums(void *farg1, int const *farg2) {
+  int fresult ;
+  void *arg1 = (void *) 0 ;
+  int arg2 ;
+  int result;
+  
+  arg1 = (void *)(farg1);
+  arg2 = (int)(*farg2);
+  result = (int)ARKodeSetUseCompensatedSums(arg1,arg2);
+  fresult = (int)(result);
+  return fresult;
+}
+
+
 SWIGEXPORT int _wrap_FARKodeSetAccumulatedErrorType(void *farg1, int const *farg2) {
   int fresult ;
   void *arg1 = (void *) 0 ;

--- a/src/arkode/fmod_int32/farkode_mod.f90
+++ b/src/arkode/fmod_int32/farkode_mod.f90
@@ -185,6 +185,7 @@ module farkode_mod
  public :: FARKodeSetMaxNumConstrFails
  public :: FARKodeSetAdjointCheckpointScheme
  public :: FARKodeSetAdjointCheckpointIndex
+ public :: FARKodeSetUseCompensatedSums
  public :: FARKodeSetAccumulatedErrorType
  public :: FARKodeResetAccumulatedError
  public :: FARKodeEvolve
@@ -1059,6 +1060,15 @@ result(fresult)
 use, intrinsic :: ISO_C_BINDING
 type(C_PTR), value :: farg1
 integer(C_LONG), intent(in) :: farg2
+integer(C_INT) :: fresult
+end function
+
+function swigc_FARKodeSetUseCompensatedSums(farg1, farg2) &
+bind(C, name="_wrap_FARKodeSetUseCompensatedSums") &
+result(fresult)
+use, intrinsic :: ISO_C_BINDING
+type(C_PTR), value :: farg1
+integer(C_INT), intent(in) :: farg2
 integer(C_INT) :: fresult
 end function
 
@@ -3541,6 +3551,22 @@ integer(C_LONG) :: farg2
 farg1 = arkode_mem
 farg2 = step_index
 fresult = swigc_FARKodeSetAdjointCheckpointIndex(farg1, farg2)
+swig_result = fresult
+end function
+
+function FARKodeSetUseCompensatedSums(arkode_mem, onoff) &
+result(swig_result)
+use, intrinsic :: ISO_C_BINDING
+integer(C_INT) :: swig_result
+type(C_PTR) :: arkode_mem
+integer(C_INT), intent(in) :: onoff
+integer(C_INT) :: fresult 
+type(C_PTR) :: farg1 
+integer(C_INT) :: farg2 
+
+farg1 = arkode_mem
+farg2 = onoff
+fresult = swigc_FARKodeSetUseCompensatedSums(farg1, farg2)
 swig_result = fresult
 end function
 

--- a/src/arkode/fmod_int64/farkode_mod.c
+++ b/src/arkode/fmod_int64/farkode_mod.c
@@ -1209,6 +1209,20 @@ SWIGEXPORT int _wrap_FARKodeSetAdjointCheckpointIndex(void *farg1, long const *f
 }
 
 
+SWIGEXPORT int _wrap_FARKodeSetUseCompensatedSums(void *farg1, int const *farg2) {
+  int fresult ;
+  void *arg1 = (void *) 0 ;
+  int arg2 ;
+  int result;
+  
+  arg1 = (void *)(farg1);
+  arg2 = (int)(*farg2);
+  result = (int)ARKodeSetUseCompensatedSums(arg1,arg2);
+  fresult = (int)(result);
+  return fresult;
+}
+
+
 SWIGEXPORT int _wrap_FARKodeSetAccumulatedErrorType(void *farg1, int const *farg2) {
   int fresult ;
   void *arg1 = (void *) 0 ;

--- a/src/arkode/fmod_int64/farkode_mod.f90
+++ b/src/arkode/fmod_int64/farkode_mod.f90
@@ -185,6 +185,7 @@ module farkode_mod
  public :: FARKodeSetMaxNumConstrFails
  public :: FARKodeSetAdjointCheckpointScheme
  public :: FARKodeSetAdjointCheckpointIndex
+ public :: FARKodeSetUseCompensatedSums
  public :: FARKodeSetAccumulatedErrorType
  public :: FARKodeResetAccumulatedError
  public :: FARKodeEvolve
@@ -1059,6 +1060,15 @@ result(fresult)
 use, intrinsic :: ISO_C_BINDING
 type(C_PTR), value :: farg1
 integer(C_LONG), intent(in) :: farg2
+integer(C_INT) :: fresult
+end function
+
+function swigc_FARKodeSetUseCompensatedSums(farg1, farg2) &
+bind(C, name="_wrap_FARKodeSetUseCompensatedSums") &
+result(fresult)
+use, intrinsic :: ISO_C_BINDING
+type(C_PTR), value :: farg1
+integer(C_INT), intent(in) :: farg2
 integer(C_INT) :: fresult
 end function
 
@@ -3541,6 +3551,22 @@ integer(C_LONG) :: farg2
 farg1 = arkode_mem
 farg2 = step_index
 fresult = swigc_FARKodeSetAdjointCheckpointIndex(farg1, farg2)
+swig_result = fresult
+end function
+
+function FARKodeSetUseCompensatedSums(arkode_mem, onoff) &
+result(swig_result)
+use, intrinsic :: ISO_C_BINDING
+integer(C_INT) :: swig_result
+type(C_PTR) :: arkode_mem
+integer(C_INT), intent(in) :: onoff
+integer(C_INT) :: fresult 
+type(C_PTR) :: farg1 
+integer(C_INT) :: farg2 
+
+farg1 = arkode_mem
+farg2 = onoff
+fresult = swigc_FARKodeSetUseCompensatedSums(farg1, farg2)
 swig_result = fresult
 end function
 

--- a/src/sundials/sundials_adjointstepper.c
+++ b/src/sundials/sundials_adjointstepper.c
@@ -99,8 +99,11 @@ SUNErrCode SUNAdjointStepper_RecomputeFwd(SUNAdjointStepper self,
 
   SUNCheckCall(SUNStepper_SetStopTime(fwd_stepper, tf));
 
+  suncountertype nst_before, nst_after;
+  SUNCheckCall(SUNStepper_GetNumSteps(fwd_stepper, &nst_before));
   SUNCheckCall(SUNStepper_Evolve(fwd_stepper, tf, y0, &fwd_t));
-  self->nrecompute++;
+  SUNCheckCall(SUNStepper_GetNumSteps(fwd_stepper, &nst_after));
+  self->nrecompute += nst_after - nst_before;
 
   SUNCheckCall(SUNAdjointCheckpointScheme_EnableDense(self->checkpoint_scheme, 0));
 
@@ -148,7 +151,7 @@ SUNErrCode SUNAdjointStepper_PrintAllStats(SUNAdjointStepper self,
   suncountertype nst = 0;
   SUNCheckCall(SUNStepper_GetNumSteps(self->adj_sunstepper, &nst));
   sunfprintf_long(outfile, fmt, SUNTRUE, "Num backwards steps", nst);
-  sunfprintf_long(outfile, fmt, SUNFALSE, "Num recompute passes",
+  sunfprintf_long(outfile, fmt, SUNFALSE, "Num recompute steps",
                   self->nrecompute);
 
   return SUN_SUCCESS;

--- a/test/unit_tests/arkode/CXX_serial/ark_test_adjoint_ark_--check-freq_1.out
+++ b/test/unit_tests/arkode/CXX_serial/ark_test_adjoint_ark_--check-freq_1.out
@@ -46,7 +46,7 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 0
+Num recompute steps           = 0
 
 
 -- Redo adjoint problem using VJP --
@@ -61,7 +61,7 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 0
+Num recompute steps           = 0
 
 
 -- Redo adjoint problem with change of variables tau = -t  --
@@ -108,5 +108,5 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 0
+Num recompute steps           = 0
 

--- a/test/unit_tests/arkode/CXX_serial/ark_test_adjoint_ark_--check-freq_1_--dont-keep.out
+++ b/test/unit_tests/arkode/CXX_serial/ark_test_adjoint_ark_--check-freq_1_--dont-keep.out
@@ -46,7 +46,7 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 0
+Num recompute steps           = 0
 
 
 -- Redo adjoint problem using VJP --
@@ -86,7 +86,7 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 0
+Num recompute steps           = 0
 
 
 -- Redo adjoint problem with change of variables tau = -t  --
@@ -133,5 +133,5 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 0
+Num recompute steps           = 0
 

--- a/test/unit_tests/arkode/CXX_serial/ark_test_adjoint_ark_--check-freq_2.out
+++ b/test/unit_tests/arkode/CXX_serial/ark_test_adjoint_ark_--check-freq_2.out
@@ -46,7 +46,7 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 5000
+Num recompute steps           = 5000
 
 
 -- Redo adjoint problem using VJP --
@@ -61,7 +61,7 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 0
+Num recompute steps           = 0
 
 
 -- Redo adjoint problem with change of variables tau = -t  --
@@ -108,5 +108,5 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 5000
+Num recompute steps           = 5000
 

--- a/test/unit_tests/arkode/CXX_serial/ark_test_adjoint_ark_--check-freq_2_--dont-keep.out
+++ b/test/unit_tests/arkode/CXX_serial/ark_test_adjoint_ark_--check-freq_2_--dont-keep.out
@@ -46,7 +46,7 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 5000
+Num recompute steps           = 5000
 
 
 -- Redo adjoint problem using VJP --
@@ -86,7 +86,7 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 5000
+Num recompute steps           = 5000
 
 
 -- Redo adjoint problem with change of variables tau = -t  --
@@ -133,5 +133,5 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 5000
+Num recompute steps           = 5000
 

--- a/test/unit_tests/arkode/CXX_serial/ark_test_adjoint_ark_--check-freq_5.out
+++ b/test/unit_tests/arkode/CXX_serial/ark_test_adjoint_ark_--check-freq_5.out
@@ -46,7 +46,7 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 2000
+Num recompute steps           = 8000
 
 
 -- Redo adjoint problem using VJP --
@@ -61,7 +61,7 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 0
+Num recompute steps           = 0
 
 
 -- Redo adjoint problem with change of variables tau = -t  --
@@ -108,5 +108,5 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 2000
+Num recompute steps           = 8000
 

--- a/test/unit_tests/arkode/CXX_serial/ark_test_adjoint_ark_--check-freq_5_--dont-keep.out
+++ b/test/unit_tests/arkode/CXX_serial/ark_test_adjoint_ark_--check-freq_5_--dont-keep.out
@@ -46,7 +46,7 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 2000
+Num recompute steps           = 8000
 
 
 -- Redo adjoint problem using VJP --
@@ -86,7 +86,7 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 2000
+Num recompute steps           = 8000
 
 
 -- Redo adjoint problem with change of variables tau = -t  --
@@ -133,5 +133,5 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 2000
+Num recompute steps           = 8000
 

--- a/test/unit_tests/arkode/CXX_serial/ark_test_adjoint_erk_--check-freq_1.out
+++ b/test/unit_tests/arkode/CXX_serial/ark_test_adjoint_erk_--check-freq_1.out
@@ -41,7 +41,7 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 0
+Num recompute steps           = 0
 
 
 -- Redo adjoint problem using VJP --
@@ -56,7 +56,7 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 0
+Num recompute steps           = 0
 
 
 -- Redo adjoint problem with change of variables tau = -t  --
@@ -98,5 +98,5 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 0
+Num recompute steps           = 0
 

--- a/test/unit_tests/arkode/CXX_serial/ark_test_adjoint_erk_--check-freq_1_--dont-keep.out
+++ b/test/unit_tests/arkode/CXX_serial/ark_test_adjoint_erk_--check-freq_1_--dont-keep.out
@@ -41,7 +41,7 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 0
+Num recompute steps           = 0
 
 
 -- Redo adjoint problem using VJP --
@@ -76,7 +76,7 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 0
+Num recompute steps           = 0
 
 
 -- Redo adjoint problem with change of variables tau = -t  --
@@ -118,5 +118,5 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 0
+Num recompute steps           = 0
 

--- a/test/unit_tests/arkode/CXX_serial/ark_test_adjoint_erk_--check-freq_2.out
+++ b/test/unit_tests/arkode/CXX_serial/ark_test_adjoint_erk_--check-freq_2.out
@@ -41,7 +41,7 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 5000
+Num recompute steps           = 5000
 
 
 -- Redo adjoint problem using VJP --
@@ -56,7 +56,7 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 0
+Num recompute steps           = 0
 
 
 -- Redo adjoint problem with change of variables tau = -t  --
@@ -98,5 +98,5 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 5000
+Num recompute steps           = 5000
 

--- a/test/unit_tests/arkode/CXX_serial/ark_test_adjoint_erk_--check-freq_2_--dont-keep.out
+++ b/test/unit_tests/arkode/CXX_serial/ark_test_adjoint_erk_--check-freq_2_--dont-keep.out
@@ -41,7 +41,7 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 5000
+Num recompute steps           = 5000
 
 
 -- Redo adjoint problem using VJP --
@@ -76,7 +76,7 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 5000
+Num recompute steps           = 5000
 
 
 -- Redo adjoint problem with change of variables tau = -t  --
@@ -118,5 +118,5 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 5000
+Num recompute steps           = 5000
 

--- a/test/unit_tests/arkode/CXX_serial/ark_test_adjoint_erk_--check-freq_5.out
+++ b/test/unit_tests/arkode/CXX_serial/ark_test_adjoint_erk_--check-freq_5.out
@@ -41,7 +41,7 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 2000
+Num recompute steps           = 8000
 
 
 -- Redo adjoint problem using VJP --
@@ -56,7 +56,7 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 0
+Num recompute steps           = 0
 
 
 -- Redo adjoint problem with change of variables tau = -t  --
@@ -98,5 +98,5 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 2000
+Num recompute steps           = 8000
 

--- a/test/unit_tests/arkode/CXX_serial/ark_test_adjoint_erk_--check-freq_5_--dont-keep.out
+++ b/test/unit_tests/arkode/CXX_serial/ark_test_adjoint_erk_--check-freq_5_--dont-keep.out
@@ -41,7 +41,7 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 2000
+Num recompute steps           = 8000
 
 
 -- Redo adjoint problem using VJP --
@@ -76,7 +76,7 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 2000
+Num recompute steps           = 8000
 
 
 -- Redo adjoint problem with change of variables tau = -t  --
@@ -118,5 +118,5 @@ Adjoint Solution:
 
 SUNAdjointStepper Stats:
 Num backwards steps           = 10001
-Num recompute passes          = 2000
+Num recompute steps           = 8000
 


### PR DESCRIPTION
This PR enables us to use compensated summation of `tcur` in any of the ARKODE modules and fixes the "nrecomputes" accumulator in the `SUNAdjointStepper`. 
