### PR TITLE
Use long specifier instead of long int

### DIFF
--- a/include/arkode/arkode.h
+++ b/include/arkode/arkode.h
@@ -250,7 +250,7 @@ SUNDIALS_EXPORT int ARKodeSetDefaults(void* arkode_mem);
 SUNDIALS_EXPORT int ARKodeSetOrder(void* arkode_mem, int maxord);
 SUNDIALS_EXPORT int ARKodeSetInterpolantType(void* arkode_mem, int itype);
 SUNDIALS_EXPORT int ARKodeSetInterpolantDegree(void* arkode_mem, int degree);
-SUNDIALS_EXPORT int ARKodeSetMaxNumSteps(void* arkode_mem, long int mxsteps);
+SUNDIALS_EXPORT int ARKodeSetMaxNumSteps(void* arkode_mem, long mxsteps);
 SUNDIALS_EXPORT int ARKodeSetInterpolateStopTime(void* arkode_mem,
                                                  sunbooleantype interp);
 SUNDIALS_EXPORT int ARKodeSetStopTime(void* arkode_mem, sunrealtype tstop);
@@ -336,103 +336,90 @@ SUNDIALS_EXPORT int ARKodeComputeState(void* arkode_mem, N_Vector zcor,
 
 /* Optional output functions (general) */
 SUNDIALS_EXPORT int ARKodeGetNumRhsEvals(void* arkode_mem, int partition_index,
-                                         long int* num_rhs_evals);
+                                         long* num_rhs_evals);
 SUNDIALS_EXPORT int ARKodeGetNumStepAttempts(void* arkode_mem,
-                                             long int* step_attempts);
+                                             long* step_attempts);
 
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int ARKodeGetWorkSpace(void* arkode_mem, long int* lenrw, long int* leniw);
-SUNDIALS_EXPORT int ARKodeGetNumSteps(void* arkode_mem, long int* nsteps);
+int ARKodeGetWorkSpace(void* arkode_mem, long* lenrw, long* leniw);
+SUNDIALS_EXPORT int ARKodeGetNumSteps(void* arkode_mem, long* nsteps);
 SUNDIALS_EXPORT int ARKodeGetLastStep(void* arkode_mem, sunrealtype* hlast);
 SUNDIALS_EXPORT int ARKodeGetCurrentStep(void* arkode_mem, sunrealtype* hcur);
 SUNDIALS_EXPORT int ARKodeGetStepDirection(void* arkode_mem,
                                            sunrealtype* stepdir);
 SUNDIALS_EXPORT int ARKodeGetErrWeights(void* arkode_mem, N_Vector eweight);
-SUNDIALS_EXPORT int ARKodeGetNumGEvals(void* arkode_mem, long int* ngevals);
+SUNDIALS_EXPORT int ARKodeGetNumGEvals(void* arkode_mem, long* ngevals);
 SUNDIALS_EXPORT int ARKodeGetRootInfo(void* arkode_mem, int* rootsfound);
 SUNDIALS_EXPORT int ARKodeGetUserData(void* arkode_mem, void** user_data);
 SUNDIALS_EXPORT int ARKodePrintAllStats(void* arkode_mem, FILE* outfile,
                                         SUNOutputFormat fmt);
-SUNDIALS_EXPORT char* ARKodeGetReturnFlagName(long int flag);
+SUNDIALS_EXPORT char* ARKodeGetReturnFlagName(long flag);
 SUNDIALS_EXPORT int ARKodeWriteParameters(void* arkode_mem, FILE* fp);
 
 /* Optional output functions (temporal adaptivity) */
-SUNDIALS_EXPORT int ARKodeGetNumExpSteps(void* arkode_mem, long int* expsteps);
-SUNDIALS_EXPORT int ARKodeGetNumAccSteps(void* arkode_mem, long int* accsteps);
-SUNDIALS_EXPORT int ARKodeGetNumErrTestFails(void* arkode_mem,
-                                             long int* netfails);
+SUNDIALS_EXPORT int ARKodeGetNumExpSteps(void* arkode_mem, long* expsteps);
+SUNDIALS_EXPORT int ARKodeGetNumAccSteps(void* arkode_mem, long* accsteps);
+SUNDIALS_EXPORT int ARKodeGetNumErrTestFails(void* arkode_mem, long* netfails);
 SUNDIALS_EXPORT int ARKodeGetEstLocalErrors(void* arkode_mem, N_Vector ele);
 SUNDIALS_EXPORT int ARKodeGetActualInitStep(void* arkode_mem,
                                             sunrealtype* hinused);
 SUNDIALS_EXPORT int ARKodeGetTolScaleFactor(void* arkode_mem,
                                             sunrealtype* tolsfac);
-SUNDIALS_EXPORT int ARKodeGetNumConstrFails(void* arkode_mem,
-                                            long int* nconstrfails);
-SUNDIALS_EXPORT int ARKodeGetStepStats(void* arkode_mem, long int* nsteps,
+SUNDIALS_EXPORT int ARKodeGetNumConstrFails(void* arkode_mem, long* nconstrfails);
+SUNDIALS_EXPORT int ARKodeGetStepStats(void* arkode_mem, long* nsteps,
                                        sunrealtype* hinused, sunrealtype* hlast,
                                        sunrealtype* hcur, sunrealtype* tcur);
 SUNDIALS_EXPORT int ARKodeGetAccumulatedError(void* arkode_mem,
                                               sunrealtype* accum_error);
 
 /* Optional output functions (implicit solver) */
-SUNDIALS_EXPORT int ARKodeGetNumLinSolvSetups(void* arkode_mem,
-                                              long int* nlinsetups);
+SUNDIALS_EXPORT int ARKodeGetNumLinSolvSetups(void* arkode_mem, long* nlinsetups);
 SUNDIALS_EXPORT int ARKodeGetCurrentTime(void* arkode_mem, sunrealtype* tcur);
 SUNDIALS_EXPORT int ARKodeGetCurrentState(void* arkode_mem, N_Vector* state);
 SUNDIALS_EXPORT int ARKodeGetCurrentGamma(void* arkode_mem, sunrealtype* gamma);
 SUNDIALS_EXPORT int ARKodeGetNonlinearSystemData(
   void* arkode_mem, sunrealtype* tcur, N_Vector* zpred, N_Vector* z,
   N_Vector* Fi, sunrealtype* gamma, N_Vector* sdata, void** user_data);
-SUNDIALS_EXPORT int ARKodeGetNumNonlinSolvIters(void* arkode_mem,
-                                                long int* nniters);
+SUNDIALS_EXPORT int ARKodeGetNumNonlinSolvIters(void* arkode_mem, long* nniters);
 SUNDIALS_EXPORT int ARKodeGetNumNonlinSolvConvFails(void* arkode_mem,
-                                                    long int* nnfails);
-SUNDIALS_EXPORT int ARKodeGetNonlinSolvStats(void* arkode_mem, long int* nniters,
-                                             long int* nnfails);
-SUNDIALS_EXPORT int ARKodeGetNumStepSolveFails(void* arkode_mem,
-                                               long int* nncfails);
+                                                    long* nnfails);
+SUNDIALS_EXPORT int ARKodeGetNonlinSolvStats(void* arkode_mem, long* nniters,
+                                             long* nnfails);
+SUNDIALS_EXPORT int ARKodeGetNumStepSolveFails(void* arkode_mem, long* nncfails);
 SUNDIALS_EXPORT int ARKodeGetJac(void* arkode_mem, SUNMatrix* J);
 SUNDIALS_EXPORT int ARKodeGetJacTime(void* arkode_mem, sunrealtype* t_J);
-SUNDIALS_EXPORT int ARKodeGetJacNumSteps(void* arkode_mem, long int* nst_J);
+SUNDIALS_EXPORT int ARKodeGetJacNumSteps(void* arkode_mem, long* nst_J);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int ARKodeGetLinWorkSpace(void* arkode_mem, long int* lenrwLS, long int* leniwLS);
-SUNDIALS_EXPORT int ARKodeGetNumJacEvals(void* arkode_mem, long int* njevals);
-SUNDIALS_EXPORT int ARKodeGetNumPrecEvals(void* arkode_mem, long int* npevals);
-SUNDIALS_EXPORT int ARKodeGetNumPrecSolves(void* arkode_mem, long int* npsolves);
-SUNDIALS_EXPORT int ARKodeGetNumLinIters(void* arkode_mem, long int* nliters);
-SUNDIALS_EXPORT int ARKodeGetNumLinConvFails(void* arkode_mem,
-                                             long int* nlcfails);
-SUNDIALS_EXPORT int ARKodeGetNumJTSetupEvals(void* arkode_mem,
-                                             long int* njtsetups);
-SUNDIALS_EXPORT int ARKodeGetNumJtimesEvals(void* arkode_mem, long int* njvevals);
-SUNDIALS_EXPORT int ARKodeGetNumLinRhsEvals(void* arkode_mem,
-                                            long int* nfevalsLS);
-SUNDIALS_EXPORT int ARKodeGetLastLinFlag(void* arkode_mem, long int* flag);
-SUNDIALS_EXPORT char* ARKodeGetLinReturnFlagName(long int flag);
+int ARKodeGetLinWorkSpace(void* arkode_mem, long* lenrwLS, long* leniwLS);
+SUNDIALS_EXPORT int ARKodeGetNumJacEvals(void* arkode_mem, long* njevals);
+SUNDIALS_EXPORT int ARKodeGetNumPrecEvals(void* arkode_mem, long* npevals);
+SUNDIALS_EXPORT int ARKodeGetNumPrecSolves(void* arkode_mem, long* npsolves);
+SUNDIALS_EXPORT int ARKodeGetNumLinIters(void* arkode_mem, long* nliters);
+SUNDIALS_EXPORT int ARKodeGetNumLinConvFails(void* arkode_mem, long* nlcfails);
+SUNDIALS_EXPORT int ARKodeGetNumJTSetupEvals(void* arkode_mem, long* njtsetups);
+SUNDIALS_EXPORT int ARKodeGetNumJtimesEvals(void* arkode_mem, long* njvevals);
+SUNDIALS_EXPORT int ARKodeGetNumLinRhsEvals(void* arkode_mem, long* nfevalsLS);
+SUNDIALS_EXPORT int ARKodeGetLastLinFlag(void* arkode_mem, long* flag);
+SUNDIALS_EXPORT char* ARKodeGetLinReturnFlagName(long flag);
 
 /* Optional output functions (non-identity mass matrices) */
 SUNDIALS_EXPORT int ARKodeGetCurrentMassMatrix(void* arkode_mem, SUNMatrix* M);
 SUNDIALS_EXPORT int ARKodeGetResWeights(void* arkode_mem, N_Vector rweight);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int ARKodeGetMassWorkSpace(void* arkode_mem, long int* lenrwMLS,
-                           long int* leniwMLS);
-SUNDIALS_EXPORT int ARKodeGetNumMassSetups(void* arkode_mem, long int* nmsetups);
-SUNDIALS_EXPORT int ARKodeGetNumMassMultSetups(void* arkode_mem,
-                                               long int* nmvsetups);
-SUNDIALS_EXPORT int ARKodeGetNumMassMult(void* arkode_mem, long int* nmvevals);
-SUNDIALS_EXPORT int ARKodeGetNumMassSolves(void* arkode_mem, long int* nmsolves);
-SUNDIALS_EXPORT int ARKodeGetNumMassPrecEvals(void* arkode_mem,
-                                              long int* nmpevals);
-SUNDIALS_EXPORT int ARKodeGetNumMassPrecSolves(void* arkode_mem,
-                                               long int* nmpsolves);
-SUNDIALS_EXPORT int ARKodeGetNumMassIters(void* arkode_mem, long int* nmiters);
-SUNDIALS_EXPORT int ARKodeGetNumMassConvFails(void* arkode_mem,
-                                              long int* nmcfails);
-SUNDIALS_EXPORT int ARKodeGetNumMTSetups(void* arkode_mem, long int* nmtsetups);
-SUNDIALS_EXPORT int ARKodeGetLastMassFlag(void* arkode_mem, long int* flag);
+int ARKodeGetMassWorkSpace(void* arkode_mem, long* lenrwMLS, long* leniwMLS);
+SUNDIALS_EXPORT int ARKodeGetNumMassSetups(void* arkode_mem, long* nmsetups);
+SUNDIALS_EXPORT int ARKodeGetNumMassMultSetups(void* arkode_mem, long* nmvsetups);
+SUNDIALS_EXPORT int ARKodeGetNumMassMult(void* arkode_mem, long* nmvevals);
+SUNDIALS_EXPORT int ARKodeGetNumMassSolves(void* arkode_mem, long* nmsolves);
+SUNDIALS_EXPORT int ARKodeGetNumMassPrecEvals(void* arkode_mem, long* nmpevals);
+SUNDIALS_EXPORT int ARKodeGetNumMassPrecSolves(void* arkode_mem, long* nmpsolves);
+SUNDIALS_EXPORT int ARKodeGetNumMassIters(void* arkode_mem, long* nmiters);
+SUNDIALS_EXPORT int ARKodeGetNumMassConvFails(void* arkode_mem, long* nmcfails);
+SUNDIALS_EXPORT int ARKodeGetNumMTSetups(void* arkode_mem, long* nmtsetups);
+SUNDIALS_EXPORT int ARKodeGetLastMassFlag(void* arkode_mem, long* flag);
 
 /* Free function */
 SUNDIALS_EXPORT void ARKodeFree(void** arkode_mem);
@@ -452,17 +439,12 @@ SUNDIALS_EXPORT int ARKodeSetRelaxResTol(void* arkode_mem, sunrealtype res_tol);
 SUNDIALS_EXPORT int ARKodeSetRelaxTol(void* arkode_mem, sunrealtype rel_tol,
                                       sunrealtype abs_tol);
 SUNDIALS_EXPORT int ARKodeSetRelaxUpperBound(void* arkode_mem, sunrealtype upper);
-SUNDIALS_EXPORT int ARKodeGetNumRelaxFnEvals(void* arkode_mem, long int* r_evals);
-SUNDIALS_EXPORT int ARKodeGetNumRelaxJacEvals(void* arkode_mem,
-                                              long int* J_evals);
-SUNDIALS_EXPORT int ARKodeGetNumRelaxFails(void* arkode_mem,
-                                           long int* relax_fails);
-SUNDIALS_EXPORT int ARKodeGetNumRelaxBoundFails(void* arkode_mem,
-                                                long int* fails);
-SUNDIALS_EXPORT int ARKodeGetNumRelaxSolveFails(void* arkode_mem,
-                                                long int* fails);
-SUNDIALS_EXPORT int ARKodeGetNumRelaxSolveIters(void* arkode_mem,
-                                                long int* iters);
+SUNDIALS_EXPORT int ARKodeGetNumRelaxFnEvals(void* arkode_mem, long* r_evals);
+SUNDIALS_EXPORT int ARKodeGetNumRelaxJacEvals(void* arkode_mem, long* J_evals);
+SUNDIALS_EXPORT int ARKodeGetNumRelaxFails(void* arkode_mem, long* relax_fails);
+SUNDIALS_EXPORT int ARKodeGetNumRelaxBoundFails(void* arkode_mem, long* fails);
+SUNDIALS_EXPORT int ARKodeGetNumRelaxSolveFails(void* arkode_mem, long* fails);
+SUNDIALS_EXPORT int ARKodeGetNumRelaxSolveIters(void* arkode_mem, long* iters);
 
 /* SUNStepper functions */
 SUNDIALS_EXPORT int ARKodeCreateSUNStepper(void* arkode_mem, SUNStepper* stepper);

