### PR TITLE
update gitlab ci spack version and ginkgo version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,7 +64,7 @@ variables:
 # Used in script/gitlab/build_and_test.sh script.
 # TODO: add a clean-up mechanism.
   BUILD_ROOT: ${CI_PROJECT_DIR}
-  SPACK_REF: "594a376c521cc746978571b1181a47bbcff30a21" # v0.22.2
+  SPACK_REF: "1f55b591715496b15d58b43605ce8657d722fe7d" # v0.22.4
 
 ##### SHARED_CI CONFIGURATION
 # Required information about GitHub repository

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -48,8 +48,8 @@ tioga_rocmcc_571_tpls:
         AMDGPU_TARGET: [gfx90a]
   variables:
     ON_TIOGA: "OFF" # disable until we can figure out libpgmath.so error
-    # have to use ginkgo@master because our spack version does not have ginkgo@1.8.0: yet (which seems to be needed)
-    SPEC: "%${COMPILER_SPEC} cstd=99 cxxstd=14 precision=double amdgpu_target=${AMDGPU_TARGET} +rocm+mpi+magma+ginkgo+kokkos ^magma+rocm amdgpu_target=${AMDGPU_TARGET} ^ginkgo@master+rocm amdgpu_target=${AMDGPU_TARGET} ^kokkos+rocm amdgpu_target=${AMDGPU_TARGET}"
+    # have to use ginkgo because our spack version does not have ginkgo@1.8.0: yet (which seems to be needed)
+    SPEC: "%${COMPILER_SPEC} cstd=99 cxxstd=14 precision=double amdgpu_target=${AMDGPU_TARGET} +rocm+mpi+magma+ginkgo+kokkos ^magma+rocm amdgpu_target=${AMDGPU_TARGET} ^ginkgo+rocm amdgpu_target=${AMDGPU_TARGET} ^kokkos+rocm amdgpu_target=${AMDGPU_TARGET}"
   before_script:
     - module load rocmcc/5.7.1-magic
   extends: [.sundials_job_on_tioga]
@@ -60,9 +60,9 @@ tioga_rocmcc_620_tpls:
       - COMPILER_SPEC: rocmcc@6.2.0
         AMDGPU_TARGET: [gfx90a]
   variables:
-    # have to use ginkgo@master because our spack version does not have ginkgo@1.8.0: yet (which seems to be needed)
+    # have to use ginkgo because our spack version does not have ginkgo@1.8.0: yet (which seems to be needed)
     # similarly, we need a newer magma than available to compile with 'rocm@6:' so we turn it off
-    SPEC: "%${COMPILER_SPEC} cstd=99 cxxstd=14 precision=double amdgpu_target=${AMDGPU_TARGET} +rocm+mpi~magma+ginkgo+kokkos ^ginkgo@master+rocm amdgpu_target=${AMDGPU_TARGET} ^kokkos+rocm amdgpu_target=${AMDGPU_TARGET}"
+    SPEC: "%${COMPILER_SPEC} cstd=99 cxxstd=14 precision=double amdgpu_target=${AMDGPU_TARGET} +rocm+mpi~magma+ginkgo+kokkos ^ginkgo+rocm amdgpu_target=${AMDGPU_TARGET} ^kokkos+rocm amdgpu_target=${AMDGPU_TARGET}"
   before_script:
     - module load rocmcc/6.2.0-magic
   extends: [.sundials_job_on_tioga]

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -48,7 +48,6 @@ tioga_rocmcc_571_tpls:
         AMDGPU_TARGET: [gfx90a]
   variables:
     ON_TIOGA: "OFF" # disable until we can figure out libpgmath.so error
-    # have to use ginkgo because our spack version does not have ginkgo@1.8.0: yet (which seems to be needed)
     SPEC: "%${COMPILER_SPEC} cstd=99 cxxstd=14 precision=double amdgpu_target=${AMDGPU_TARGET} +rocm+mpi+magma+ginkgo+kokkos ^magma+rocm amdgpu_target=${AMDGPU_TARGET} ^ginkgo+rocm amdgpu_target=${AMDGPU_TARGET} ^kokkos+rocm amdgpu_target=${AMDGPU_TARGET}"
   before_script:
     - module load rocmcc/5.7.1-magic
@@ -60,8 +59,7 @@ tioga_rocmcc_620_tpls:
       - COMPILER_SPEC: rocmcc@6.2.0
         AMDGPU_TARGET: [gfx90a]
   variables:
-    # have to use ginkgo because our spack version does not have ginkgo@1.8.0: yet (which seems to be needed)
-    # similarly, we need a newer magma than available to compile with 'rocm@6:' so we turn it off
+    # we need a newer magma than available to compile with 'rocm@6:' so we turn it off
     SPEC: "%${COMPILER_SPEC} cstd=99 cxxstd=14 precision=double amdgpu_target=${AMDGPU_TARGET} +rocm+mpi~magma+ginkgo+kokkos ^ginkgo+rocm amdgpu_target=${AMDGPU_TARGET} ^kokkos+rocm amdgpu_target=${AMDGPU_TARGET}"
   before_script:
     - module load rocmcc/6.2.0-magic

--- a/scripts/spack/packages/sundials/package.py
+++ b/scripts/spack/packages/sundials/package.py
@@ -221,7 +221,7 @@ class Sundials(CachedCMakePackage, CudaPackage, ROCmPackage):
     # External libraries
     depends_on("adiak", when="+adiak")
     depends_on("caliper", when="+caliper")
-    depends_on("ginkgo@1.5.0:", when="+ginkgo")
+    depends_on("ginkgo@1.9.0:", when="+ginkgo")
     depends_on("kokkos", when="+kokkos")
     depends_on("kokkos-kernels", when="+kokkos-kernels")
     for cuda_arch in CudaPackage.cuda_arch_values:


### PR DESCRIPTION
This updates spack version used in our GitLab CI testing so that we can use a newer version of Ginkgo. 