--- a/include/arkode/arkode_arkstep.h
+++ b/include/arkode/arkode_arkstep.h
@@ -95,10 +95,11 @@ SUNDIALS_EXPORT int ARKStepSetTableName(void* arkode_mem, const char* itable,
 SUNDIALS_EXPORT int ARKStepGetCurrentButcherTables(void* arkode_mem,
                                                    ARKodeButcherTable* Bi,
                                                    ARKodeButcherTable* Be);
-SUNDIALS_EXPORT int ARKStepGetTimestepperStats(
-  void* arkode_mem, long int* expsteps, long int* accsteps,
-  long int* step_attempts, long int* nfe_evals, long int* nfi_evals,
-  long int* nlinsetups, long int* netfails);
+SUNDIALS_EXPORT int ARKStepGetTimestepperStats(void* arkode_mem, long* expsteps,
+                                               long* accsteps,
+                                               long* step_attempts,
+                                               long* nfe_evals, long* nfi_evals,
+                                               long* nlinsetups, long* netfails);
 
 /* --------------------------------------------------------------------------
  * Deprecated Functions -- all are superseded by shared ARKODE-level routines
@@ -205,7 +206,7 @@ int ARKStepSetNonlinConvCoef(void* arkode_mem, sunrealtype nlscoef);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetConstraints instead")
 int ARKStepSetConstraints(void* arkode_mem, N_Vector constraints);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetMaxNumSteps instead")
-int ARKStepSetMaxNumSteps(void* arkode_mem, long int mxsteps);
+int ARKStepSetMaxNumSteps(void* arkode_mem, long mxsteps);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetMaxHnilWarns instead")
 int ARKStepSetMaxHnilWarns(void* arkode_mem, int mxhnil);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetInitStep instead")
@@ -241,7 +242,7 @@ int ARKStepSetJacFn(void* arkode_mem, ARKLsJacFn jac);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetMassFn instead")
 int ARKStepSetMassFn(void* arkode_mem, ARKLsMassFn mass);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetJacEvalFrequency instead")
-int ARKStepSetJacEvalFrequency(void* arkode_mem, long int msbj);
+int ARKStepSetJacEvalFrequency(void* arkode_mem, long msbj);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetLinearSolutionScaling instead")
 int ARKStepSetLinearSolutionScaling(void* arkode_mem, sunbooleantype onoff);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetEpsLin instead")
@@ -276,22 +277,22 @@ int ARKStepGetDky(void* arkode_mem, sunrealtype t, int k, N_Vector dky);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeComputeState instead")
 int ARKStepComputeState(void* arkode_mem, N_Vector zcor, N_Vector z);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumExpSteps instead")
-int ARKStepGetNumExpSteps(void* arkode_mem, long int* expsteps);
+int ARKStepGetNumExpSteps(void* arkode_mem, long* expsteps);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumAccSteps instead")
-int ARKStepGetNumAccSteps(void* arkode_mem, long int* accsteps);
+int ARKStepGetNumAccSteps(void* arkode_mem, long* accsteps);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumStepAttempts instead")
-int ARKStepGetNumStepAttempts(void* arkode_mem, long int* step_attempts);
+int ARKStepGetNumStepAttempts(void* arkode_mem, long* step_attempts);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumLinSolvSetups instead")
-int ARKStepGetNumLinSolvSetups(void* arkode_mem, long int* nlinsetups);
+int ARKStepGetNumLinSolvSetups(void* arkode_mem, long* nlinsetups);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumErrTestFails instead")
-int ARKStepGetNumErrTestFails(void* arkode_mem, long int* netfails);
+int ARKStepGetNumErrTestFails(void* arkode_mem, long* netfails);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetEstLocalErrors instead")
 int ARKStepGetEstLocalErrors(void* arkode_mem, N_Vector ele);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int ARKStepGetWorkSpace(void* arkode_mem, long int* lenrw, long int* leniw);
+int ARKStepGetWorkSpace(void* arkode_mem, long* lenrw, long* leniw);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumSteps instead")
-int ARKStepGetNumSteps(void* arkode_mem, long int* nsteps);
+int ARKStepGetNumSteps(void* arkode_mem, long* nsteps);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetActualInitStep instead")
 int ARKStepGetActualInitStep(void* arkode_mem, sunrealtype* hinused);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetLastStep instead")
@@ -313,24 +314,24 @@ int ARKStepGetErrWeights(void* arkode_mem, N_Vector eweight);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetResWeights instead")
 int ARKStepGetResWeights(void* arkode_mem, N_Vector rweight);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumGEvals instead")
-int ARKStepGetNumGEvals(void* arkode_mem, long int* ngevals);
+int ARKStepGetNumGEvals(void* arkode_mem, long* ngevals);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetRootInfo instead")
 int ARKStepGetRootInfo(void* arkode_mem, int* rootsfound);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumConstrFails instead")
-int ARKStepGetNumConstrFails(void* arkode_mem, long int* nconstrfails);
+int ARKStepGetNumConstrFails(void* arkode_mem, long* nconstrfails);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetUserData instead")
 int ARKStepGetUserData(void* arkode_mem, void** user_data);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodePrintAllStats instead")
 int ARKStepPrintAllStats(void* arkode_mem, FILE* outfile, SUNOutputFormat fmt);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetReturnFlagName instead")
-char* ARKStepGetReturnFlagName(long int flag);
+char* ARKStepGetReturnFlagName(long flag);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeWriteParameters instead")
 int ARKStepWriteParameters(void* arkode_mem, FILE* fp);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "use ARKStepGetCurrentButcherTables and ARKodeButcherTable_Write instead")
 int ARKStepWriteButcher(void* arkode_mem, FILE* fp);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetStepStats instead")
-int ARKStepGetStepStats(void* arkode_mem, long int* nsteps, sunrealtype* hinused,
+int ARKStepGetStepStats(void* arkode_mem, long* nsteps, sunrealtype* hinused,
                         sunrealtype* hlast, sunrealtype* hcur, sunrealtype* tcur);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNonlinearSystemData instead")
 int ARKStepGetNonlinearSystemData(void* arkode_mem, sunrealtype* tcur,
@@ -338,69 +339,66 @@ int ARKStepGetNonlinearSystemData(void* arkode_mem, sunrealtype* tcur,
                                   sunrealtype* gamma, N_Vector* sdata,
                                   void** user_data);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumNonlinSolvIters instead")
-int ARKStepGetNumNonlinSolvIters(void* arkode_mem, long int* nniters);
+int ARKStepGetNumNonlinSolvIters(void* arkode_mem, long* nniters);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumNonlinSolvConvFails instead")
-int ARKStepGetNumNonlinSolvConvFails(void* arkode_mem, long int* nnfails);
+int ARKStepGetNumNonlinSolvConvFails(void* arkode_mem, long* nnfails);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNonlinSolvStats instead")
-int ARKStepGetNonlinSolvStats(void* arkode_mem, long int* nniters,
-                              long int* nnfails);
+int ARKStepGetNonlinSolvStats(void* arkode_mem, long* nniters, long* nnfails);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumStepSolveFails instead")
-int ARKStepGetNumStepSolveFails(void* arkode_mem, long int* nncfails);
+int ARKStepGetNumStepSolveFails(void* arkode_mem, long* nncfails);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetJac instead")
 int ARKStepGetJac(void* arkode_mem, SUNMatrix* J);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetJacTime instead")
 int ARKStepGetJacTime(void* arkode_mem, sunrealtype* t_J);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetJacNumSteps instead")
-int ARKStepGetJacNumSteps(void* arkode_mem, long int* nst_J);
+int ARKStepGetJacNumSteps(void* arkode_mem, long* nst_J);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int ARKStepGetLinWorkSpace(void* arkode_mem, long int* lenrwLS,
-                           long int* leniwLS);
+int ARKStepGetLinWorkSpace(void* arkode_mem, long* lenrwLS, long* leniwLS);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumJacEvals instead")
-int ARKStepGetNumJacEvals(void* arkode_mem, long int* njevals);
+int ARKStepGetNumJacEvals(void* arkode_mem, long* njevals);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumPrecEvals instead")
-int ARKStepGetNumPrecEvals(void* arkode_mem, long int* npevals);
+int ARKStepGetNumPrecEvals(void* arkode_mem, long* npevals);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumPrecSolves instead")
-int ARKStepGetNumPrecSolves(void* arkode_mem, long int* npsolves);
+int ARKStepGetNumPrecSolves(void* arkode_mem, long* npsolves);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumLinIters instead")
-int ARKStepGetNumLinIters(void* arkode_mem, long int* nliters);
+int ARKStepGetNumLinIters(void* arkode_mem, long* nliters);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumLinConvFails instead")
-int ARKStepGetNumLinConvFails(void* arkode_mem, long int* nlcfails);
+int ARKStepGetNumLinConvFails(void* arkode_mem, long* nlcfails);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumJTSetupEvals instead")
-int ARKStepGetNumJTSetupEvals(void* arkode_mem, long int* njtsetups);
+int ARKStepGetNumJTSetupEvals(void* arkode_mem, long* njtsetups);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumJtimesEvals instead")
-int ARKStepGetNumJtimesEvals(void* arkode_mem, long int* njvevals);
+int ARKStepGetNumJtimesEvals(void* arkode_mem, long* njvevals);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumLinRhsEvals instead")
-int ARKStepGetNumLinRhsEvals(void* arkode_mem, long int* nfevalsLS);
+int ARKStepGetNumLinRhsEvals(void* arkode_mem, long* nfevalsLS);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetLastLinFlag instead")
-int ARKStepGetLastLinFlag(void* arkode_mem, long int* flag);
+int ARKStepGetLastLinFlag(void* arkode_mem, long* flag);
 
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int ARKStepGetMassWorkSpace(void* arkode_mem, long int* lenrwMLS,
-                            long int* leniwMLS);
+int ARKStepGetMassWorkSpace(void* arkode_mem, long* lenrwMLS, long* leniwMLS);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumMassSetups instead")
-int ARKStepGetNumMassSetups(void* arkode_mem, long int* nmsetups);
+int ARKStepGetNumMassSetups(void* arkode_mem, long* nmsetups);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumMassMultSetups instead")
-int ARKStepGetNumMassMultSetups(void* arkode_mem, long int* nmvsetups);
+int ARKStepGetNumMassMultSetups(void* arkode_mem, long* nmvsetups);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumMassMult instead")
-int ARKStepGetNumMassMult(void* arkode_mem, long int* nmvevals);
+int ARKStepGetNumMassMult(void* arkode_mem, long* nmvevals);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumMassSolves instead")
-int ARKStepGetNumMassSolves(void* arkode_mem, long int* nmsolves);
+int ARKStepGetNumMassSolves(void* arkode_mem, long* nmsolves);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumMassPrecEvals instead")
-int ARKStepGetNumMassPrecEvals(void* arkode_mem, long int* nmpevals);
+int ARKStepGetNumMassPrecEvals(void* arkode_mem, long* nmpevals);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumMassPrecSolves instead")
-int ARKStepGetNumMassPrecSolves(void* arkode_mem, long int* nmpsolves);
+int ARKStepGetNumMassPrecSolves(void* arkode_mem, long* nmpsolves);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumMassIters instead")
-int ARKStepGetNumMassIters(void* arkode_mem, long int* nmiters);
+int ARKStepGetNumMassIters(void* arkode_mem, long* nmiters);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumMassConvFails instead")
-int ARKStepGetNumMassConvFails(void* arkode_mem, long int* nmcfails);
+int ARKStepGetNumMassConvFails(void* arkode_mem, long* nmcfails);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumMTSetups instead")
-int ARKStepGetNumMTSetups(void* arkode_mem, long int* nmtsetups);
+int ARKStepGetNumMTSetups(void* arkode_mem, long* nmtsetups);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetLastMassFlag instead")
-int ARKStepGetLastMassFlag(void* arkode_mem, long int* flag);
+int ARKStepGetLastMassFlag(void* arkode_mem, long* flag);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetLinReturnFlagName instead")
-char* ARKStepGetLinReturnFlagName(long int flag);
+char* ARKStepGetLinReturnFlagName(long flag);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeFree instead")
 void ARKStepFree(void** arkode_mem);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodePrintMem instead")
@@ -434,20 +432,19 @@ int ARKStepSetRelaxTol(void* arkode_mem, sunrealtype rel_tol,
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetRelaxUpperBound instead")
 int ARKStepSetRelaxUpperBound(void* arkode_mem, sunrealtype upper);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumRelaxFnEvals instead")
-int ARKStepGetNumRelaxFnEvals(void* arkode_mem, long int* r_evals);
+int ARKStepGetNumRelaxFnEvals(void* arkode_mem, long* r_evals);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumRelaxJacEvals instead")
-int ARKStepGetNumRelaxJacEvals(void* arkode_mem, long int* J_evals);
+int ARKStepGetNumRelaxJacEvals(void* arkode_mem, long* J_evals);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumRelaxFails instead")
-int ARKStepGetNumRelaxFails(void* arkode_mem, long int* relax_fails);
+int ARKStepGetNumRelaxFails(void* arkode_mem, long* relax_fails);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumRelaxBoundFails instead")
-int ARKStepGetNumRelaxBoundFails(void* arkode_mem, long int* fails);
+int ARKStepGetNumRelaxBoundFails(void* arkode_mem, long* fails);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumRelaxSolveFails instead")
-int ARKStepGetNumRelaxSolveFails(void* arkode_mem, long int* fails);
+int ARKStepGetNumRelaxSolveFails(void* arkode_mem, long* fails);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumRelaxSolveIters instead")
-int ARKStepGetNumRelaxSolveIters(void* arkode_mem, long int* iters);
+int ARKStepGetNumRelaxSolveIters(void* arkode_mem, long* iters);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumRhsEvals instead")
-int ARKStepGetNumRhsEvals(void* arkode_mem, long int* nfe_evals,
-                          long int* nfi_evals);
+int ARKStepGetNumRhsEvals(void* arkode_mem, long* nfe_evals, long* nfi_evals);
 #ifdef __cplusplus
 }
 #endif

--- a/include/arkode/arkode_bandpre.h
+++ b/include/arkode/arkode_bandpre.h
@@ -32,10 +32,8 @@ SUNDIALS_EXPORT int ARKBandPrecInit(void* arkode_mem, sunindextype N,
 /* Optional output functions */
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int ARKBandPrecGetWorkSpace(void* arkode_mem, long int* lenrwLS,
-                            long int* leniwLS);
-SUNDIALS_EXPORT int ARKBandPrecGetNumRhsEvals(void* arkode_mem,
-                                              long int* nfevalsBP);
+int ARKBandPrecGetWorkSpace(void* arkode_mem, long* lenrwLS, long* leniwLS);
+SUNDIALS_EXPORT int ARKBandPrecGetNumRhsEvals(void* arkode_mem, long* nfevalsBP);
 
 #ifdef __cplusplus
 }

--- a/include/arkode/arkode_bbdpre.h
+++ b/include/arkode/arkode_bbdpre.h
@@ -48,11 +48,9 @@ SUNDIALS_EXPORT int ARKBBDPrecReInit(void* arkode_mem, sunindextype mudq,
 
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int ARKBBDPrecGetWorkSpace(void* arkode_mem, long int* lenrwBBDP,
-                           long int* leniwBBDP);
+int ARKBBDPrecGetWorkSpace(void* arkode_mem, long* lenrwBBDP, long* leniwBBDP);
 
-SUNDIALS_EXPORT int ARKBBDPrecGetNumGfnEvals(void* arkode_mem,
-                                             long int* ngevalsBBDP);
+SUNDIALS_EXPORT int ARKBBDPrecGetNumGfnEvals(void* arkode_mem, long* ngevalsBBDP);
 
 #ifdef __cplusplus
 }

--- a/include/arkode/arkode_erkstep.h
+++ b/include/arkode/arkode_erkstep.h
@@ -65,9 +65,10 @@ SUNDIALS_EXPORT int ERKStepGetCurrentButcherTable(void* arkode_mem,
                                                   ARKodeButcherTable* B);
 
 /* Grouped optional output functions */
-SUNDIALS_EXPORT int ERKStepGetTimestepperStats(
-  void* arkode_mem, long int* expsteps, long int* accsteps,
-  long int* step_attempts, long int* nfevals, long int* netfails);
+SUNDIALS_EXPORT int ERKStepGetTimestepperStats(void* arkode_mem, long* expsteps,
+                                               long* accsteps,
+                                               long* step_attempts,
+                                               long* nfevals, long* netfails);
 
 /* Adjoint solver functions */
 SUNDIALS_EXPORT
@@ -136,7 +137,7 @@ int ERKStepSetMaxErrTestFails(void* arkode_mem, int maxnef);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetConstraints instead")
 int ERKStepSetConstraints(void* arkode_mem, N_Vector constraints);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetMaxNumSteps instead")
-int ERKStepSetMaxNumSteps(void* arkode_mem, long int mxsteps);
+int ERKStepSetMaxNumSteps(void* arkode_mem, long mxsteps);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetMaxHnilWarns instead")
 int ERKStepSetMaxHnilWarns(void* arkode_mem, int mxhnil);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetInitStep instead")
@@ -171,20 +172,20 @@ int ERKStepEvolve(void* arkode_mem, sunrealtype tout, N_Vector yout,
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetDky instead")
 int ERKStepGetDky(void* arkode_mem, sunrealtype t, int k, N_Vector dky);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumExpSteps instead")
-int ERKStepGetNumExpSteps(void* arkode_mem, long int* expsteps);
+int ERKStepGetNumExpSteps(void* arkode_mem, long* expsteps);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumAccSteps instead")
-int ERKStepGetNumAccSteps(void* arkode_mem, long int* accsteps);
+int ERKStepGetNumAccSteps(void* arkode_mem, long* accsteps);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumStepAttempts instead")
-int ERKStepGetNumStepAttempts(void* arkode_mem, long int* step_attempts);
+int ERKStepGetNumStepAttempts(void* arkode_mem, long* step_attempts);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumErrTestFails instead")
-int ERKStepGetNumErrTestFails(void* arkode_mem, long int* netfails);
+int ERKStepGetNumErrTestFails(void* arkode_mem, long* netfails);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetEstLocalErrors instead")
 int ERKStepGetEstLocalErrors(void* arkode_mem, N_Vector ele);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int ERKStepGetWorkSpace(void* arkode_mem, long int* lenrw, long int* leniw);
+int ERKStepGetWorkSpace(void* arkode_mem, long* lenrw, long* leniw);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumSteps instead")
-int ERKStepGetNumSteps(void* arkode_mem, long int* nsteps);
+int ERKStepGetNumSteps(void* arkode_mem, long* nsteps);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetActualInitStep instead")
 int ERKStepGetActualInitStep(void* arkode_mem, sunrealtype* hinused);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetLastStep instead")
@@ -198,24 +199,24 @@ int ERKStepGetTolScaleFactor(void* arkode_mem, sunrealtype* tolsfac);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetErrWeights instead")
 int ERKStepGetErrWeights(void* arkode_mem, N_Vector eweight);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumGEvals instead")
-int ERKStepGetNumGEvals(void* arkode_mem, long int* ngevals);
+int ERKStepGetNumGEvals(void* arkode_mem, long* ngevals);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetRootInfo instead")
 int ERKStepGetRootInfo(void* arkode_mem, int* rootsfound);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumConstrFails instead")
-int ERKStepGetNumConstrFails(void* arkode_mem, long int* nconstrfails);
+int ERKStepGetNumConstrFails(void* arkode_mem, long* nconstrfails);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetUserData instead")
 int ERKStepGetUserData(void* arkode_mem, void** user_data);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodePrintAllStats instead")
 int ERKStepPrintAllStats(void* arkode_mem, FILE* outfile, SUNOutputFormat fmt);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetReturnFlagName instead")
-char* ERKStepGetReturnFlagName(long int flag);
+char* ERKStepGetReturnFlagName(long flag);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeWriteParameters instead")
 int ERKStepWriteParameters(void* arkode_mem, FILE* fp);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "use ERKStepGetCurrentButcherTable and ARKodeButcherTable_Write instead")
 int ERKStepWriteButcher(void* arkode_mem, FILE* fp);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetStepStats instead")
-int ERKStepGetStepStats(void* arkode_mem, long int* nsteps, sunrealtype* hinused,
+int ERKStepGetStepStats(void* arkode_mem, long* nsteps, sunrealtype* hinused,
                         sunrealtype* hlast, sunrealtype* hcur, sunrealtype* tcur);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeFree instead")
 void ERKStepFree(void** arkode_mem);
@@ -241,19 +242,19 @@ int ERKStepSetRelaxTol(void* arkode_mem, sunrealtype rel_tol,
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetRelaxUpperBound instead")
 int ERKStepSetRelaxUpperBound(void* arkode_mem, sunrealtype upper);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumRelaxFnEvals instead")
-int ERKStepGetNumRelaxFnEvals(void* arkode_mem, long int* r_evals);
+int ERKStepGetNumRelaxFnEvals(void* arkode_mem, long* r_evals);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumRelaxJacEvals instead")
-int ERKStepGetNumRelaxJacEvals(void* arkode_mem, long int* J_evals);
+int ERKStepGetNumRelaxJacEvals(void* arkode_mem, long* J_evals);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumRelaxFails instead")
-int ERKStepGetNumRelaxFails(void* arkode_mem, long int* relax_fails);
+int ERKStepGetNumRelaxFails(void* arkode_mem, long* relax_fails);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumRelaxBoundFails instead")
-int ERKStepGetNumRelaxBoundFails(void* arkode_mem, long int* fails);
+int ERKStepGetNumRelaxBoundFails(void* arkode_mem, long* fails);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumRelaxSolveFails instead")
-int ERKStepGetNumRelaxSolveFails(void* arkode_mem, long int* fails);
+int ERKStepGetNumRelaxSolveFails(void* arkode_mem, long* fails);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumRelaxSolveIters instead")
-int ERKStepGetNumRelaxSolveIters(void* arkode_mem, long int* iters);
+int ERKStepGetNumRelaxSolveIters(void* arkode_mem, long* iters);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumRhsEvals instead")
-int ERKStepGetNumRhsEvals(void* arkode_mem, long int* nfevals);
+int ERKStepGetNumRhsEvals(void* arkode_mem, long* nfevals);
 
 #ifdef __cplusplus
 }

--- a/include/arkode/arkode_forcingstep.h
+++ b/include/arkode/arkode_forcingstep.h
@@ -34,7 +34,7 @@ SUNDIALS_EXPORT int ForcingStepReInit(void* arkode_mem, SUNStepper stepper1,
                                       N_Vector y0);
 
 SUNDIALS_EXPORT int ForcingStepGetNumEvolves(void* arkode_mem, int partition,
-                                             long int* evolves);
+                                             long* evolves);
 
 #ifdef __cplusplus
 }

--- a/include/arkode/arkode_ls.h
+++ b/include/arkode/arkode_ls.h
@@ -98,7 +98,7 @@ SUNDIALS_EXPORT int ARKodeSetMassLinearSolver(void* arkode_mem,
    AFTER ARKodeSetLinearSolver and/or ARKodeSetMassLinearSolver */
 SUNDIALS_EXPORT int ARKodeSetJacFn(void* arkode_mem, ARKLsJacFn jac);
 SUNDIALS_EXPORT int ARKodeSetMassFn(void* arkode_mem, ARKLsMassFn mass);
-SUNDIALS_EXPORT int ARKodeSetJacEvalFrequency(void* arkode_mem, long int msbj);
+SUNDIALS_EXPORT int ARKodeSetJacEvalFrequency(void* arkode_mem, long msbj);
 SUNDIALS_EXPORT int ARKodeSetLinearSolutionScaling(void* arkode_mem,
                                                    sunbooleantype onoff);
 SUNDIALS_EXPORT int ARKodeSetEpsLin(void* arkode_mem, sunrealtype eplifac);

--- a/include/arkode/arkode_lsrkstep.h
+++ b/include/arkode/arkode_lsrkstep.h
@@ -75,7 +75,7 @@ SUNDIALS_EXPORT int LSRKStepSetSSPMethodByName(void* arkode_mem,
 
 SUNDIALS_EXPORT int LSRKStepSetDomEigFn(void* arkode_mem, ARKDomEigFn dom_eig);
 
-SUNDIALS_EXPORT int LSRKStepSetDomEigFrequency(void* arkode_mem, long int nsteps);
+SUNDIALS_EXPORT int LSRKStepSetDomEigFrequency(void* arkode_mem, long nsteps);
 
 SUNDIALS_EXPORT int LSRKStepSetMaxNumStages(void* arkode_mem,
                                             int stage_max_limit);
@@ -88,7 +88,7 @@ SUNDIALS_EXPORT int LSRKStepSetNumSSPStages(void* arkode_mem, int num_of_stages)
 /* Optional output functions */
 
 SUNDIALS_EXPORT int LSRKStepGetNumDomEigUpdates(void* arkode_mem,
-                                                long int* dom_eig_num_evals);
+                                                long* dom_eig_num_evals);
 
 SUNDIALS_EXPORT int LSRKStepGetMaxNumStages(void* arkode_mem, int* stage_max);
 

--- a/include/arkode/arkode_mristep.h
+++ b/include/arkode/arkode_mristep.h
@@ -198,7 +198,7 @@ SUNDIALS_EXPORT int MRIStepGetCurrentCoupling(void* arkode_mem,
                                               MRIStepCoupling* MRIC);
 SUNDIALS_EXPORT int MRIStepGetLastInnerStepFlag(void* arkode_mem, int* flag);
 SUNDIALS_EXPORT int MRIStepGetNumInnerStepperFails(void* arkode_mem,
-                                                   long int* inner_fails);
+                                                   long* inner_fails);
 
 /* Custom inner stepper functions */
 SUNDIALS_EXPORT int MRIStepInnerStepper_Create(SUNContext sunctx,
@@ -268,7 +268,7 @@ int MRIStepSetLinear(void* arkode_mem, int timedepend);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetNonlinear instead")
 int MRIStepSetNonlinear(void* arkode_mem);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetMaxNumSteps instead")
-int MRIStepSetMaxNumSteps(void* arkode_mem, long int mxsteps);
+int MRIStepSetMaxNumSteps(void* arkode_mem, long mxsteps);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetNonlinCRDown instead")
 int MRIStepSetNonlinCRDown(void* arkode_mem, sunrealtype crdown);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetNonlinRDiv instead")
@@ -310,7 +310,7 @@ int MRIStepSetDeduceImplicitRhs(void* arkode_mem, sunbooleantype deduce);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetJacFn instead")
 int MRIStepSetJacFn(void* arkode_mem, ARKLsJacFn jac);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetJacEvalFrequency instead")
-int MRIStepSetJacEvalFrequency(void* arkode_mem, long int msbj);
+int MRIStepSetJacEvalFrequency(void* arkode_mem, long msbj);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetLinearSolutionScaling instead")
 int MRIStepSetLinearSolutionScaling(void* arkode_mem, sunbooleantype onoff);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetEpsLin instead")
@@ -335,12 +335,12 @@ int MRIStepGetDky(void* arkode_mem, sunrealtype t, int k, N_Vector dky);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeComputeState instead")
 int MRIStepComputeState(void* arkode_mem, N_Vector zcor, N_Vector z);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumLinSolvSetups instead")
-int MRIStepGetNumLinSolvSetups(void* arkode_mem, long int* nlinsetups);
+int MRIStepGetNumLinSolvSetups(void* arkode_mem, long* nlinsetups);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int MRIStepGetWorkSpace(void* arkode_mem, long int* lenrw, long int* leniw);
+int MRIStepGetWorkSpace(void* arkode_mem, long* lenrw, long* leniw);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumSteps instead")
-int MRIStepGetNumSteps(void* arkode_mem, long int* nssteps);
+int MRIStepGetNumSteps(void* arkode_mem, long* nssteps);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetLastStep instead")
 int MRIStepGetLastStep(void* arkode_mem, sunrealtype* hlast);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetCurrentTime instead")
@@ -354,7 +354,7 @@ int MRIStepGetTolScaleFactor(void* arkode_mem, sunrealtype* tolsfac);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetErrWeights instead")
 int MRIStepGetErrWeights(void* arkode_mem, N_Vector eweight);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumGEvals instead")
-int MRIStepGetNumGEvals(void* arkode_mem, long int* ngevals);
+int MRIStepGetNumGEvals(void* arkode_mem, long* ngevals);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetRootInfo instead")
 int MRIStepGetRootInfo(void* arkode_mem, int* rootsfound);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetUserData instead")
@@ -362,7 +362,7 @@ int MRIStepGetUserData(void* arkode_mem, void** user_data);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodePrintAllStats instead")
 int MRIStepPrintAllStats(void* arkode_mem, FILE* outfile, SUNOutputFormat fmt);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetReturnFlagName instead")
-char* MRIStepGetReturnFlagName(long int flag);
+char* MRIStepGetReturnFlagName(long flag);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeWriteParameters instead")
 int MRIStepWriteParameters(void* arkode_mem, FILE* fp);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
@@ -374,14 +374,13 @@ int MRIStepGetNonlinearSystemData(void* arkode_mem, sunrealtype* tcur,
                                   sunrealtype* gamma, N_Vector* sdata,
                                   void** user_data);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumNonlinSolvIters instead")
-int MRIStepGetNumNonlinSolvIters(void* arkode_mem, long int* nniters);
+int MRIStepGetNumNonlinSolvIters(void* arkode_mem, long* nniters);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumNonlinSolvConvFails instead")
-int MRIStepGetNumNonlinSolvConvFails(void* arkode_mem, long int* nnfails);
+int MRIStepGetNumNonlinSolvConvFails(void* arkode_mem, long* nnfails);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNonlinSolvStats instead")
-int MRIStepGetNonlinSolvStats(void* arkode_mem, long int* nniters,
-                              long int* nnfails);
+int MRIStepGetNonlinSolvStats(void* arkode_mem, long* nniters, long* nnfails);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumStepSolveFails instead")
-int MRIStepGetNumStepSolveFails(void* arkode_mem, long int* nncfails);
+int MRIStepGetNumStepSolveFails(void* arkode_mem, long* nncfails);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetJac instead")
 int MRIStepGetJac(void* arkode_mem, SUNMatrix* J);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetJacTime instead")
@@ -390,35 +389,33 @@ SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetJacNumSteps instead")
 int MRIStepGetJacNumSteps(void* arkode_mem, long* nst_J);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int MRIStepGetLinWorkSpace(void* arkode_mem, long int* lenrwLS,
-                           long int* leniwLS);
+int MRIStepGetLinWorkSpace(void* arkode_mem, long* lenrwLS, long* leniwLS);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumJacEvals instead")
-int MRIStepGetNumJacEvals(void* arkode_mem, long int* njevals);
+int MRIStepGetNumJacEvals(void* arkode_mem, long* njevals);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumPrecEvals instead")
-int MRIStepGetNumPrecEvals(void* arkode_mem, long int* npevals);
+int MRIStepGetNumPrecEvals(void* arkode_mem, long* npevals);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumPrecSolves instead")
-int MRIStepGetNumPrecSolves(void* arkode_mem, long int* npsolves);
+int MRIStepGetNumPrecSolves(void* arkode_mem, long* npsolves);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumLinIters instead")
-int MRIStepGetNumLinIters(void* arkode_mem, long int* nliters);
+int MRIStepGetNumLinIters(void* arkode_mem, long* nliters);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumLinConvFails instead")
-int MRIStepGetNumLinConvFails(void* arkode_mem, long int* nlcfails);
+int MRIStepGetNumLinConvFails(void* arkode_mem, long* nlcfails);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumJTSetupEvals instead")
-int MRIStepGetNumJTSetupEvals(void* arkode_mem, long int* njtsetups);
+int MRIStepGetNumJTSetupEvals(void* arkode_mem, long* njtsetups);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumJtimesEvals instead")
-int MRIStepGetNumJtimesEvals(void* arkode_mem, long int* njvevals);
+int MRIStepGetNumJtimesEvals(void* arkode_mem, long* njvevals);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumLinRhsEvals instead")
-int MRIStepGetNumLinRhsEvals(void* arkode_mem, long int* nfevalsLS);
+int MRIStepGetNumLinRhsEvals(void* arkode_mem, long* nfevalsLS);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetLastLinFlag instead")
-int MRIStepGetLastLinFlag(void* arkode_mem, long int* flag);
+int MRIStepGetLastLinFlag(void* arkode_mem, long* flag);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetLinReturnFlagName instead")
-char* MRIStepGetLinReturnFlagName(long int flag);
+char* MRIStepGetLinReturnFlagName(long flag);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeFree instead")
 void MRIStepFree(void** arkode_mem);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodePrintMem instead")
 void MRIStepPrintMem(void* arkode_mem, FILE* outfile);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumRhsEvals instead")
-int MRIStepGetNumRhsEvals(void* arkode_mem, long int* nfse_evals,
-                          long int* nfsi_evals);
+int MRIStepGetNumRhsEvals(void* arkode_mem, long* nfse_evals, long* nfsi_evals);
 
 #ifdef __cplusplus
 }

--- a/include/arkode/arkode_splittingstep.h
+++ b/include/arkode/arkode_splittingstep.h
@@ -106,7 +106,7 @@ SUNDIALS_EXPORT int SplittingStepSetCoefficients(
   void* arkode_mem, SplittingStepCoefficients coefficients);
 
 SUNDIALS_EXPORT int SplittingStepGetNumEvolves(void* arkode_mem, int partition,
-                                               long int* evolves);
+                                               long* evolves);
 
 #ifdef __cplusplus
 }

--- a/include/arkode/arkode_sprkstep.h
+++ b/include/arkode/arkode_sprkstep.h
@@ -79,7 +79,7 @@ int SPRKStepSetInterpolantType(void* arkode_mem, int itype);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetInterpolantDegree instead")
 int SPRKStepSetInterpolantDegree(void* arkode_mem, int degree);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetMaxNumSteps instead")
-int SPRKStepSetMaxNumSteps(void* arkode_mem, long int mxsteps);
+int SPRKStepSetMaxNumSteps(void* arkode_mem, long mxsteps);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetStopTime instead")
 int SPRKStepSetStopTime(void* arkode_mem, sunrealtype tstop);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeSetFixedStep instead")
@@ -97,7 +97,7 @@ int SPRKStepEvolve(void* arkode_mem, sunrealtype tout, N_Vector yout,
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetDky instead")
 int SPRKStepGetDky(void* arkode_mem, sunrealtype t, int k, N_Vector dky);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetReturnFlagName instead")
-char* SPRKStepGetReturnFlagName(long int flag);
+char* SPRKStepGetReturnFlagName(long flag);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetCurrentState instead")
 int SPRKStepGetCurrentState(void* arkode_mem, N_Vector* state);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetCurrentStep instead")
@@ -107,9 +107,9 @@ int SPRKStepGetCurrentTime(void* arkode_mem, sunrealtype* tcur);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetLastStep instead")
 int SPRKStepGetLastStep(void* arkode_mem, sunrealtype* hlast);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumStepAttempts instead")
-int SPRKStepGetNumStepAttempts(void* arkode_mem, long int* step_attempts);
+int SPRKStepGetNumStepAttempts(void* arkode_mem, long* step_attempts);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumSteps instead")
-int SPRKStepGetNumSteps(void* arkode_mem, long int* nsteps);
+int SPRKStepGetNumSteps(void* arkode_mem, long* nsteps);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetRootInfo instead")
 int SPRKStepGetRootInfo(void* arkode_mem, int* rootsfound);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetUserData instead")
@@ -119,13 +119,13 @@ int SPRKStepPrintAllStats(void* arkode_mem, FILE* outfile, SUNOutputFormat fmt);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeWriteParameters instead")
 int SPRKStepWriteParameters(void* arkode_mem, FILE* fp);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetStepStats instead")
-int SPRKStepGetStepStats(void* arkode_mem, long int* nsteps,
-                         sunrealtype* hinused, sunrealtype* hlast,
-                         sunrealtype* hcur, sunrealtype* tcur);
+int SPRKStepGetStepStats(void* arkode_mem, long* nsteps, sunrealtype* hinused,
+                         sunrealtype* hlast, sunrealtype* hcur,
+                         sunrealtype* tcur);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeFree instead")
 void SPRKStepFree(void** arkode_mem);
 SUNDIALS_DEPRECATED_EXPORT_MSG("use ARKodeGetNumRhsEvals instead")
-int SPRKStepGetNumRhsEvals(void* arkode_mem, long int* nf1, long int* nf2);
+int SPRKStepGetNumRhsEvals(void* arkode_mem, long* nf1, long* nf2);
 
 #ifdef __cplusplus
 }

--- a/include/cvode/cvode.h
+++ b/include/cvode/cvode.h
@@ -123,17 +123,17 @@ SUNDIALS_EXPORT int CVodeSetConstraints(void* cvode_mem, N_Vector constraints);
 SUNDIALS_EXPORT int CVodeSetDeltaGammaMaxLSetup(void* cvode_mem,
                                                 sunrealtype dgmax_lsetup);
 SUNDIALS_EXPORT int CVodeSetInitStep(void* cvode_mem, sunrealtype hin);
-SUNDIALS_EXPORT int CVodeSetLSetupFrequency(void* cvode_mem, long int msbp);
+SUNDIALS_EXPORT int CVodeSetLSetupFrequency(void* cvode_mem, long msbp);
 SUNDIALS_EXPORT int CVodeSetMaxConvFails(void* cvode_mem, int maxncf);
 SUNDIALS_EXPORT int CVodeSetMaxErrTestFails(void* cvode_mem, int maxnef);
 SUNDIALS_EXPORT int CVodeSetMaxHnilWarns(void* cvode_mem, int mxhnil);
 SUNDIALS_EXPORT int CVodeSetMaxNonlinIters(void* cvode_mem, int maxcor);
-SUNDIALS_EXPORT int CVodeSetMaxNumSteps(void* cvode_mem, long int mxsteps);
+SUNDIALS_EXPORT int CVodeSetMaxNumSteps(void* cvode_mem, long mxsteps);
 SUNDIALS_EXPORT int CVodeSetMaxOrd(void* cvode_mem, int maxord);
 SUNDIALS_EXPORT int CVodeSetMaxStep(void* cvode_mem, sunrealtype hmax);
 SUNDIALS_EXPORT int CVodeSetMinStep(void* cvode_mem, sunrealtype hmin);
 SUNDIALS_EXPORT int CVodeSetMonitorFn(void* cvode_mem, CVMonitorFn fn);
-SUNDIALS_EXPORT int CVodeSetMonitorFrequency(void* cvode_mem, long int nst);
+SUNDIALS_EXPORT int CVodeSetMonitorFrequency(void* cvode_mem, long nst);
 SUNDIALS_EXPORT int CVodeSetNlsRhsFn(void* cvode_mem, CVRhsFn f);
 SUNDIALS_EXPORT int CVodeSetNonlinConvCoef(void* cvode_mem, sunrealtype nlscoef);
 SUNDIALS_EXPORT int CVodeSetNonlinearSolver(void* cvode_mem,
@@ -156,7 +156,7 @@ int CVodeSetEtaMaxFirstStep(void* cvode_mem, sunrealtype eta_max_fs);
 SUNDIALS_EXPORT
 int CVodeSetEtaMaxEarlyStep(void* cvode_mem, sunrealtype eta_max_es);
 SUNDIALS_EXPORT
-int CVodeSetNumStepsEtaMaxEarlyStep(void* cvode_mem, long int small_nst);
+int CVodeSetNumStepsEtaMaxEarlyStep(void* cvode_mem, long small_nst);
 SUNDIALS_EXPORT
 int CVodeSetEtaMax(void* cvode_mem, sunrealtype eta_max_gs);
 SUNDIALS_EXPORT
@@ -191,17 +191,15 @@ SUNDIALS_EXPORT int CVodeGetDky(void* cvode_mem, sunrealtype t, int k,
 /* Optional output functions */
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int CVodeGetWorkSpace(void* cvode_mem, long int* lenrw, long int* leniw);
-SUNDIALS_EXPORT int CVodeGetNumSteps(void* cvode_mem, long int* nsteps);
-SUNDIALS_EXPORT int CVodeGetNumRhsEvals(void* cvode_mem, long int* nfevals);
-SUNDIALS_EXPORT int CVodeGetNumLinSolvSetups(void* cvode_mem,
-                                             long int* nlinsetups);
-SUNDIALS_EXPORT int CVodeGetNumErrTestFails(void* cvode_mem, long int* netfails);
+int CVodeGetWorkSpace(void* cvode_mem, long* lenrw, long* leniw);
+SUNDIALS_EXPORT int CVodeGetNumSteps(void* cvode_mem, long* nsteps);
+SUNDIALS_EXPORT int CVodeGetNumRhsEvals(void* cvode_mem, long* nfevals);
+SUNDIALS_EXPORT int CVodeGetNumLinSolvSetups(void* cvode_mem, long* nlinsetups);
+SUNDIALS_EXPORT int CVodeGetNumErrTestFails(void* cvode_mem, long* netfails);
 SUNDIALS_EXPORT int CVodeGetLastOrder(void* cvode_mem, int* qlast);
 SUNDIALS_EXPORT int CVodeGetCurrentOrder(void* cvode_mem, int* qcur);
 SUNDIALS_EXPORT int CVodeGetCurrentGamma(void* cvode_mem, sunrealtype* gamma);
-SUNDIALS_EXPORT int CVodeGetNumStabLimOrderReds(void* cvode_mem,
-                                                long int* nslred);
+SUNDIALS_EXPORT int CVodeGetNumStabLimOrderReds(void* cvode_mem, long* nslred);
 SUNDIALS_EXPORT int CVodeGetActualInitStep(void* cvode_mem, sunrealtype* hinused);
 SUNDIALS_EXPORT int CVodeGetLastStep(void* cvode_mem, sunrealtype* hlast);
 SUNDIALS_EXPORT int CVodeGetCurrentStep(void* cvode_mem, sunrealtype* hcur);
@@ -210,30 +208,30 @@ SUNDIALS_EXPORT int CVodeGetCurrentTime(void* cvode_mem, sunrealtype* tcur);
 SUNDIALS_EXPORT int CVodeGetTolScaleFactor(void* cvode_mem, sunrealtype* tolsfac);
 SUNDIALS_EXPORT int CVodeGetErrWeights(void* cvode_mem, N_Vector eweight);
 SUNDIALS_EXPORT int CVodeGetEstLocalErrors(void* cvode_mem, N_Vector ele);
-SUNDIALS_EXPORT int CVodeGetNumGEvals(void* cvode_mem, long int* ngevals);
+SUNDIALS_EXPORT int CVodeGetNumGEvals(void* cvode_mem, long* ngevals);
 SUNDIALS_EXPORT int CVodeGetRootInfo(void* cvode_mem, int* rootsfound);
-SUNDIALS_EXPORT int CVodeGetIntegratorStats(
-  void* cvode_mem, long int* nsteps, long int* nfevals, long int* nlinsetups,
-  long int* netfails, int* qlast, int* qcur, sunrealtype* hinused,
-  sunrealtype* hlast, sunrealtype* hcur, sunrealtype* tcur);
+SUNDIALS_EXPORT int CVodeGetIntegratorStats(void* cvode_mem, long* nsteps,
+                                            long* nfevals, long* nlinsetups,
+                                            long* netfails, int* qlast,
+                                            int* qcur, sunrealtype* hinused,
+                                            sunrealtype* hlast,
+                                            sunrealtype* hcur, sunrealtype* tcur);
 SUNDIALS_EXPORT int CVodeGetNonlinearSystemData(void* cvode_mem,
                                                 sunrealtype* tcur,
                                                 N_Vector* ypred, N_Vector* yn,
                                                 N_Vector* fn, sunrealtype* gamma,
                                                 sunrealtype* rl1, N_Vector* zn1,
                                                 void** user_data);
-SUNDIALS_EXPORT int CVodeGetNumNonlinSolvIters(void* cvode_mem,
-                                               long int* nniters);
+SUNDIALS_EXPORT int CVodeGetNumNonlinSolvIters(void* cvode_mem, long* nniters);
 SUNDIALS_EXPORT int CVodeGetNumNonlinSolvConvFails(void* cvode_mem,
-                                                   long int* nnfails);
-SUNDIALS_EXPORT int CVodeGetNonlinSolvStats(void* cvode_mem, long int* nniters,
-                                            long int* nnfails);
-SUNDIALS_EXPORT int CVodeGetNumStepSolveFails(void* cvode_mem,
-                                              long int* nncfails);
+                                                   long* nnfails);
+SUNDIALS_EXPORT int CVodeGetNonlinSolvStats(void* cvode_mem, long* nniters,
+                                            long* nnfails);
+SUNDIALS_EXPORT int CVodeGetNumStepSolveFails(void* cvode_mem, long* nncfails);
 SUNDIALS_EXPORT int CVodeGetUserData(void* cvode_mem, void** user_data);
 SUNDIALS_EXPORT int CVodePrintAllStats(void* cvode_mem, FILE* outfile,
                                        SUNOutputFormat fmt);
-SUNDIALS_EXPORT char* CVodeGetReturnFlagName(long int flag);
+SUNDIALS_EXPORT char* CVodeGetReturnFlagName(long flag);
 
 /* Free function */
 SUNDIALS_EXPORT void CVodeFree(void** cvode_mem);

--- a/include/cvode/cvode_bandpre.h
+++ b/include/cvode/cvode_bandpre.h
@@ -34,9 +34,8 @@ SUNDIALS_EXPORT int CVBandPrecInit(void* cvode_mem, sunindextype N,
 
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int CVBandPrecGetWorkSpace(void* cvode_mem, long int* lenrwLS, long int* leniwLS);
-SUNDIALS_EXPORT int CVBandPrecGetNumRhsEvals(void* cvode_mem,
-                                             long int* nfevalsBP);
+int CVBandPrecGetWorkSpace(void* cvode_mem, long* lenrwLS, long* leniwLS);
+SUNDIALS_EXPORT int CVBandPrecGetNumRhsEvals(void* cvode_mem, long* nfevalsBP);
 
 #ifdef __cplusplus
 }

--- a/include/cvode/cvode_bbdpre.h
+++ b/include/cvode/cvode_bbdpre.h
@@ -50,11 +50,9 @@ SUNDIALS_EXPORT int CVBBDPrecReInit(void* cvode_mem, sunindextype mudq,
 
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int CVBBDPrecGetWorkSpace(void* cvode_mem, long int* lenrwBBDP,
-                          long int* leniwBBDP);
+int CVBBDPrecGetWorkSpace(void* cvode_mem, long* lenrwBBDP, long* leniwBBDP);
 
-SUNDIALS_EXPORT int CVBBDPrecGetNumGfnEvals(void* cvode_mem,
-                                            long int* ngevalsBBDP);
+SUNDIALS_EXPORT int CVBBDPrecGetNumGfnEvals(void* cvode_mem, long* ngevalsBBDP);
 
 #ifdef __cplusplus
 }

--- a/include/cvode/cvode_diag.h
+++ b/include/cvode/cvode_diag.h
@@ -48,10 +48,10 @@ SUNDIALS_EXPORT int CVDiag(void* cvode_mem);
 
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int CVDiagGetWorkSpace(void* cvode_mem, long int* lenrwLS, long int* leniwLS);
-SUNDIALS_EXPORT int CVDiagGetNumRhsEvals(void* cvode_mem, long int* nfevalsLS);
-SUNDIALS_EXPORT int CVDiagGetLastFlag(void* cvode_mem, long int* flag);
-SUNDIALS_EXPORT char* CVDiagGetReturnFlagName(long int flag);
+int CVDiagGetWorkSpace(void* cvode_mem, long* lenrwLS, long* leniwLS);
+SUNDIALS_EXPORT int CVDiagGetNumRhsEvals(void* cvode_mem, long* nfevalsLS);
+SUNDIALS_EXPORT int CVDiagGetLastFlag(void* cvode_mem, long* flag);
+SUNDIALS_EXPORT char* CVDiagGetReturnFlagName(long flag);
 
 #ifdef __cplusplus
 }

--- a/include/cvode/cvode_ls.h
+++ b/include/cvode/cvode_ls.h
@@ -84,7 +84,7 @@ SUNDIALS_EXPORT int CVodeSetLinearSolver(void* cvode_mem, SUNLinearSolver LS,
   -----------------------------------------------------------------*/
 
 SUNDIALS_EXPORT int CVodeSetJacFn(void* cvode_mem, CVLsJacFn jac);
-SUNDIALS_EXPORT int CVodeSetJacEvalFrequency(void* cvode_mem, long int msbj);
+SUNDIALS_EXPORT int CVodeSetJacEvalFrequency(void* cvode_mem, long msbj);
 SUNDIALS_EXPORT int CVodeSetLinearSolutionScaling(void* cvode_mem,
                                                   sunbooleantype onoff);
 SUNDIALS_EXPORT int CVodeSetDeltaGammaMaxBadJac(void* cvode_mem,
@@ -103,25 +103,25 @@ SUNDIALS_EXPORT int CVodeSetLinSysFn(void* cvode_mem, CVLsLinSysFn linsys);
 
 SUNDIALS_EXPORT int CVodeGetJac(void* cvode_mem, SUNMatrix* J);
 SUNDIALS_EXPORT int CVodeGetJacTime(void* cvode_mem, sunrealtype* t_J);
-SUNDIALS_EXPORT int CVodeGetJacNumSteps(void* cvode_mem, long int* nst_J);
+SUNDIALS_EXPORT int CVodeGetJacNumSteps(void* cvode_mem, long* nst_J);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int CVodeGetLinWorkSpace(void* cvode_mem, long int* lenrwLS, long int* leniwLS);
-SUNDIALS_EXPORT int CVodeGetNumJacEvals(void* cvode_mem, long int* njevals);
-SUNDIALS_EXPORT int CVodeGetNumPrecEvals(void* cvode_mem, long int* npevals);
-SUNDIALS_EXPORT int CVodeGetNumPrecSolves(void* cvode_mem, long int* npsolves);
-SUNDIALS_EXPORT int CVodeGetNumLinIters(void* cvode_mem, long int* nliters);
-SUNDIALS_EXPORT int CVodeGetNumLinConvFails(void* cvode_mem, long int* nlcfails);
-SUNDIALS_EXPORT int CVodeGetNumJTSetupEvals(void* cvode_mem, long int* njtsetups);
-SUNDIALS_EXPORT int CVodeGetNumJtimesEvals(void* cvode_mem, long int* njvevals);
-SUNDIALS_EXPORT int CVodeGetNumLinRhsEvals(void* cvode_mem, long int* nfevalsLS);
-SUNDIALS_EXPORT int CVodeGetLinSolveStats(void* cvode_mem, long int* njevals,
-                                          long int* nfevalsLS,
-                                          long int* nliters, long int* nlcfails,
-                                          long int* npevals, long int* npsolves,
-                                          long int* njtsetups, long int* njtimes);
-SUNDIALS_EXPORT int CVodeGetLastLinFlag(void* cvode_mem, long int* flag);
-SUNDIALS_EXPORT char* CVodeGetLinReturnFlagName(long int flag);
+int CVodeGetLinWorkSpace(void* cvode_mem, long* lenrwLS, long* leniwLS);
+SUNDIALS_EXPORT int CVodeGetNumJacEvals(void* cvode_mem, long* njevals);
+SUNDIALS_EXPORT int CVodeGetNumPrecEvals(void* cvode_mem, long* npevals);
+SUNDIALS_EXPORT int CVodeGetNumPrecSolves(void* cvode_mem, long* npsolves);
+SUNDIALS_EXPORT int CVodeGetNumLinIters(void* cvode_mem, long* nliters);
+SUNDIALS_EXPORT int CVodeGetNumLinConvFails(void* cvode_mem, long* nlcfails);
+SUNDIALS_EXPORT int CVodeGetNumJTSetupEvals(void* cvode_mem, long* njtsetups);
+SUNDIALS_EXPORT int CVodeGetNumJtimesEvals(void* cvode_mem, long* njvevals);
+SUNDIALS_EXPORT int CVodeGetNumLinRhsEvals(void* cvode_mem, long* nfevalsLS);
+SUNDIALS_EXPORT int CVodeGetLinSolveStats(void* cvode_mem, long* njevals,
+                                          long* nfevalsLS, long* nliters,
+                                          long* nlcfails, long* npevals,
+                                          long* npsolves, long* njtsetups,
+                                          long* njtimes);
+SUNDIALS_EXPORT int CVodeGetLastLinFlag(void* cvode_mem, long* flag);
+SUNDIALS_EXPORT char* CVodeGetLinReturnFlagName(long flag);
 
 #ifdef __cplusplus
 }

--- a/include/cvode/cvode_proj.h
+++ b/include/cvode/cvode_proj.h
@@ -41,14 +41,14 @@ SUNDIALS_EXPORT int CVodeSetProjFn(void* cvode_mem, CVProjFn pfun);
 
 /* Optional input functions */
 SUNDIALS_EXPORT int CVodeSetProjErrEst(void* cvode_mem, sunbooleantype onoff);
-SUNDIALS_EXPORT int CVodeSetProjFrequency(void* cvode_mem, long int proj_freq);
+SUNDIALS_EXPORT int CVodeSetProjFrequency(void* cvode_mem, long proj_freq);
 SUNDIALS_EXPORT int CVodeSetMaxNumProjFails(void* cvode_mem, int max_fails);
 SUNDIALS_EXPORT int CVodeSetEpsProj(void* cvode_mem, sunrealtype eps);
 SUNDIALS_EXPORT int CVodeSetProjFailEta(void* cvode_mem, sunrealtype eta);
 
 /* Optional output functions */
-SUNDIALS_EXPORT int CVodeGetNumProjEvals(void* cvode_mem, long int* nproj);
-SUNDIALS_EXPORT int CVodeGetNumProjFails(void* cvode_mem, long int* nprf);
+SUNDIALS_EXPORT int CVodeGetNumProjEvals(void* cvode_mem, long* nproj);
+SUNDIALS_EXPORT int CVodeGetNumProjFails(void* cvode_mem, long* nprf);
 
 #ifdef __cplusplus
 }

--- a/include/cvodes/cvodes.h
+++ b/include/cvodes/cvodes.h
@@ -194,17 +194,17 @@ SUNDIALS_EXPORT int CVodeSetConstraints(void* cvode_mem, N_Vector constraints);
 SUNDIALS_EXPORT int CVodeSetDeltaGammaMaxLSetup(void* cvode_mem,
                                                 sunrealtype dgmax_lsetup);
 SUNDIALS_EXPORT int CVodeSetInitStep(void* cvode_mem, sunrealtype hin);
-SUNDIALS_EXPORT int CVodeSetLSetupFrequency(void* cvode_mem, long int msbp);
+SUNDIALS_EXPORT int CVodeSetLSetupFrequency(void* cvode_mem, long msbp);
 SUNDIALS_EXPORT int CVodeSetMaxConvFails(void* cvode_mem, int maxncf);
 SUNDIALS_EXPORT int CVodeSetMaxErrTestFails(void* cvode_mem, int maxnef);
 SUNDIALS_EXPORT int CVodeSetMaxHnilWarns(void* cvode_mem, int mxhnil);
 SUNDIALS_EXPORT int CVodeSetMaxNonlinIters(void* cvode_mem, int maxcor);
-SUNDIALS_EXPORT int CVodeSetMaxNumSteps(void* cvode_mem, long int mxsteps);
+SUNDIALS_EXPORT int CVodeSetMaxNumSteps(void* cvode_mem, long mxsteps);
 SUNDIALS_EXPORT int CVodeSetMaxOrd(void* cvode_mem, int maxord);
 SUNDIALS_EXPORT int CVodeSetMaxStep(void* cvode_mem, sunrealtype hmax);
 SUNDIALS_EXPORT int CVodeSetMinStep(void* cvode_mem, sunrealtype hmin);
 SUNDIALS_EXPORT int CVodeSetMonitorFn(void* cvode_mem, CVMonitorFn fn);
-SUNDIALS_EXPORT int CVodeSetMonitorFrequency(void* cvode_mem, long int nst);
+SUNDIALS_EXPORT int CVodeSetMonitorFrequency(void* cvode_mem, long nst);
 SUNDIALS_EXPORT int CVodeSetNlsRhsFn(void* cvode_mem, CVRhsFn f);
 SUNDIALS_EXPORT int CVodeSetNonlinConvCoef(void* cvode_mem, sunrealtype nlscoef);
 SUNDIALS_EXPORT int CVodeSetNonlinearSolver(void* cvode_mem,
@@ -225,7 +225,7 @@ int CVodeSetEtaMaxFirstStep(void* cvode_mem, sunrealtype eta_max_fs);
 SUNDIALS_EXPORT
 int CVodeSetEtaMaxEarlyStep(void* cvode_mem, sunrealtype eta_max_es);
 SUNDIALS_EXPORT
-int CVodeSetNumStepsEtaMaxEarlyStep(void* cvode_mem, long int small_nst);
+int CVodeSetNumStepsEtaMaxEarlyStep(void* cvode_mem, long small_nst);
 SUNDIALS_EXPORT
 int CVodeSetEtaMax(void* cvode_mem, sunrealtype eta_max_gs);
 SUNDIALS_EXPORT
@@ -264,17 +264,15 @@ SUNDIALS_EXPORT int CVodeGetDky(void* cvode_mem, sunrealtype t, int k,
 /* Optional output functions */
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int CVodeGetWorkSpace(void* cvode_mem, long int* lenrw, long int* leniw);
-SUNDIALS_EXPORT int CVodeGetNumSteps(void* cvode_mem, long int* nsteps);
-SUNDIALS_EXPORT int CVodeGetNumRhsEvals(void* cvode_mem, long int* nfevals);
-SUNDIALS_EXPORT int CVodeGetNumLinSolvSetups(void* cvode_mem,
-                                             long int* nlinsetups);
-SUNDIALS_EXPORT int CVodeGetNumErrTestFails(void* cvode_mem, long int* netfails);
+int CVodeGetWorkSpace(void* cvode_mem, long* lenrw, long* leniw);
+SUNDIALS_EXPORT int CVodeGetNumSteps(void* cvode_mem, long* nsteps);
+SUNDIALS_EXPORT int CVodeGetNumRhsEvals(void* cvode_mem, long* nfevals);
+SUNDIALS_EXPORT int CVodeGetNumLinSolvSetups(void* cvode_mem, long* nlinsetups);
+SUNDIALS_EXPORT int CVodeGetNumErrTestFails(void* cvode_mem, long* netfails);
 SUNDIALS_EXPORT int CVodeGetLastOrder(void* cvode_mem, int* qlast);
 SUNDIALS_EXPORT int CVodeGetCurrentOrder(void* cvode_mem, int* qcur);
 SUNDIALS_EXPORT int CVodeGetCurrentGamma(void* cvode_mem, sunrealtype* gamma);
-SUNDIALS_EXPORT int CVodeGetNumStabLimOrderReds(void* cvode_mem,
-                                                long int* nslred);
+SUNDIALS_EXPORT int CVodeGetNumStabLimOrderReds(void* cvode_mem, long* nslred);
 SUNDIALS_EXPORT int CVodeGetActualInitStep(void* cvode_mem, sunrealtype* hinused);
 SUNDIALS_EXPORT int CVodeGetLastStep(void* cvode_mem, sunrealtype* hlast);
 SUNDIALS_EXPORT int CVodeGetCurrentStep(void* cvode_mem, sunrealtype* hcur);
@@ -285,12 +283,14 @@ SUNDIALS_EXPORT int CVodeGetCurrentTime(void* cvode_mem, sunrealtype* tcur);
 SUNDIALS_EXPORT int CVodeGetTolScaleFactor(void* cvode_mem, sunrealtype* tolsfac);
 SUNDIALS_EXPORT int CVodeGetErrWeights(void* cvode_mem, N_Vector eweight);
 SUNDIALS_EXPORT int CVodeGetEstLocalErrors(void* cvode_mem, N_Vector ele);
-SUNDIALS_EXPORT int CVodeGetNumGEvals(void* cvode_mem, long int* ngevals);
+SUNDIALS_EXPORT int CVodeGetNumGEvals(void* cvode_mem, long* ngevals);
 SUNDIALS_EXPORT int CVodeGetRootInfo(void* cvode_mem, int* rootsfound);
-SUNDIALS_EXPORT int CVodeGetIntegratorStats(
-  void* cvode_mem, long int* nsteps, long int* nfevals, long int* nlinsetups,
-  long int* netfails, int* qlast, int* qcur, sunrealtype* hinused,
-  sunrealtype* hlast, sunrealtype* hcur, sunrealtype* tcur);
+SUNDIALS_EXPORT int CVodeGetIntegratorStats(void* cvode_mem, long* nsteps,
+                                            long* nfevals, long* nlinsetups,
+                                            long* netfails, int* qlast,
+                                            int* qcur, sunrealtype* hinused,
+                                            sunrealtype* hlast,
+                                            sunrealtype* hcur, sunrealtype* tcur);
 SUNDIALS_EXPORT int CVodeGetNonlinearSystemData(void* cvode_mem,
                                                 sunrealtype* tcur,
                                                 N_Vector* ypred, N_Vector* yn,
@@ -300,18 +300,16 @@ SUNDIALS_EXPORT int CVodeGetNonlinearSystemData(void* cvode_mem,
 SUNDIALS_EXPORT int CVodeGetNonlinearSystemDataSens(
   void* cvode_mem, sunrealtype* tcur, N_Vector** ySpred, N_Vector** ySn,
   sunrealtype* gamma, sunrealtype* rl1, N_Vector** zn1, void** user_data);
-SUNDIALS_EXPORT int CVodeGetNumNonlinSolvIters(void* cvode_mem,
-                                               long int* nniters);
+SUNDIALS_EXPORT int CVodeGetNumNonlinSolvIters(void* cvode_mem, long* nniters);
 SUNDIALS_EXPORT int CVodeGetNumNonlinSolvConvFails(void* cvode_mem,
-                                                   long int* nnfails);
-SUNDIALS_EXPORT int CVodeGetNonlinSolvStats(void* cvode_mem, long int* nniters,
-                                            long int* nnfails);
-SUNDIALS_EXPORT int CVodeGetNumStepSolveFails(void* cvode_mem,
-                                              long int* nncfails);
+                                                   long* nnfails);
+SUNDIALS_EXPORT int CVodeGetNonlinSolvStats(void* cvode_mem, long* nniters,
+                                            long* nnfails);
+SUNDIALS_EXPORT int CVodeGetNumStepSolveFails(void* cvode_mem, long* nncfails);
 SUNDIALS_EXPORT int CVodeGetUserData(void* cvode_mem, void** user_data);
 SUNDIALS_EXPORT int CVodePrintAllStats(void* cvode_mem, FILE* outfile,
                                        SUNOutputFormat fmt);
-SUNDIALS_EXPORT char* CVodeGetReturnFlagName(long int flag);
+SUNDIALS_EXPORT char* CVodeGetReturnFlagName(long flag);
 
 /* Free function */
 SUNDIALS_EXPORT void CVodeFree(void** cvode_mem);
@@ -343,12 +341,11 @@ SUNDIALS_EXPORT int CVodeGetQuadDky(void* cvode_mem, sunrealtype t, int k,
                                     N_Vector dky);
 
 /* Optional output specification functions */
-SUNDIALS_EXPORT int CVodeGetQuadNumRhsEvals(void* cvode_mem, long int* nfQevals);
-SUNDIALS_EXPORT int CVodeGetQuadNumErrTestFails(void* cvode_mem,
-                                                long int* nQetfails);
+SUNDIALS_EXPORT int CVodeGetQuadNumRhsEvals(void* cvode_mem, long* nfQevals);
+SUNDIALS_EXPORT int CVodeGetQuadNumErrTestFails(void* cvode_mem, long* nQetfails);
 SUNDIALS_EXPORT int CVodeGetQuadErrWeights(void* cvode_mem, N_Vector eQweight);
-SUNDIALS_EXPORT int CVodeGetQuadStats(void* cvode_mem, long int* nfQevals,
-                                      long int* nQetfails);
+SUNDIALS_EXPORT int CVodeGetQuadStats(void* cvode_mem, long* nfQevals,
+                                      long* nQetfails);
 
 /* Free function */
 SUNDIALS_EXPORT void CVodeQuadFree(void* cvode_mem);
@@ -402,34 +399,32 @@ SUNDIALS_EXPORT int CVodeGetSensDky1(void* cvode_mem, sunrealtype t, int k,
                                      int is, N_Vector dky);
 
 /* Optional output specification functions */
-SUNDIALS_EXPORT int CVodeGetSensNumRhsEvals(void* cvode_mem, long int* nfSevals);
-SUNDIALS_EXPORT int CVodeGetNumRhsEvalsSens(void* cvode_mem, long int* nfevalsS);
-SUNDIALS_EXPORT int CVodeGetSensNumErrTestFails(void* cvode_mem,
-                                                long int* nSetfails);
+SUNDIALS_EXPORT int CVodeGetSensNumRhsEvals(void* cvode_mem, long* nfSevals);
+SUNDIALS_EXPORT int CVodeGetNumRhsEvalsSens(void* cvode_mem, long* nfevalsS);
+SUNDIALS_EXPORT int CVodeGetSensNumErrTestFails(void* cvode_mem, long* nSetfails);
 SUNDIALS_EXPORT int CVodeGetSensNumLinSolvSetups(void* cvode_mem,
-                                                 long int* nlinsetupsS);
+                                                 long* nlinsetupsS);
 SUNDIALS_EXPORT int CVodeGetSensErrWeights(void* cvode_mem, N_Vector* eSweight);
-SUNDIALS_EXPORT int CVodeGetSensStats(void* cvode_mem, long int* nfSevals,
-                                      long int* nfevalsS, long int* nSetfails,
-                                      long int* nlinsetupsS);
+SUNDIALS_EXPORT int CVodeGetSensStats(void* cvode_mem, long* nfSevals,
+                                      long* nfevalsS, long* nSetfails,
+                                      long* nlinsetupsS);
 SUNDIALS_EXPORT int CVodeGetSensNumNonlinSolvIters(void* cvode_mem,
-                                                   long int* nSniters);
+                                                   long* nSniters);
 SUNDIALS_EXPORT int CVodeGetSensNumNonlinSolvConvFails(void* cvode_mem,
-                                                       long int* nSnfails);
-SUNDIALS_EXPORT int CVodeGetSensNonlinSolvStats(void* cvode_mem,
-                                                long int* nSniters,
-                                                long int* nSnfails);
+                                                       long* nSnfails);
+SUNDIALS_EXPORT int CVodeGetSensNonlinSolvStats(void* cvode_mem, long* nSniters,
+                                                long* nSnfails);
 SUNDIALS_EXPORT int CVodeGetNumStepSensSolveFails(void* cvode_mem,
-                                                  long int* nSncfails);
+                                                  long* nSncfails);
 SUNDIALS_EXPORT int CVodeGetStgrSensNumNonlinSolvIters(void* cvode_mem,
-                                                       long int* nSTGR1niters);
+                                                       long* nSTGR1niters);
 SUNDIALS_EXPORT int CVodeGetStgrSensNumNonlinSolvConvFails(void* cvode_mem,
-                                                           long int* nSTGR1nfails);
+                                                           long* nSTGR1nfails);
 SUNDIALS_EXPORT int CVodeGetStgrSensNonlinSolvStats(void* cvode_mem,
-                                                    long int* nSTGR1niters,
-                                                    long int* nSTGR1nfails);
+                                                    long* nSTGR1niters,
+                                                    long* nSTGR1nfails);
 SUNDIALS_EXPORT int CVodeGetNumStepStgrSensSolveFails(void* cvode_mem,
-                                                      long int* nSTGR1ncfails);
+                                                      long* nSTGR1ncfails);
 
 /* Free function */
 SUNDIALS_EXPORT void CVodeSensFree(void* cvode_mem);
@@ -468,14 +463,13 @@ SUNDIALS_EXPORT int CVodeGetQuadSensDky1(void* cvode_mem, sunrealtype t, int k,
                                          int is, N_Vector dkyQS);
 
 /* Optional output specification functions */
-SUNDIALS_EXPORT int CVodeGetQuadSensNumRhsEvals(void* cvode_mem,
-                                                long int* nfQSevals);
+SUNDIALS_EXPORT int CVodeGetQuadSensNumRhsEvals(void* cvode_mem, long* nfQSevals);
 SUNDIALS_EXPORT int CVodeGetQuadSensNumErrTestFails(void* cvode_mem,
-                                                    long int* nQSetfails);
+                                                    long* nQSetfails);
 SUNDIALS_EXPORT int CVodeGetQuadSensErrWeights(void* cvode_mem,
                                                N_Vector* eQSweight);
-SUNDIALS_EXPORT int CVodeGetQuadSensStats(void* cvode_mem, long int* nfQSevals,
-                                          long int* nQSetfails);
+SUNDIALS_EXPORT int CVodeGetQuadSensStats(void* cvode_mem, long* nfQSevals,
+                                          long* nQSetfails);
 
 /* Free function */
 SUNDIALS_EXPORT void CVodeQuadSensFree(void* cvode_mem);
@@ -486,7 +480,7 @@ SUNDIALS_EXPORT void CVodeQuadSensFree(void* cvode_mem);
 
 /* Initialization functions */
 
-SUNDIALS_EXPORT int CVodeAdjInit(void* cvode_mem, long int steps, int interp);
+SUNDIALS_EXPORT int CVodeAdjInit(void* cvode_mem, long steps, int interp);
 
 SUNDIALS_EXPORT int CVodeAdjReInit(void* cvode_mem);
 
@@ -538,7 +532,7 @@ SUNDIALS_EXPORT int CVodeSetUserDataB(void* cvode_mem, int which,
                                       void* user_dataB);
 SUNDIALS_EXPORT int CVodeSetMaxOrdB(void* cvode_mem, int which, int maxordB);
 SUNDIALS_EXPORT int CVodeSetMaxNumStepsB(void* cvode_mem, int which,
-                                         long int mxstepsB);
+                                         long mxstepsB);
 SUNDIALS_EXPORT int CVodeSetStabLimDetB(void* cvode_mem, int which,
                                         sunbooleantype stldetB);
 SUNDIALS_EXPORT int CVodeSetInitStepB(void* cvode_mem, int which,
@@ -574,7 +568,7 @@ typedef struct
   void* next_addr;
   sunrealtype t0;
   sunrealtype t1;
-  long int nstep;
+  long nstep;
   int order;
   sunrealtype step;
 } CVadjCheckPointRec;

--- a/include/cvodes/cvodes_bandpre.h
+++ b/include/cvodes/cvodes_bandpre.h
@@ -38,9 +38,8 @@ SUNDIALS_EXPORT int CVBandPrecInit(void* cvode_mem, sunindextype N,
 
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int CVBandPrecGetWorkSpace(void* cvode_mem, long int* lenrwLS, long int* leniwLS);
-SUNDIALS_EXPORT int CVBandPrecGetNumRhsEvals(void* cvode_mem,
-                                             long int* nfevalsBP);
+int CVBandPrecGetWorkSpace(void* cvode_mem, long* lenrwLS, long* leniwLS);
+SUNDIALS_EXPORT int CVBandPrecGetNumRhsEvals(void* cvode_mem, long* nfevalsBP);
 
 /*------------------
   BACKWARD PROBLEMS

--- a/include/cvodes/cvodes_bbdpre.h
+++ b/include/cvodes/cvodes_bbdpre.h
@@ -53,11 +53,9 @@ SUNDIALS_EXPORT int CVBBDPrecReInit(void* cvode_mem, sunindextype mudq,
 
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int CVBBDPrecGetWorkSpace(void* cvode_mem, long int* lenrwBBDP,
-                          long int* leniwBBDP);
+int CVBBDPrecGetWorkSpace(void* cvode_mem, long* lenrwBBDP, long* leniwBBDP);
 
-SUNDIALS_EXPORT int CVBBDPrecGetNumGfnEvals(void* cvode_mem,
-                                            long int* ngevalsBBDP);
+SUNDIALS_EXPORT int CVBBDPrecGetNumGfnEvals(void* cvode_mem, long* ngevalsBBDP);
 
 /*------------------
   BACKWARD PROBLEMS

--- a/include/cvodes/cvodes_diag.h
+++ b/include/cvodes/cvodes_diag.h
@@ -55,10 +55,10 @@ SUNDIALS_EXPORT int CVDiag(void* cvode_mem);
 
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int CVDiagGetWorkSpace(void* cvode_mem, long int* lenrwLS, long int* leniwLS);
-SUNDIALS_EXPORT int CVDiagGetNumRhsEvals(void* cvode_mem, long int* nfevalsLS);
-SUNDIALS_EXPORT int CVDiagGetLastFlag(void* cvode_mem, long int* flag);
-SUNDIALS_EXPORT char* CVDiagGetReturnFlagName(long int flag);
+int CVDiagGetWorkSpace(void* cvode_mem, long* lenrwLS, long* leniwLS);
+SUNDIALS_EXPORT int CVDiagGetNumRhsEvals(void* cvode_mem, long* nfevalsLS);
+SUNDIALS_EXPORT int CVDiagGetLastFlag(void* cvode_mem, long* flag);
+SUNDIALS_EXPORT char* CVDiagGetReturnFlagName(long flag);
 
 /* -------------------------------------
  * Backward Problems - Function CVDiagB

--- a/include/cvodes/cvodes_ls.h
+++ b/include/cvodes/cvodes_ls.h
@@ -92,7 +92,7 @@ SUNDIALS_EXPORT int CVodeSetLinearSolver(void* cvode_mem, SUNLinearSolver LS,
   -----------------------------------------------------------------*/
 
 SUNDIALS_EXPORT int CVodeSetJacFn(void* cvode_mem, CVLsJacFn jac);
-SUNDIALS_EXPORT int CVodeSetJacEvalFrequency(void* cvode_mem, long int msbj);
+SUNDIALS_EXPORT int CVodeSetJacEvalFrequency(void* cvode_mem, long msbj);
 SUNDIALS_EXPORT int CVodeSetLinearSolutionScaling(void* cvode_mem,
                                                   sunbooleantype onoff);
 SUNDIALS_EXPORT int CVodeSetDeltaGammaMaxBadJac(void* cvode_mem,
@@ -111,25 +111,25 @@ SUNDIALS_EXPORT int CVodeSetLinSysFn(void* cvode_mem, CVLsLinSysFn linsys);
 
 SUNDIALS_EXPORT int CVodeGetJac(void* cvode_mem, SUNMatrix* J);
 SUNDIALS_EXPORT int CVodeGetJacTime(void* cvode_mem, sunrealtype* t_J);
-SUNDIALS_EXPORT int CVodeGetJacNumSteps(void* cvode_mem, long int* nst_J);
+SUNDIALS_EXPORT int CVodeGetJacNumSteps(void* cvode_mem, long* nst_J);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int CVodeGetLinWorkSpace(void* cvode_mem, long int* lenrwLS, long int* leniwLS);
-SUNDIALS_EXPORT int CVodeGetNumJacEvals(void* cvode_mem, long int* njevals);
-SUNDIALS_EXPORT int CVodeGetNumPrecEvals(void* cvode_mem, long int* npevals);
-SUNDIALS_EXPORT int CVodeGetNumPrecSolves(void* cvode_mem, long int* npsolves);
-SUNDIALS_EXPORT int CVodeGetNumLinIters(void* cvode_mem, long int* nliters);
-SUNDIALS_EXPORT int CVodeGetNumLinConvFails(void* cvode_mem, long int* nlcfails);
-SUNDIALS_EXPORT int CVodeGetNumJTSetupEvals(void* cvode_mem, long int* njtsetups);
-SUNDIALS_EXPORT int CVodeGetNumJtimesEvals(void* cvode_mem, long int* njvevals);
-SUNDIALS_EXPORT int CVodeGetNumLinRhsEvals(void* cvode_mem, long int* nfevalsLS);
-SUNDIALS_EXPORT int CVodeGetLinSolveStats(void* cvode_mem, long int* njevals,
-                                          long int* nfevalsLS,
-                                          long int* nliters, long int* nlcfails,
-                                          long int* npevals, long int* npsolves,
-                                          long int* njtsetups, long int* njtimes);
-SUNDIALS_EXPORT int CVodeGetLastLinFlag(void* cvode_mem, long int* flag);
-SUNDIALS_EXPORT char* CVodeGetLinReturnFlagName(long int flag);
+int CVodeGetLinWorkSpace(void* cvode_mem, long* lenrwLS, long* leniwLS);
+SUNDIALS_EXPORT int CVodeGetNumJacEvals(void* cvode_mem, long* njevals);
+SUNDIALS_EXPORT int CVodeGetNumPrecEvals(void* cvode_mem, long* npevals);
+SUNDIALS_EXPORT int CVodeGetNumPrecSolves(void* cvode_mem, long* npsolves);
+SUNDIALS_EXPORT int CVodeGetNumLinIters(void* cvode_mem, long* nliters);
+SUNDIALS_EXPORT int CVodeGetNumLinConvFails(void* cvode_mem, long* nlcfails);
+SUNDIALS_EXPORT int CVodeGetNumJTSetupEvals(void* cvode_mem, long* njtsetups);
+SUNDIALS_EXPORT int CVodeGetNumJtimesEvals(void* cvode_mem, long* njvevals);
+SUNDIALS_EXPORT int CVodeGetNumLinRhsEvals(void* cvode_mem, long* nfevalsLS);
+SUNDIALS_EXPORT int CVodeGetLinSolveStats(void* cvode_mem, long* njevals,
+                                          long* nfevalsLS, long* nliters,
+                                          long* nlcfails, long* npevals,
+                                          long* npsolves, long* njtsetups,
+                                          long* njtimes);
+SUNDIALS_EXPORT int CVodeGetLastLinFlag(void* cvode_mem, long* flag);
+SUNDIALS_EXPORT char* CVodeGetLinReturnFlagName(long flag);
 
 /*=================================================================
   Backward problems

--- a/include/cvodes/cvodes_proj.h
+++ b/include/cvodes/cvodes_proj.h
@@ -41,14 +41,14 @@ SUNDIALS_EXPORT int CVodeSetProjFn(void* cvode_mem, CVProjFn pfun);
 
 /* Optional input functions */
 SUNDIALS_EXPORT int CVodeSetProjErrEst(void* cvode_mem, sunbooleantype onoff);
-SUNDIALS_EXPORT int CVodeSetProjFrequency(void* cvode_mem, long int proj_freq);
+SUNDIALS_EXPORT int CVodeSetProjFrequency(void* cvode_mem, long proj_freq);
 SUNDIALS_EXPORT int CVodeSetMaxNumProjFails(void* cvode_mem, int max_fails);
 SUNDIALS_EXPORT int CVodeSetEpsProj(void* cvode_mem, sunrealtype eps);
 SUNDIALS_EXPORT int CVodeSetProjFailEta(void* cvode_mem, sunrealtype eta);
 
 /* Optional output functions */
-SUNDIALS_EXPORT int CVodeGetNumProjEvals(void* cvode_mem, long int* nproj);
-SUNDIALS_EXPORT int CVodeGetNumProjFails(void* cvode_mem, long int* nprf);
+SUNDIALS_EXPORT int CVodeGetNumProjEvals(void* cvode_mem, long* nproj);
+SUNDIALS_EXPORT int CVodeGetNumProjFails(void* cvode_mem, long* nprf);
 
 #ifdef __cplusplus
 }

--- a/include/ida/ida.h
+++ b/include/ida/ida.h
@@ -127,7 +127,7 @@ SUNDIALS_EXPORT int IDASetMaxBacksIC(void* ida_mem, int maxbacks);
 SUNDIALS_EXPORT int IDASetDeltaCjLSetup(void* ida_max, sunrealtype dcj);
 SUNDIALS_EXPORT int IDASetUserData(void* ida_mem, void* user_data);
 SUNDIALS_EXPORT int IDASetMaxOrd(void* ida_mem, int maxord);
-SUNDIALS_EXPORT int IDASetMaxNumSteps(void* ida_mem, long int mxsteps);
+SUNDIALS_EXPORT int IDASetMaxNumSteps(void* ida_mem, long mxsteps);
 SUNDIALS_EXPORT int IDASetInitStep(void* ida_mem, sunrealtype hin);
 SUNDIALS_EXPORT int IDASetMaxStep(void* ida_mem, sunrealtype hmax);
 SUNDIALS_EXPORT int IDASetMinStep(void* ida_mem, sunrealtype hmin);
@@ -181,12 +181,12 @@ SUNDIALS_EXPORT int IDAGetDky(void* ida_mem, sunrealtype t, int k, N_Vector dky)
 /* Optional output functions */
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int IDAGetWorkSpace(void* ida_mem, long int* lenrw, long int* leniw);
-SUNDIALS_EXPORT int IDAGetNumSteps(void* ida_mem, long int* nsteps);
-SUNDIALS_EXPORT int IDAGetNumResEvals(void* ida_mem, long int* nrevals);
-SUNDIALS_EXPORT int IDAGetNumLinSolvSetups(void* ida_mem, long int* nlinsetups);
-SUNDIALS_EXPORT int IDAGetNumErrTestFails(void* ida_mem, long int* netfails);
-SUNDIALS_EXPORT int IDAGetNumBacktrackOps(void* ida_mem, long int* nbacktr);
+int IDAGetWorkSpace(void* ida_mem, long* lenrw, long* leniw);
+SUNDIALS_EXPORT int IDAGetNumSteps(void* ida_mem, long* nsteps);
+SUNDIALS_EXPORT int IDAGetNumResEvals(void* ida_mem, long* nrevals);
+SUNDIALS_EXPORT int IDAGetNumLinSolvSetups(void* ida_mem, long* nlinsetups);
+SUNDIALS_EXPORT int IDAGetNumErrTestFails(void* ida_mem, long* netfails);
+SUNDIALS_EXPORT int IDAGetNumBacktrackOps(void* ida_mem, long* nbacktr);
 SUNDIALS_EXPORT int IDAGetConsistentIC(void* ida_mem, N_Vector yy0_mod,
                                        N_Vector yp0_mod);
 SUNDIALS_EXPORT int IDAGetLastOrder(void* ida_mem, int* klast);
@@ -201,12 +201,12 @@ SUNDIALS_EXPORT int IDAGetCurrentTime(void* ida_mem, sunrealtype* tcur);
 SUNDIALS_EXPORT int IDAGetTolScaleFactor(void* ida_mem, sunrealtype* tolsfact);
 SUNDIALS_EXPORT int IDAGetErrWeights(void* ida_mem, N_Vector eweight);
 SUNDIALS_EXPORT int IDAGetEstLocalErrors(void* ida_mem, N_Vector ele);
-SUNDIALS_EXPORT int IDAGetNumGEvals(void* ida_mem, long int* ngevals);
+SUNDIALS_EXPORT int IDAGetNumGEvals(void* ida_mem, long* ngevals);
 SUNDIALS_EXPORT int IDAGetRootInfo(void* ida_mem, int* rootsfound);
-SUNDIALS_EXPORT int IDAGetIntegratorStats(void* ida_mem, long int* nsteps,
-                                          long int* nrevals, long int* nlinsetups,
-                                          long int* netfails, int* qlast,
-                                          int* qcur, sunrealtype* hinused,
+SUNDIALS_EXPORT int IDAGetIntegratorStats(void* ida_mem, long* nsteps,
+                                          long* nrevals, long* nlinsetups,
+                                          long* netfails, int* qlast, int* qcur,
+                                          sunrealtype* hinused,
                                           sunrealtype* hlast, sunrealtype* hcur,
                                           sunrealtype* tcur);
 SUNDIALS_EXPORT int IDAGetNonlinearSystemData(void* ida_mem, sunrealtype* tcur,
@@ -214,16 +214,15 @@ SUNDIALS_EXPORT int IDAGetNonlinearSystemData(void* ida_mem, sunrealtype* tcur,
                                               N_Vector* yppred, N_Vector* yyn,
                                               N_Vector* ypn, N_Vector* res,
                                               sunrealtype* cj, void** user_data);
-SUNDIALS_EXPORT int IDAGetNumNonlinSolvIters(void* ida_mem, long int* nniters);
-SUNDIALS_EXPORT int IDAGetNumNonlinSolvConvFails(void* ida_mem,
-                                                 long int* nnfails);
-SUNDIALS_EXPORT int IDAGetNonlinSolvStats(void* ida_mem, long int* nniters,
-                                          long int* nnfails);
-SUNDIALS_EXPORT int IDAGetNumStepSolveFails(void* ida_mem, long int* nncfails);
+SUNDIALS_EXPORT int IDAGetNumNonlinSolvIters(void* ida_mem, long* nniters);
+SUNDIALS_EXPORT int IDAGetNumNonlinSolvConvFails(void* ida_mem, long* nnfails);
+SUNDIALS_EXPORT int IDAGetNonlinSolvStats(void* ida_mem, long* nniters,
+                                          long* nnfails);
+SUNDIALS_EXPORT int IDAGetNumStepSolveFails(void* ida_mem, long* nncfails);
 SUNDIALS_EXPORT int IDAGetUserData(void* ida_mem, void** user_data);
 SUNDIALS_EXPORT int IDAPrintAllStats(void* ida_mem, FILE* outfile,
                                      SUNOutputFormat fmt);
-SUNDIALS_EXPORT char* IDAGetReturnFlagName(long int flag);
+SUNDIALS_EXPORT char* IDAGetReturnFlagName(long flag);
 
 /* Free function */
 SUNDIALS_EXPORT void IDAFree(void** ida_mem);

--- a/include/ida/ida_bbdpre.h
+++ b/include/ida/ida_bbdpre.h
@@ -49,11 +49,9 @@ SUNDIALS_EXPORT int IDABBDPrecReInit(void* ida_mem, sunindextype mudq,
 
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int IDABBDPrecGetWorkSpace(void* ida_mem, long int* lenrwBBDP,
-                           long int* leniwBBDP);
+int IDABBDPrecGetWorkSpace(void* ida_mem, long* lenrwBBDP, long* leniwBBDP);
 
-SUNDIALS_EXPORT int IDABBDPrecGetNumGfnEvals(void* ida_mem,
-                                             long int* ngevalsBBDP);
+SUNDIALS_EXPORT int IDABBDPrecGetNumGfnEvals(void* ida_mem, long* ngevalsBBDP);
 
 #ifdef __cplusplus
 }

--- a/include/ida/ida_ls.h
+++ b/include/ida/ida_ls.h
@@ -98,20 +98,20 @@ SUNDIALS_EXPORT int IDASetIncrementFactor(void* ida_mem, sunrealtype dqincfac);
 SUNDIALS_EXPORT int IDAGetJac(void* ida_mem, SUNMatrix* J);
 SUNDIALS_EXPORT int IDAGetJacCj(void* ida_mem, sunrealtype* cj_J);
 SUNDIALS_EXPORT int IDAGetJacTime(void* ida_mem, sunrealtype* t_J);
-SUNDIALS_EXPORT int IDAGetJacNumSteps(void* ida_mem, long int* nst_J);
+SUNDIALS_EXPORT int IDAGetJacNumSteps(void* ida_mem, long* nst_J);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int IDAGetLinWorkSpace(void* ida_mem, long int* lenrwLS, long int* leniwLS);
-SUNDIALS_EXPORT int IDAGetNumJacEvals(void* ida_mem, long int* njevals);
-SUNDIALS_EXPORT int IDAGetNumPrecEvals(void* ida_mem, long int* npevals);
-SUNDIALS_EXPORT int IDAGetNumPrecSolves(void* ida_mem, long int* npsolves);
-SUNDIALS_EXPORT int IDAGetNumLinIters(void* ida_mem, long int* nliters);
-SUNDIALS_EXPORT int IDAGetNumLinConvFails(void* ida_mem, long int* nlcfails);
-SUNDIALS_EXPORT int IDAGetNumJTSetupEvals(void* ida_mem, long int* njtsetups);
-SUNDIALS_EXPORT int IDAGetNumJtimesEvals(void* ida_mem, long int* njvevals);
-SUNDIALS_EXPORT int IDAGetNumLinResEvals(void* ida_mem, long int* nrevalsLS);
-SUNDIALS_EXPORT int IDAGetLastLinFlag(void* ida_mem, long int* flag);
-SUNDIALS_EXPORT char* IDAGetLinReturnFlagName(long int flag);
+int IDAGetLinWorkSpace(void* ida_mem, long* lenrwLS, long* leniwLS);
+SUNDIALS_EXPORT int IDAGetNumJacEvals(void* ida_mem, long* njevals);
+SUNDIALS_EXPORT int IDAGetNumPrecEvals(void* ida_mem, long* npevals);
+SUNDIALS_EXPORT int IDAGetNumPrecSolves(void* ida_mem, long* npsolves);
+SUNDIALS_EXPORT int IDAGetNumLinIters(void* ida_mem, long* nliters);
+SUNDIALS_EXPORT int IDAGetNumLinConvFails(void* ida_mem, long* nlcfails);
+SUNDIALS_EXPORT int IDAGetNumJTSetupEvals(void* ida_mem, long* njtsetups);
+SUNDIALS_EXPORT int IDAGetNumJtimesEvals(void* ida_mem, long* njvevals);
+SUNDIALS_EXPORT int IDAGetNumLinResEvals(void* ida_mem, long* nrevalsLS);
+SUNDIALS_EXPORT int IDAGetLastLinFlag(void* ida_mem, long* flag);
+SUNDIALS_EXPORT char* IDAGetLinReturnFlagName(long flag);
 
 #ifdef __cplusplus
 }

--- a/include/idas/idas.h
+++ b/include/idas/idas.h
@@ -191,7 +191,7 @@ SUNDIALS_EXPORT int IDASetMaxBacksIC(void* ida_mem, int maxbacks);
 SUNDIALS_EXPORT int IDASetDeltaCjLSetup(void* ida_max, sunrealtype dcj);
 SUNDIALS_EXPORT int IDASetUserData(void* ida_mem, void* user_data);
 SUNDIALS_EXPORT int IDASetMaxOrd(void* ida_mem, int maxord);
-SUNDIALS_EXPORT int IDASetMaxNumSteps(void* ida_mem, long int mxsteps);
+SUNDIALS_EXPORT int IDASetMaxNumSteps(void* ida_mem, long mxsteps);
 SUNDIALS_EXPORT int IDASetInitStep(void* ida_mem, sunrealtype hin);
 SUNDIALS_EXPORT int IDASetMaxStep(void* ida_mem, sunrealtype hmax);
 SUNDIALS_EXPORT int IDASetMinStep(void* ida_mem, sunrealtype hmin);
@@ -248,12 +248,12 @@ SUNDIALS_EXPORT int IDAGetDky(void* ida_mem, sunrealtype t, int k, N_Vector dky)
 /* Optional output functions */
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int IDAGetWorkSpace(void* ida_mem, long int* lenrw, long int* leniw);
-SUNDIALS_EXPORT int IDAGetNumSteps(void* ida_mem, long int* nsteps);
-SUNDIALS_EXPORT int IDAGetNumResEvals(void* ida_mem, long int* nrevals);
-SUNDIALS_EXPORT int IDAGetNumLinSolvSetups(void* ida_mem, long int* nlinsetups);
-SUNDIALS_EXPORT int IDAGetNumErrTestFails(void* ida_mem, long int* netfails);
-SUNDIALS_EXPORT int IDAGetNumBacktrackOps(void* ida_mem, long int* nbacktr);
+int IDAGetWorkSpace(void* ida_mem, long* lenrw, long* leniw);
+SUNDIALS_EXPORT int IDAGetNumSteps(void* ida_mem, long* nsteps);
+SUNDIALS_EXPORT int IDAGetNumResEvals(void* ida_mem, long* nrevals);
+SUNDIALS_EXPORT int IDAGetNumLinSolvSetups(void* ida_mem, long* nlinsetups);
+SUNDIALS_EXPORT int IDAGetNumErrTestFails(void* ida_mem, long* netfails);
+SUNDIALS_EXPORT int IDAGetNumBacktrackOps(void* ida_mem, long* nbacktr);
 SUNDIALS_EXPORT int IDAGetConsistentIC(void* ida_mem, N_Vector yy0_mod,
                                        N_Vector yp0_mod);
 SUNDIALS_EXPORT int IDAGetLastOrder(void* ida_mem, int* klast);
@@ -270,12 +270,12 @@ SUNDIALS_EXPORT int IDAGetCurrentTime(void* ida_mem, sunrealtype* tcur);
 SUNDIALS_EXPORT int IDAGetTolScaleFactor(void* ida_mem, sunrealtype* tolsfact);
 SUNDIALS_EXPORT int IDAGetErrWeights(void* ida_mem, N_Vector eweight);
 SUNDIALS_EXPORT int IDAGetEstLocalErrors(void* ida_mem, N_Vector ele);
-SUNDIALS_EXPORT int IDAGetNumGEvals(void* ida_mem, long int* ngevals);
+SUNDIALS_EXPORT int IDAGetNumGEvals(void* ida_mem, long* ngevals);
 SUNDIALS_EXPORT int IDAGetRootInfo(void* ida_mem, int* rootsfound);
-SUNDIALS_EXPORT int IDAGetIntegratorStats(void* ida_mem, long int* nsteps,
-                                          long int* nrevals, long int* nlinsetups,
-                                          long int* netfails, int* qlast,
-                                          int* qcur, sunrealtype* hinused,
+SUNDIALS_EXPORT int IDAGetIntegratorStats(void* ida_mem, long* nsteps,
+                                          long* nrevals, long* nlinsetups,
+                                          long* netfails, int* qlast, int* qcur,
+                                          sunrealtype* hinused,
                                           sunrealtype* hlast, sunrealtype* hcur,
                                           sunrealtype* tcur);
 SUNDIALS_EXPORT int IDAGetNonlinearSystemData(void* ida_mem, sunrealtype* tcur,
@@ -286,16 +286,15 @@ SUNDIALS_EXPORT int IDAGetNonlinearSystemData(void* ida_mem, sunrealtype* tcur,
 SUNDIALS_EXPORT int IDAGetNonlinearSystemDataSens(
   void* ida_mem, sunrealtype* tcur, N_Vector** yySpred, N_Vector** ypSpred,
   N_Vector** yySn, N_Vector** ypSn, sunrealtype* cj, void** user_data);
-SUNDIALS_EXPORT int IDAGetNumNonlinSolvIters(void* ida_mem, long int* nniters);
-SUNDIALS_EXPORT int IDAGetNumNonlinSolvConvFails(void* ida_mem,
-                                                 long int* nnfails);
-SUNDIALS_EXPORT int IDAGetNonlinSolvStats(void* ida_mem, long int* nniters,
-                                          long int* nnfails);
-SUNDIALS_EXPORT int IDAGetNumStepSolveFails(void* ida_mem, long int* nncfails);
+SUNDIALS_EXPORT int IDAGetNumNonlinSolvIters(void* ida_mem, long* nniters);
+SUNDIALS_EXPORT int IDAGetNumNonlinSolvConvFails(void* ida_mem, long* nnfails);
+SUNDIALS_EXPORT int IDAGetNonlinSolvStats(void* ida_mem, long* nniters,
+                                          long* nnfails);
+SUNDIALS_EXPORT int IDAGetNumStepSolveFails(void* ida_mem, long* nncfails);
 SUNDIALS_EXPORT int IDAGetUserData(void* ida_mem, void** user_data);
 SUNDIALS_EXPORT int IDAPrintAllStats(void* ida_mem, FILE* outfile,
                                      SUNOutputFormat fmt);
-SUNDIALS_EXPORT char* IDAGetReturnFlagName(long int flag);
+SUNDIALS_EXPORT char* IDAGetReturnFlagName(long flag);
 
 /* Free function */
 SUNDIALS_EXPORT void IDAFree(void** ida_mem);
@@ -326,11 +325,11 @@ SUNDIALS_EXPORT int IDAGetQuadDky(void* ida_mem, sunrealtype t, int k,
                                   N_Vector dky);
 
 /* Optional output specification functions */
-SUNDIALS_EXPORT int IDAGetQuadNumRhsEvals(void* ida_mem, long int* nrhsQevals);
-SUNDIALS_EXPORT int IDAGetQuadNumErrTestFails(void* ida_mem, long int* nQetfails);
+SUNDIALS_EXPORT int IDAGetQuadNumRhsEvals(void* ida_mem, long* nrhsQevals);
+SUNDIALS_EXPORT int IDAGetQuadNumErrTestFails(void* ida_mem, long* nQetfails);
 SUNDIALS_EXPORT int IDAGetQuadErrWeights(void* ida_mem, N_Vector eQweight);
-SUNDIALS_EXPORT int IDAGetQuadStats(void* ida_mem, long int* nrhsQevals,
-                                    long int* nQetfails);
+SUNDIALS_EXPORT int IDAGetQuadStats(void* ida_mem, long* nrhsQevals,
+                                    long* nQetfails);
 
 /* Free function */
 SUNDIALS_EXPORT void IDAQuadFree(void* ida_mem);
@@ -385,23 +384,20 @@ SUNDIALS_EXPORT int IDAGetSensDky1(void* ida_mem, sunrealtype t, int k, int is,
                                    N_Vector dkyS);
 
 /* Optional output specification functions */
-SUNDIALS_EXPORT int IDAGetSensNumResEvals(void* ida_mem, long int* nresSevals);
-SUNDIALS_EXPORT int IDAGetNumResEvalsSens(void* ida_mem, long int* nresevalsS);
-SUNDIALS_EXPORT int IDAGetSensNumErrTestFails(void* ida_mem, long int* nSetfails);
-SUNDIALS_EXPORT int IDAGetSensNumLinSolvSetups(void* ida_mem,
-                                               long int* nlinsetupsS);
+SUNDIALS_EXPORT int IDAGetSensNumResEvals(void* ida_mem, long* nresSevals);
+SUNDIALS_EXPORT int IDAGetNumResEvalsSens(void* ida_mem, long* nresevalsS);
+SUNDIALS_EXPORT int IDAGetSensNumErrTestFails(void* ida_mem, long* nSetfails);
+SUNDIALS_EXPORT int IDAGetSensNumLinSolvSetups(void* ida_mem, long* nlinsetupsS);
 SUNDIALS_EXPORT int IDAGetSensErrWeights(void* ida_mem, N_Vector_S eSweight);
-SUNDIALS_EXPORT int IDAGetSensStats(void* ida_mem, long int* nresSevals,
-                                    long int* nresevalsS, long int* nSetfails,
-                                    long int* nlinsetupsS);
-SUNDIALS_EXPORT int IDAGetSensNumNonlinSolvIters(void* ida_mem,
-                                                 long int* nSniters);
+SUNDIALS_EXPORT int IDAGetSensStats(void* ida_mem, long* nresSevals,
+                                    long* nresevalsS, long* nSetfails,
+                                    long* nlinsetupsS);
+SUNDIALS_EXPORT int IDAGetSensNumNonlinSolvIters(void* ida_mem, long* nSniters);
 SUNDIALS_EXPORT int IDAGetSensNumNonlinSolvConvFails(void* ida_mem,
-                                                     long int* nSnfails);
-SUNDIALS_EXPORT int IDAGetSensNonlinSolvStats(void* ida_mem, long int* nSniters,
-                                              long int* nSnfails);
-SUNDIALS_EXPORT int IDAGetNumStepSensSolveFails(void* ida_mem,
-                                                long int* nSncfails);
+                                                     long* nSnfails);
+SUNDIALS_EXPORT int IDAGetSensNonlinSolvStats(void* ida_mem, long* nSniters,
+                                              long* nSnfails);
+SUNDIALS_EXPORT int IDAGetNumStepSensSolveFails(void* ida_mem, long* nSncfails);
 
 /* Free function */
 SUNDIALS_EXPORT void IDASensFree(void* ida_mem);
@@ -436,13 +432,12 @@ SUNDIALS_EXPORT int IDAGetQuadSensDky1(void* ida_mem, sunrealtype t, int k,
                                        int is, N_Vector dkyQS);
 
 /* Optional output specification functions */
-SUNDIALS_EXPORT int IDAGetQuadSensNumRhsEvals(void* ida_mem,
-                                              long int* nrhsQSevals);
+SUNDIALS_EXPORT int IDAGetQuadSensNumRhsEvals(void* ida_mem, long* nrhsQSevals);
 SUNDIALS_EXPORT int IDAGetQuadSensNumErrTestFails(void* ida_mem,
-                                                  long int* nQSetfails);
+                                                  long* nQSetfails);
 SUNDIALS_EXPORT int IDAGetQuadSensErrWeights(void* ida_mem, N_Vector* eQSweight);
-SUNDIALS_EXPORT int IDAGetQuadSensStats(void* ida_mem, long int* nrhsQSevals,
-                                        long int* nQSetfails);
+SUNDIALS_EXPORT int IDAGetQuadSensStats(void* ida_mem, long* nrhsQSevals,
+                                        long* nQSetfails);
 
 /* Free function */
 SUNDIALS_EXPORT void IDAQuadSensFree(void* ida_mem);
@@ -453,7 +448,7 @@ SUNDIALS_EXPORT void IDAQuadSensFree(void* ida_mem);
 
 /* Initialization functions */
 
-SUNDIALS_EXPORT int IDAAdjInit(void* ida_mem, long int steps, int interp);
+SUNDIALS_EXPORT int IDAAdjInit(void* ida_mem, long steps, int interp);
 
 SUNDIALS_EXPORT int IDAAdjReInit(void* ida_mem);
 
@@ -516,8 +511,7 @@ SUNDIALS_EXPORT int IDAAdjSetNoSensi(void* ida_mem);
 
 SUNDIALS_EXPORT int IDASetUserDataB(void* ida_mem, int which, void* user_dataB);
 SUNDIALS_EXPORT int IDASetMaxOrdB(void* ida_mem, int which, int maxordB);
-SUNDIALS_EXPORT int IDASetMaxNumStepsB(void* ida_mem, int which,
-                                       long int mxstepsB);
+SUNDIALS_EXPORT int IDASetMaxNumStepsB(void* ida_mem, int which, long mxstepsB);
 SUNDIALS_EXPORT int IDASetInitStepB(void* ida_mem, int which, sunrealtype hinB);
 SUNDIALS_EXPORT int IDASetMaxStepB(void* ida_mem, int which, sunrealtype hmaxB);
 SUNDIALS_EXPORT int IDASetSuppressAlgB(void* ida_mem, int which,
@@ -553,7 +547,7 @@ typedef struct
   void* next_addr;
   sunrealtype t0;
   sunrealtype t1;
-  long int nstep;
+  long nstep;
   int order;
   sunrealtype step;
 } IDAadjCheckPointRec;

--- a/include/idas/idas_bbdpre.h
+++ b/include/idas/idas_bbdpre.h
@@ -53,11 +53,9 @@ SUNDIALS_EXPORT int IDABBDPrecReInit(void* ida_mem, sunindextype mudq,
 
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int IDABBDPrecGetWorkSpace(void* ida_mem, long int* lenrwBBDP,
-                           long int* leniwBBDP);
+int IDABBDPrecGetWorkSpace(void* ida_mem, long* lenrwBBDP, long* leniwBBDP);
 
-SUNDIALS_EXPORT int IDABBDPrecGetNumGfnEvals(void* ida_mem,
-                                             long int* ngevalsBBDP);
+SUNDIALS_EXPORT int IDABBDPrecGetNumGfnEvals(void* ida_mem, long* ngevalsBBDP);
 
 /*------------------
   BACKWARD PROBLEMS

--- a/include/idas/idas_ls.h
+++ b/include/idas/idas_ls.h
@@ -105,20 +105,20 @@ SUNDIALS_EXPORT int IDASetIncrementFactor(void* ida_mem, sunrealtype dqincfac);
 SUNDIALS_EXPORT int IDAGetJac(void* ida_mem, SUNMatrix* J);
 SUNDIALS_EXPORT int IDAGetJacCj(void* ida_mem, sunrealtype* cj_J);
 SUNDIALS_EXPORT int IDAGetJacTime(void* ida_mem, sunrealtype* t_J);
-SUNDIALS_EXPORT int IDAGetJacNumSteps(void* ida_mem, long int* nst_J);
+SUNDIALS_EXPORT int IDAGetJacNumSteps(void* ida_mem, long* nst_J);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int IDAGetLinWorkSpace(void* ida_mem, long int* lenrwLS, long int* leniwLS);
-SUNDIALS_EXPORT int IDAGetNumJacEvals(void* ida_mem, long int* njevals);
-SUNDIALS_EXPORT int IDAGetNumPrecEvals(void* ida_mem, long int* npevals);
-SUNDIALS_EXPORT int IDAGetNumPrecSolves(void* ida_mem, long int* npsolves);
-SUNDIALS_EXPORT int IDAGetNumLinIters(void* ida_mem, long int* nliters);
-SUNDIALS_EXPORT int IDAGetNumLinConvFails(void* ida_mem, long int* nlcfails);
-SUNDIALS_EXPORT int IDAGetNumJTSetupEvals(void* ida_mem, long int* njtsetups);
-SUNDIALS_EXPORT int IDAGetNumJtimesEvals(void* ida_mem, long int* njvevals);
-SUNDIALS_EXPORT int IDAGetNumLinResEvals(void* ida_mem, long int* nrevalsLS);
-SUNDIALS_EXPORT int IDAGetLastLinFlag(void* ida_mem, long int* flag);
-SUNDIALS_EXPORT char* IDAGetLinReturnFlagName(long int flag);
+int IDAGetLinWorkSpace(void* ida_mem, long* lenrwLS, long* leniwLS);
+SUNDIALS_EXPORT int IDAGetNumJacEvals(void* ida_mem, long* njevals);
+SUNDIALS_EXPORT int IDAGetNumPrecEvals(void* ida_mem, long* npevals);
+SUNDIALS_EXPORT int IDAGetNumPrecSolves(void* ida_mem, long* npsolves);
+SUNDIALS_EXPORT int IDAGetNumLinIters(void* ida_mem, long* nliters);
+SUNDIALS_EXPORT int IDAGetNumLinConvFails(void* ida_mem, long* nlcfails);
+SUNDIALS_EXPORT int IDAGetNumJTSetupEvals(void* ida_mem, long* njtsetups);
+SUNDIALS_EXPORT int IDAGetNumJtimesEvals(void* ida_mem, long* njvevals);
+SUNDIALS_EXPORT int IDAGetNumLinResEvals(void* ida_mem, long* nrevalsLS);
+SUNDIALS_EXPORT int IDAGetLastLinFlag(void* ida_mem, long* flag);
+SUNDIALS_EXPORT char* IDAGetLinReturnFlagName(long flag);
 
 /*=================================================================
   Backward problems

--- a/include/kinsol/kinsol.h
+++ b/include/kinsol/kinsol.h
@@ -84,13 +84,13 @@ typedef int (*KINSysFn)(N_Vector uu, N_Vector fval, void* user_data);
 typedef void (*KINInfoHandlerFn)(const char* module, const char* function,
                                  char* msg, void* user_data);
 
-typedef int (*KINDampingFn)(long int iter, N_Vector u_val, N_Vector g_val,
-                            sunrealtype* qt_fn, long int depth, void* user_data,
+typedef int (*KINDampingFn)(long iter, N_Vector u_val, N_Vector g_val,
+                            sunrealtype* qt_fn, long depth, void* user_data,
                             sunrealtype* damping_factor);
 
-typedef int (*KINDepthFn)(long int iter, N_Vector u_val, N_Vector g_val,
+typedef int (*KINDepthFn)(long iter, N_Vector u_val, N_Vector g_val,
                           N_Vector f_val, N_Vector* df, sunrealtype* R_mat,
-                          long int depth, void* user_data, long int* new_depth,
+                          long depth, void* user_data, long* new_depth,
                           sunbooleantype* remove_indices);
 
 /* -------------------
@@ -110,18 +110,18 @@ SUNDIALS_EXPORT int KINSol(void* kinmem, N_Vector uu, int strategy,
 /* Optional input functions */
 SUNDIALS_EXPORT int KINSetUserData(void* kinmem, void* user_data);
 SUNDIALS_EXPORT int KINSetDamping(void* kinmem, sunrealtype beta);
-SUNDIALS_EXPORT int KINSetMAA(void* kinmem, long int maa);
+SUNDIALS_EXPORT int KINSetMAA(void* kinmem, long maa);
 SUNDIALS_EXPORT int KINSetOrthAA(void* kinmem, int orthaa);
-SUNDIALS_EXPORT int KINSetDelayAA(void* kinmem, long int delay);
+SUNDIALS_EXPORT int KINSetDelayAA(void* kinmem, long delay);
 SUNDIALS_EXPORT int KINSetDampingAA(void* kinmem, sunrealtype beta);
 SUNDIALS_EXPORT int KINSetDampingFn(void* kinmem, KINDampingFn damping_fn);
 SUNDIALS_EXPORT int KINSetDepthFn(void* kinmem, KINDepthFn depth_fn);
 SUNDIALS_EXPORT int KINSetReturnNewest(void* kinmem, sunbooleantype ret_newest);
-SUNDIALS_EXPORT int KINSetNumMaxIters(void* kinmem, long int mxiter);
+SUNDIALS_EXPORT int KINSetNumMaxIters(void* kinmem, long mxiter);
 SUNDIALS_EXPORT int KINSetNoInitSetup(void* kinmem, sunbooleantype noInitSetup);
 SUNDIALS_EXPORT int KINSetNoResMon(void* kinmem, sunbooleantype noNNIResMon);
-SUNDIALS_EXPORT int KINSetMaxSetupCalls(void* kinmem, long int msbset);
-SUNDIALS_EXPORT int KINSetMaxSubSetupCalls(void* kinmem, long int msbsetsub);
+SUNDIALS_EXPORT int KINSetMaxSetupCalls(void* kinmem, long msbset);
+SUNDIALS_EXPORT int KINSetMaxSubSetupCalls(void* kinmem, long msbsetsub);
 SUNDIALS_EXPORT int KINSetEtaForm(void* kinmem, int etachoice);
 SUNDIALS_EXPORT int KINSetEtaConstValue(void* kinmem, sunrealtype eta);
 SUNDIALS_EXPORT int KINSetEtaParams(void* kinmem, sunrealtype egamma,
@@ -131,7 +131,7 @@ SUNDIALS_EXPORT int KINSetResMonParams(void* kinmem, sunrealtype omegamin,
 SUNDIALS_EXPORT int KINSetResMonConstValue(void* kinmem, sunrealtype omegaconst);
 SUNDIALS_EXPORT int KINSetNoMinEps(void* kinmem, sunbooleantype noMinEps);
 SUNDIALS_EXPORT int KINSetMaxNewtonStep(void* kinmem, sunrealtype mxnewtstep);
-SUNDIALS_EXPORT int KINSetMaxBetaFails(void* kinmem, long int mxnbcf);
+SUNDIALS_EXPORT int KINSetMaxBetaFails(void* kinmem, long mxnbcf);
 SUNDIALS_EXPORT int KINSetRelErrFunc(void* kinmem, sunrealtype relfunc);
 SUNDIALS_EXPORT int KINSetFuncNormTol(void* kinmem, sunrealtype fnormtol);
 SUNDIALS_EXPORT int KINSetScaledStepTol(void* kinmem, sunrealtype scsteptol);
@@ -141,17 +141,17 @@ SUNDIALS_EXPORT int KINSetSysFunc(void* kinmem, KINSysFn func);
 /* Optional output functions */
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int KINGetWorkSpace(void* kinmem, long int* lenrw, long int* leniw);
-SUNDIALS_EXPORT int KINGetNumNonlinSolvIters(void* kinmem, long int* nniters);
-SUNDIALS_EXPORT int KINGetNumFuncEvals(void* kinmem, long int* nfevals);
-SUNDIALS_EXPORT int KINGetNumBetaCondFails(void* kinmem, long int* nbcfails);
-SUNDIALS_EXPORT int KINGetNumBacktrackOps(void* kinmem, long int* nbacktr);
+int KINGetWorkSpace(void* kinmem, long* lenrw, long* leniw);
+SUNDIALS_EXPORT int KINGetNumNonlinSolvIters(void* kinmem, long* nniters);
+SUNDIALS_EXPORT int KINGetNumFuncEvals(void* kinmem, long* nfevals);
+SUNDIALS_EXPORT int KINGetNumBetaCondFails(void* kinmem, long* nbcfails);
+SUNDIALS_EXPORT int KINGetNumBacktrackOps(void* kinmem, long* nbacktr);
 SUNDIALS_EXPORT int KINGetFuncNorm(void* kinmem, sunrealtype* fnorm);
 SUNDIALS_EXPORT int KINGetStepLength(void* kinmem, sunrealtype* steplength);
 SUNDIALS_EXPORT int KINGetUserData(void* kinmem, void** user_data);
 SUNDIALS_EXPORT int KINPrintAllStats(void* kinmem, FILE* outfile,
                                      SUNOutputFormat fmt);
-SUNDIALS_EXPORT char* KINGetReturnFlagName(long int flag);
+SUNDIALS_EXPORT char* KINGetReturnFlagName(long flag);
 
 /* Free function */
 SUNDIALS_EXPORT void KINFree(void** kinmem);

--- a/include/kinsol/kinsol_bbdpre.h
+++ b/include/kinsol/kinsol_bbdpre.h
@@ -52,10 +52,9 @@ SUNDIALS_EXPORT int KINBBDPrecInit(void* kinmem, sunindextype Nlocal,
 
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int KINBBDPrecGetWorkSpace(void* kinmem, long int* lenrwBBDP,
-                           long int* leniwBBDP);
+int KINBBDPrecGetWorkSpace(void* kinmem, long* lenrwBBDP, long* leniwBBDP);
 
-SUNDIALS_EXPORT int KINBBDPrecGetNumGfnEvals(void* kinmem, long int* ngevalsBBDP);
+SUNDIALS_EXPORT int KINBBDPrecGetNumGfnEvals(void* kinmem, long* ngevalsBBDP);
 
 #ifdef __cplusplus
 }

--- a/include/kinsol/kinsol_ls.h
+++ b/include/kinsol/kinsol_ls.h
@@ -81,19 +81,19 @@ SUNDIALS_EXPORT int KINSetJacTimesVecFn(void* kinmem, KINLsJacTimesVecFn jtv);
   -----------------------------------------------------------------*/
 
 SUNDIALS_EXPORT int KINGetJac(void* kinmem, SUNMatrix* J);
-SUNDIALS_EXPORT int KINGetJacNumIters(void* kinmem, long int* nni_J);
+SUNDIALS_EXPORT int KINGetJacNumIters(void* kinmem, long* nni_J);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int KINGetLinWorkSpace(void* kinmem, long int* lenrwLS, long int* leniwLS);
-SUNDIALS_EXPORT int KINGetNumJacEvals(void* kinmem, long int* njevals);
-SUNDIALS_EXPORT int KINGetNumLinFuncEvals(void* kinmem, long int* nfevals);
-SUNDIALS_EXPORT int KINGetNumPrecEvals(void* kinmem, long int* npevals);
-SUNDIALS_EXPORT int KINGetNumPrecSolves(void* kinmem, long int* npsolves);
-SUNDIALS_EXPORT int KINGetNumLinIters(void* kinmem, long int* nliters);
-SUNDIALS_EXPORT int KINGetNumLinConvFails(void* kinmem, long int* nlcfails);
-SUNDIALS_EXPORT int KINGetNumJtimesEvals(void* kinmem, long int* njvevals);
-SUNDIALS_EXPORT int KINGetLastLinFlag(void* kinmem, long int* flag);
-SUNDIALS_EXPORT char* KINGetLinReturnFlagName(long int flag);
+int KINGetLinWorkSpace(void* kinmem, long* lenrwLS, long* leniwLS);
+SUNDIALS_EXPORT int KINGetNumJacEvals(void* kinmem, long* njevals);
+SUNDIALS_EXPORT int KINGetNumLinFuncEvals(void* kinmem, long* nfevals);
+SUNDIALS_EXPORT int KINGetNumPrecEvals(void* kinmem, long* npevals);
+SUNDIALS_EXPORT int KINGetNumPrecSolves(void* kinmem, long* npsolves);
+SUNDIALS_EXPORT int KINGetNumLinIters(void* kinmem, long* nliters);
+SUNDIALS_EXPORT int KINGetNumLinConvFails(void* kinmem, long* nlcfails);
+SUNDIALS_EXPORT int KINGetNumJtimesEvals(void* kinmem, long* njvevals);
+SUNDIALS_EXPORT int KINGetLastLinFlag(void* kinmem, long* flag);
+SUNDIALS_EXPORT char* KINGetLinReturnFlagName(long flag);
 
 #ifdef __cplusplus
 }

--- a/include/sunadaptcontroller/sunadaptcontroller_imexgus.h
+++ b/include/sunadaptcontroller/sunadaptcontroller_imexgus.h
@@ -81,8 +81,8 @@ SUNErrCode SUNAdaptController_UpdateH_ImExGus(SUNAdaptController C,
 
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNAdaptController_Space_ImExGus(SUNAdaptController C,
-                                            long int* lenrw, long int* leniw);
+SUNErrCode SUNAdaptController_Space_ImExGus(SUNAdaptController C, long* lenrw,
+                                            long* leniw);
 
 #ifdef __cplusplus
 }

--- a/include/sunadaptcontroller/sunadaptcontroller_mrihtol.h
+++ b/include/sunadaptcontroller/sunadaptcontroller_mrihtol.h
@@ -79,8 +79,8 @@ int SUNAdaptController_UpdateMRIHTol_MRIHTol(SUNAdaptController C,
                                              sunrealtype DSM, sunrealtype dsm);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-int SUNAdaptController_Space_MRIHTol(SUNAdaptController C, long int* lenrw,
-                                     long int* leniw);
+int SUNAdaptController_Space_MRIHTol(SUNAdaptController C, long* lenrw,
+                                     long* leniw);
 
 #ifdef __cplusplus
 }

--- a/include/sunadaptcontroller/sunadaptcontroller_soderlind.h
+++ b/include/sunadaptcontroller/sunadaptcontroller_soderlind.h
@@ -90,8 +90,8 @@ SUNErrCode SUNAdaptController_UpdateH_Soderlind(SUNAdaptController C,
 
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNAdaptController_Space_Soderlind(SUNAdaptController C,
-                                              long int* lenrw, long int* leniw);
+SUNErrCode SUNAdaptController_Space_Soderlind(SUNAdaptController C, long* lenrw,
+                                              long* leniw);
 
 /* Convenience routines to construct subsidiary controllers */
 

--- a/include/sundials/sundials_adaptcontroller.h
+++ b/include/sundials/sundials_adaptcontroller.h
@@ -80,7 +80,7 @@ struct _generic_SUNAdaptController_Ops
   SUNErrCode (*updatemrihtol)(SUNAdaptController C, sunrealtype H,
                               sunrealtype tolfac, sunrealtype DSM,
                               sunrealtype dsm);
-  SUNErrCode (*space)(SUNAdaptController C, long int* lenrw, long int* leniw);
+  SUNErrCode (*space)(SUNAdaptController C, long* lenrw, long* leniw);
 };
 
 /* A SUNAdaptController is a structure with an implementation-dependent
@@ -181,8 +181,8 @@ SUNErrCode SUNAdaptController_UpdateMRIHTol(SUNAdaptController C, sunrealtype H,
 /* Function to return the memory requirements of the controller object. */
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNAdaptController_Space(SUNAdaptController C, long int* lenrw,
-                                    long int* leniw);
+SUNErrCode SUNAdaptController_Space(SUNAdaptController C, long* lenrw,
+                                    long* leniw);
 
 #ifdef __cplusplus
 }

--- a/include/sundials/sundials_linearsolver.h
+++ b/include/sundials/sundials_linearsolver.h
@@ -125,7 +125,7 @@ struct _generic_SUNLinearSolver_Ops
   int (*numiters)(SUNLinearSolver);
   sunrealtype (*resnorm)(SUNLinearSolver);
   sunindextype (*lastflag)(SUNLinearSolver);
-  SUNErrCode (*space)(SUNLinearSolver, long int*, long int*);
+  SUNErrCode (*space)(SUNLinearSolver, long*, long*);
   N_Vector (*resid)(SUNLinearSolver);
   SUNErrCode (*free)(SUNLinearSolver);
 };
@@ -181,7 +181,7 @@ SUNDIALS_EXPORT
 int SUNLinSolSolve(SUNLinearSolver S, SUNMatrix A, N_Vector x, N_Vector b,
                    sunrealtype tol);
 
-/* TODO(CJB): We should consider changing the return type to long int since
+/* TODO(CJB): We should consider changing the return type to long since
  batched solvers could in theory return a very large number here. */
 SUNDIALS_EXPORT
 int SUNLinSolNumIters(SUNLinearSolver S);
@@ -199,8 +199,7 @@ sunindextype SUNLinSolLastFlag(SUNLinearSolver S);
 
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNLinSolSpace(SUNLinearSolver S, long int* lenrwLS,
-                          long int* leniwLS);
+SUNErrCode SUNLinSolSpace(SUNLinearSolver S, long* lenrwLS, long* leniwLS);
 
 SUNDIALS_EXPORT
 SUNErrCode SUNLinSolFree(SUNLinearSolver S);

--- a/include/sundials/sundials_matrix.h
+++ b/include/sundials/sundials_matrix.h
@@ -94,7 +94,7 @@ struct _generic_SUNMatrix_Ops
   SUNErrCode (*matvecsetup)(SUNMatrix);
   SUNErrCode (*matvec)(SUNMatrix, N_Vector, N_Vector);
   SUNErrCode (*mathermitiantransposevec)(SUNMatrix, N_Vector, N_Vector);
-  SUNErrCode (*space)(SUNMatrix, long int*, long int*);
+  SUNErrCode (*space)(SUNMatrix, long*, long*);
 };
 
 /* A matrix is a structure with an implementation-dependent
@@ -152,7 +152,7 @@ SUNErrCode SUNMatHermitianTransposeVec(SUNMatrix A, N_Vector x, N_Vector y);
 
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNMatSpace(SUNMatrix A, long int* lenrw, long int* leniw);
+SUNErrCode SUNMatSpace(SUNMatrix A, long* lenrw, long* leniw);
 
 #ifdef __cplusplus
 }

--- a/include/sundials/sundials_nonlinearsolver.h
+++ b/include/sundials/sundials_nonlinearsolver.h
@@ -110,9 +110,9 @@ struct _generic_SUNNonlinearSolver_Ops
   SUNErrCode (*setlsolvefn)(SUNNonlinearSolver, SUNNonlinSolLSolveFn);
   SUNErrCode (*setctestfn)(SUNNonlinearSolver, SUNNonlinSolConvTestFn, void*);
   SUNErrCode (*setmaxiters)(SUNNonlinearSolver, int);
-  SUNErrCode (*getnumiters)(SUNNonlinearSolver, long int*);
+  SUNErrCode (*getnumiters)(SUNNonlinearSolver, long*);
   SUNErrCode (*getcuriter)(SUNNonlinearSolver, int*);
-  SUNErrCode (*getnumconvfails)(SUNNonlinearSolver, long int*);
+  SUNErrCode (*getnumconvfails)(SUNNonlinearSolver, long*);
 };
 
 /* A nonlinear solver is a structure with an implementation-dependent 'content'
@@ -175,14 +175,13 @@ SUNErrCode SUNNonlinSolSetMaxIters(SUNNonlinearSolver NLS, int maxiters);
 
 /* get functions */
 SUNDIALS_EXPORT
-SUNErrCode SUNNonlinSolGetNumIters(SUNNonlinearSolver NLS, long int* niters);
+SUNErrCode SUNNonlinSolGetNumIters(SUNNonlinearSolver NLS, long* niters);
 
 SUNDIALS_EXPORT
 SUNErrCode SUNNonlinSolGetCurIter(SUNNonlinearSolver NLS, int* iter);
 
 SUNDIALS_EXPORT
-SUNErrCode SUNNonlinSolGetNumConvFails(SUNNonlinearSolver NLS,
-                                       long int* nconvfails);
+SUNErrCode SUNNonlinSolGetNumConvFails(SUNNonlinearSolver NLS, long* nconvfails);
 
 /* -----------------------------------------------------------------------------
  * SUNNonlinearSolver return values

--- a/include/sunlinsol/sunlinsol_band.h
+++ b/include/sunlinsol/sunlinsol_band.h
@@ -75,8 +75,7 @@ sunindextype SUNLinSolLastFlag_Band(SUNLinearSolver S);
 
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNLinSolSpace_Band(SUNLinearSolver S, long int* lenrwLS,
-                               long int* leniwLS);
+SUNErrCode SUNLinSolSpace_Band(SUNLinearSolver S, long* lenrwLS, long* leniwLS);
 
 SUNDIALS_EXPORT
 SUNErrCode SUNLinSolFree_Band(SUNLinearSolver S);

--- a/include/sunlinsol/sunlinsol_dense.h
+++ b/include/sunlinsol/sunlinsol_dense.h
@@ -80,8 +80,7 @@ sunindextype SUNLinSolLastFlag_Dense(SUNLinearSolver S);
 
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNLinSolSpace_Dense(SUNLinearSolver S, long int* lenrwLS,
-                                long int* leniwLS);
+SUNErrCode SUNLinSolSpace_Dense(SUNLinearSolver S, long* lenrwLS, long* leniwLS);
 
 SUNDIALS_EXPORT
 SUNErrCode SUNLinSolFree_Dense(SUNLinearSolver S);

--- a/include/sunlinsol/sunlinsol_klu.h
+++ b/include/sunlinsol/sunlinsol_klu.h
@@ -137,8 +137,7 @@ SUNDIALS_EXPORT int SUNLinSolSolve_KLU(SUNLinearSolver S, SUNMatrix A,
 SUNDIALS_EXPORT sunindextype SUNLinSolLastFlag_KLU(SUNLinearSolver S);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNLinSolSpace_KLU(SUNLinearSolver S, long int* lenrwLS,
-                              long int* leniwLS);
+SUNErrCode SUNLinSolSpace_KLU(SUNLinearSolver S, long* lenrwLS, long* leniwLS);
 SUNDIALS_EXPORT SUNErrCode SUNLinSolFree_KLU(SUNLinearSolver S);
 
 #ifdef __cplusplus

--- a/include/sunlinsol/sunlinsol_lapackband.h
+++ b/include/sunlinsol/sunlinsol_lapackband.h
@@ -62,8 +62,8 @@ SUNDIALS_EXPORT int SUNLinSolSolve_LapackBand(SUNLinearSolver S, SUNMatrix A,
 SUNDIALS_EXPORT sunindextype SUNLinSolLastFlag_LapackBand(SUNLinearSolver S);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNLinSolSpace_LapackBand(SUNLinearSolver S, long int* lenrwLS,
-                                     long int* leniwLS);
+SUNErrCode SUNLinSolSpace_LapackBand(SUNLinearSolver S, long* lenrwLS,
+                                     long* leniwLS);
 SUNDIALS_EXPORT SUNErrCode SUNLinSolFree_LapackBand(SUNLinearSolver S);
 
 #ifdef __cplusplus

--- a/include/sunlinsol/sunlinsol_lapackdense.h
+++ b/include/sunlinsol/sunlinsol_lapackdense.h
@@ -62,8 +62,8 @@ SUNDIALS_EXPORT int SUNLinSolSolve_LapackDense(SUNLinearSolver S, SUNMatrix A,
 SUNDIALS_EXPORT sunindextype SUNLinSolLastFlag_LapackDense(SUNLinearSolver S);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNLinSolSpace_LapackDense(SUNLinearSolver S, long int* lenrwLS,
-                                      long int* leniwLS);
+SUNErrCode SUNLinSolSpace_LapackDense(SUNLinearSolver S, long* lenrwLS,
+                                      long* leniwLS);
 SUNDIALS_EXPORT SUNErrCode SUNLinSolFree_LapackDense(SUNLinearSolver S);
 
 #ifdef __cplusplus

--- a/include/sunlinsol/sunlinsol_magmadense.h
+++ b/include/sunlinsol/sunlinsol_magmadense.h
@@ -72,8 +72,8 @@ SUNDIALS_EXPORT int SUNLinSolSolve_MagmaDense(SUNLinearSolver S, SUNMatrix A,
 SUNDIALS_EXPORT sunindextype SUNLinSolLastFlag_MagmaDense(SUNLinearSolver S);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNLinSolSpace_MagmaDense(SUNLinearSolver S, long int* lenrwLS,
-                                     long int* leniwLS);
+SUNErrCode SUNLinSolSpace_MagmaDense(SUNLinearSolver S, long* lenrwLS,
+                                     long* leniwLS);
 SUNDIALS_EXPORT SUNErrCode SUNLinSolFree_MagmaDense(SUNLinearSolver S);
 
 #ifdef __cplusplus

--- a/include/sunlinsol/sunlinsol_onemkldense.h
+++ b/include/sunlinsol/sunlinsol_onemkldense.h
@@ -76,8 +76,8 @@ sunindextype SUNLinSolLastFlag_OneMklDense(SUNLinearSolver S);
 
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNLinSolSpace_OneMklDense(SUNLinearSolver S, long int* lenrwLS,
-                                      long int* leniwLS);
+SUNErrCode SUNLinSolSpace_OneMklDense(SUNLinearSolver S, long* lenrwLS,
+                                      long* leniwLS);
 
 SUNDIALS_EXPORT
 SUNErrCode SUNLinSolFree_OneMklDense(SUNLinearSolver S);

--- a/include/sunlinsol/sunlinsol_pcg.h
+++ b/include/sunlinsol/sunlinsol_pcg.h
@@ -123,8 +123,7 @@ sunindextype SUNLinSolLastFlag_PCG(SUNLinearSolver S);
 
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNLinSolSpace_PCG(SUNLinearSolver S, long int* lenrwLS,
-                              long int* leniwLS);
+SUNErrCode SUNLinSolSpace_PCG(SUNLinearSolver S, long* lenrwLS, long* leniwLS);
 
 SUNDIALS_EXPORT
 SUNErrCode SUNLinSolFree_PCG(SUNLinearSolver S);

--- a/include/sunlinsol/sunlinsol_spbcgs.h
+++ b/include/sunlinsol/sunlinsol_spbcgs.h
@@ -105,8 +105,7 @@ SUNDIALS_EXPORT N_Vector SUNLinSolResid_SPBCGS(SUNLinearSolver S);
 SUNDIALS_EXPORT sunindextype SUNLinSolLastFlag_SPBCGS(SUNLinearSolver S);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNLinSolSpace_SPBCGS(SUNLinearSolver S, long int* lenrwLS,
-                                 long int* leniwLS);
+SUNErrCode SUNLinSolSpace_SPBCGS(SUNLinearSolver S, long* lenrwLS, long* leniwLS);
 SUNDIALS_EXPORT SUNErrCode SUNLinSolFree_SPBCGS(SUNLinearSolver S);
 
 #ifdef __cplusplus

--- a/include/sunlinsol/sunlinsol_spfgmr.h
+++ b/include/sunlinsol/sunlinsol_spfgmr.h
@@ -115,8 +115,7 @@ SUNDIALS_EXPORT N_Vector SUNLinSolResid_SPFGMR(SUNLinearSolver S);
 SUNDIALS_EXPORT sunindextype SUNLinSolLastFlag_SPFGMR(SUNLinearSolver S);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNLinSolSpace_SPFGMR(SUNLinearSolver S, long int* lenrwLS,
-                                 long int* leniwLS);
+SUNErrCode SUNLinSolSpace_SPFGMR(SUNLinearSolver S, long* lenrwLS, long* leniwLS);
 SUNDIALS_EXPORT SUNErrCode SUNLinSolFree_SPFGMR(SUNLinearSolver S);
 
 #ifdef __cplusplus

--- a/include/sunlinsol/sunlinsol_spgmr.h
+++ b/include/sunlinsol/sunlinsol_spgmr.h
@@ -114,8 +114,7 @@ SUNDIALS_EXPORT N_Vector SUNLinSolResid_SPGMR(SUNLinearSolver S);
 SUNDIALS_EXPORT sunindextype SUNLinSolLastFlag_SPGMR(SUNLinearSolver S);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNLinSolSpace_SPGMR(SUNLinearSolver S, long int* lenrwLS,
-                                long int* leniwLS);
+SUNErrCode SUNLinSolSpace_SPGMR(SUNLinearSolver S, long* lenrwLS, long* leniwLS);
 SUNDIALS_EXPORT SUNErrCode SUNLinSolFree_SPGMR(SUNLinearSolver S);
 
 #ifdef __cplusplus

--- a/include/sunlinsol/sunlinsol_sptfqmr.h
+++ b/include/sunlinsol/sunlinsol_sptfqmr.h
@@ -107,8 +107,8 @@ SUNDIALS_EXPORT N_Vector SUNLinSolResid_SPTFQMR(SUNLinearSolver S);
 SUNDIALS_EXPORT sunindextype SUNLinSolLastFlag_SPTFQMR(SUNLinearSolver S);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNLinSolSpace_SPTFQMR(SUNLinearSolver S, long int* lenrwLS,
-                                  long int* leniwLS);
+SUNErrCode SUNLinSolSpace_SPTFQMR(SUNLinearSolver S, long* lenrwLS,
+                                  long* leniwLS);
 SUNDIALS_EXPORT SUNErrCode SUNLinSolFree_SPTFQMR(SUNLinearSolver S);
 
 #ifdef __cplusplus

--- a/include/sunlinsol/sunlinsol_superludist.h
+++ b/include/sunlinsol/sunlinsol_superludist.h
@@ -118,8 +118,8 @@ SUNDIALS_EXPORT int SUNLinSolSolve_SuperLUDIST(SUNLinearSolver S, SUNMatrix A,
 SUNDIALS_EXPORT sunindextype SUNLinSolLastFlag_SuperLUDIST(SUNLinearSolver S);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNLinSolSpace_SuperLUDIST(SUNLinearSolver S, long int* lenrwLS,
-                                      long int* leniwLS);
+SUNErrCode SUNLinSolSpace_SuperLUDIST(SUNLinearSolver S, long* lenrwLS,
+                                      long* leniwLS);
 SUNDIALS_EXPORT SUNErrCode SUNLinSolFree_SuperLUDIST(SUNLinearSolver S);
 
 #ifdef __cplusplus

--- a/include/sunlinsol/sunlinsol_superlumt.h
+++ b/include/sunlinsol/sunlinsol_superlumt.h
@@ -107,8 +107,8 @@ SUNDIALS_EXPORT int SUNLinSolSolve_SuperLUMT(SUNLinearSolver S, SUNMatrix A,
 SUNDIALS_EXPORT sunindextype SUNLinSolLastFlag_SuperLUMT(SUNLinearSolver S);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNLinSolSpace_SuperLUMT(SUNLinearSolver S, long int* lenrwLS,
-                                    long int* leniwLS);
+SUNErrCode SUNLinSolSpace_SuperLUMT(SUNLinearSolver S, long* lenrwLS,
+                                    long* leniwLS);
 SUNDIALS_EXPORT SUNErrCode SUNLinSolFree_SuperLUMT(SUNLinearSolver S);
 
 #ifdef __cplusplus

--- a/include/sunmatrix/sunmatrix_band.h
+++ b/include/sunmatrix/sunmatrix_band.h
@@ -126,7 +126,7 @@ SUNDIALS_EXPORT SUNErrCode SUNMatHermitianTransposeVec_Band(SUNMatrix A,
                                                             N_Vector y);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNMatSpace_Band(SUNMatrix A, long int* lenrw, long int* leniw);
+SUNErrCode SUNMatSpace_Band(SUNMatrix A, long* lenrw, long* leniw);
 
 #ifdef __cplusplus
 }

--- a/include/sunmatrix/sunmatrix_dense.h
+++ b/include/sunmatrix/sunmatrix_dense.h
@@ -104,7 +104,7 @@ SUNDIALS_EXPORT SUNErrCode SUNMatHermitianTransposeVec_Dense(SUNMatrix A,
                                                              N_Vector y);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNMatSpace_Dense(SUNMatrix A, long int* lenrw, long int* leniw);
+SUNErrCode SUNMatSpace_Dense(SUNMatrix A, long* lenrw, long* leniw);
 
 #ifdef __cplusplus
 }

--- a/include/sunmatrix/sunmatrix_magmadense.h
+++ b/include/sunmatrix/sunmatrix_magmadense.h
@@ -122,7 +122,7 @@ SUNDIALS_EXPORT SUNErrCode SUNMatMatvec_MagmaDense(SUNMatrix A, N_Vector x,
                                                    N_Vector y);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNMatSpace_MagmaDense(SUNMatrix A, long int* lenrw, long int* leniw);
+SUNErrCode SUNMatSpace_MagmaDense(SUNMatrix A, long* lenrw, long* leniw);
 
 #ifdef __cplusplus
 }

--- a/include/sunmatrix/sunmatrix_onemkldense.h
+++ b/include/sunmatrix/sunmatrix_onemkldense.h
@@ -167,7 +167,7 @@ SUNErrCode SUNMatMatvec_OneMklDense(SUNMatrix A, N_Vector x, N_Vector y);
 
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNMatSpace_OneMklDense(SUNMatrix A, long int* lenrw, long int* leniw);
+SUNErrCode SUNMatSpace_OneMklDense(SUNMatrix A, long* lenrw, long* leniw);
 
 #ifdef __cplusplus
 }

--- a/include/sunmatrix/sunmatrix_slunrloc.h
+++ b/include/sunmatrix/sunmatrix_slunrloc.h
@@ -78,7 +78,7 @@ SUNDIALS_EXPORT SUNErrCode SUNMatMatvec_SLUNRloc(SUNMatrix A, N_Vector x,
                                                  N_Vector y);
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNMatSpace_SLUNRloc(SUNMatrix A, long int* lenrw, long int* leniw);
+SUNErrCode SUNMatSpace_SLUNRloc(SUNMatrix A, long* lenrw, long* leniw);
 
 #ifdef __cplusplus
 }

--- a/include/sunmatrix/sunmatrix_sparse.h
+++ b/include/sunmatrix/sunmatrix_sparse.h
@@ -181,7 +181,7 @@ SUNErrCode SUNMatHermitianTransposeVec_Sparse(SUNMatrix A, N_Vector x,
 
 SUNDIALS_DEPRECATED_EXPORT_MSG(
   "Work space functions will be removed in version 8.0.0")
-SUNErrCode SUNMatSpace_Sparse(SUNMatrix A, long int* lenrw, long int* leniw);
+SUNErrCode SUNMatSpace_Sparse(SUNMatrix A, long* lenrw, long* leniw);
 
 #ifdef __cplusplus
 }

--- a/include/sunnonlinsol/sunnonlinsol_fixedpoint.h
+++ b/include/sunnonlinsol/sunnonlinsol_fixedpoint.h
@@ -56,12 +56,12 @@ struct _SUNNonlinearSolverContent_FixedPoint
   N_Vector gy;
   N_Vector fold;
   N_Vector gold;
-  N_Vector delta;      /* correction vector (change between 2 iterates)  */
-  int curiter;         /* current iteration number in a solve attempt    */
-  int maxiters;        /* maximum number of iterations per solve attempt */
-  long int niters;     /* total number of iterations across all solves   */
-  long int nconvfails; /* total number of convergence failures           */
-  void* ctest_data;    /* data to pass to convergence test function      */
+  N_Vector delta;   /* correction vector (change between 2 iterates)  */
+  int curiter;      /* current iteration number in a solve attempt    */
+  int maxiters;     /* maximum number of iterations per solve attempt */
+  long niters;      /* total number of iterations across all solves   */
+  long nconvfails;  /* total number of convergence failures           */
+  void* ctest_data; /* data to pass to convergence test function      */
 };
 
 typedef struct _SUNNonlinearSolverContent_FixedPoint* SUNNonlinearSolverContent_FixedPoint;
@@ -114,14 +114,14 @@ SUNErrCode SUNNonlinSolSetDamping_FixedPoint(SUNNonlinearSolver NLS,
 /* get functions */
 SUNDIALS_EXPORT
 SUNErrCode SUNNonlinSolGetNumIters_FixedPoint(SUNNonlinearSolver NLS,
-                                              long int* niters);
+                                              long* niters);
 
 SUNDIALS_EXPORT
 SUNErrCode SUNNonlinSolGetCurIter_FixedPoint(SUNNonlinearSolver NLS, int* iter);
 
 SUNDIALS_EXPORT
 SUNErrCode SUNNonlinSolGetNumConvFails_FixedPoint(SUNNonlinearSolver NLS,
-                                                  long int* nconvfails);
+                                                  long* nconvfails);
 
 SUNDIALS_EXPORT
 SUNErrCode SUNNonlinSolGetSysFn_FixedPoint(SUNNonlinearSolver NLS,

--- a/include/sunnonlinsol/sunnonlinsol_newton.h
+++ b/include/sunnonlinsol/sunnonlinsol_newton.h
@@ -45,10 +45,10 @@ struct _SUNNonlinearSolverContent_Newton
   /* nonlinear solver variables */
   N_Vector delta; /* Newton update vector                                   */
   sunbooleantype jcur; /* Jacobian status, current = SUNTRUE / stale = SUNFALSE  */
-  int curiter;     /* current number of iterations in a solve attempt        */
-  int maxiters;    /* maximum number of iterations in a solve attempt        */
-  long int niters; /* total number of nonlinear iterations across all solves */
-  long int nconvfails; /* total number of convergence failures across all solves
+  int curiter;      /* current number of iterations in a solve attempt        */
+  int maxiters;     /* maximum number of iterations in a solve attempt        */
+  long niters;      /* total number of nonlinear iterations across all solves */
+  long nconvfails;  /* total number of convergence failures across all solves
                         */
   void* ctest_data; /* data to pass to convergence test function              */
 };
@@ -105,15 +105,14 @@ SUNErrCode SUNNonlinSolSetMaxIters_Newton(SUNNonlinearSolver NLS, int maxiters);
 
 /* get functions */
 SUNDIALS_EXPORT
-SUNErrCode SUNNonlinSolGetNumIters_Newton(SUNNonlinearSolver NLS,
-                                          long int* niters);
+SUNErrCode SUNNonlinSolGetNumIters_Newton(SUNNonlinearSolver NLS, long* niters);
 
 SUNDIALS_EXPORT
 SUNErrCode SUNNonlinSolGetCurIter_Newton(SUNNonlinearSolver NLS, int* iter);
 
 SUNDIALS_EXPORT
 SUNErrCode SUNNonlinSolGetNumConvFails_Newton(SUNNonlinearSolver NLS,
-                                              long int* nconvfails);
+                                              long* nconvfails);
 
 SUNDIALS_EXPORT
 SUNErrCode SUNNonlinSolGetSysFn_Newton(SUNNonlinearSolver NLS,

--- a/include/sunnonlinsol/sunnonlinsol_petscsnes.h
+++ b/include/sunnonlinsol/sunnonlinsol_petscsnes.h
@@ -40,11 +40,11 @@ struct _SUNNonlinearSolverContent_PetscSNES
 {
   int sysfn_last_err; /* last error returned by the system function Sys */
   PetscErrorCode petsc_last_err; /* last error return by PETSc */
-  long int nconvfails; /* number of nonlinear converge failures (recoverable or not) */
-  long int nni;        /* number of nonlinear iterations */
-  void* imem;          /* SUNDIALS integrator memory */
-  SNES snes;           /* PETSc SNES context */
-  Vec r;               /* nonlinear residual */
+  long nconvfails; /* number of nonlinear converge failures (recoverable or not) */
+  long nni;        /* number of nonlinear iterations */
+  void* imem;      /* SUNDIALS integrator memory */
+  SNES snes;       /* PETSc SNES context */
+  Vec r;           /* nonlinear residual */
   N_Vector y, f; /* wrappers for PETSc vectors in system function */
   /* functions provided by the integrator */
   SUNNonlinSolSysFn Sys; /* nonlinear system function         */
@@ -80,12 +80,11 @@ SUNErrCode SUNNonlinSolSetSysFn_PetscSNES(SUNNonlinearSolver NLS,
                                           SUNNonlinSolSysFn SysFn);
 
 SUNDIALS_EXPORT
-SUNErrCode SUNNonlinSolGetNumIters_PetscSNES(SUNNonlinearSolver NLS,
-                                             long int* nni);
+SUNErrCode SUNNonlinSolGetNumIters_PetscSNES(SUNNonlinearSolver NLS, long* nni);
 
 SUNDIALS_EXPORT
 SUNErrCode SUNNonlinSolGetNumConvFails_PetscSNES(SUNNonlinearSolver NLS,
-                                                 long int* nconvfails);
+                                                 long* nconvfails);
 
 SUNDIALS_EXPORT
 SUNErrCode SUNNonlinSolFree_PetscSNES(SUNNonlinearSolver NLS);


### PR DESCRIPTION
This is the first of a series of PRs needed for the Python bindings to SUNDIALS

The Python binding generator we are using does not recognize `long int` as a specifier.  This PR changes `long int` to the equivalent specifier `long` in our header files (which is what the generator parses). There is no need to do this in the `src` directory, but if we want to do it for consistency sakes, we can. 