### PR TITLE
Feature: Provide access to IDA interpolant via new IDAGetInterpData function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ setting the Anderson acceleration depth and orthogonalization method after
 `KINInit`. Additionally, `KINSetMAA` and `KINSetNumMaxIters` may now be called
 in any order.
 
+A new `IDAGetInterpData` function has been added to return the internal data
+defining the polynomial interpolant constructed during the last successful
+solver step.  This permits the construction of a piecewise-defined interpolant
+across multiple steps, useful for offline evaluation, checkpointing, custom
+output, etc.
+
 ### Bug Fixes
 
 The shared library version numbers for the oneMKL dense linear solver and

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -10,6 +10,12 @@ to allow for setting the Anderson acceleration depth and orthogonalization
 method after :c:func:`KINInit`. Additionally, :c:func:`KINSetMAA` and
 :c:func:`KINSetNumMaxIters` may now be called in any order.
 
+A new :c:func:`IDAGetInterpData` function has been added to return the internal
+data defining the polynomial interpolant constructed during the last successful
+solver step.  This permits the construction of a piecewise-defined interpolant
+across multiple steps, useful for offline evaluation, checkpointing, custom
+output, etc.
+
 **Bug Fixes**
 
 The shared library version numbers for the oneMKL dense linear solver and

--- a/include/ida/ida.h
+++ b/include/ida/ida.h
@@ -224,6 +224,9 @@ SUNDIALS_EXPORT int IDAGetUserData(void* ida_mem, void** user_data);
 SUNDIALS_EXPORT int IDAPrintAllStats(void* ida_mem, FILE* outfile,
                                      SUNOutputFormat fmt);
 SUNDIALS_EXPORT char* IDAGetReturnFlagName(long int flag);
+SUNDIALS_EXPORT int IDAGetInterpData(void* ida_mem, N_Vector** phi,
+                                     sunrealtype** psi, int* kused,
+                                     sunrealtype* hused, sunrealtype* tn);
 
 /* Free function */
 SUNDIALS_EXPORT void IDAFree(void** ida_mem);

--- a/test/unit_tests/ida/gtest/CMakeLists.txt
+++ b/test/unit_tests/ida/gtest/CMakeLists.txt
@@ -39,3 +39,14 @@ target_link_libraries(test_ida_error_handling PRIVATE GTest::gtest_main
                                                       GTest::gmock)
 
 gtest_discover_tests(test_ida_error_handling)
+
+sundials_add_executable(test_ida_get_interp_data test_ida_get_interp_data.cpp)
+target_include_directories(
+  test_ida_get_interp_data
+  PRIVATE $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+          ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/src)
+
+target_link_libraries(test_ida_get_interp_data PRIVATE sundials_ida)
+target_link_libraries(test_ida_get_interp_data PRIVATE GTest::gtest_main
+                                                       GTest::gmock)
+gtest_discover_tests(test_ida_get_interp_data)

--- a/test/unit_tests/ida/gtest/test_ida_get_interp_data.cpp
+++ b/test/unit_tests/ida/gtest/test_ida_get_interp_data.cpp
@@ -1,0 +1,86 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <functional>
+#include <memory>
+
+#include <ida/ida.h>
+#include <nvector/nvector_serial.h>
+#include <sundials/sundials_context.hpp>
+#include <sundials/sundials_linearsolver.hpp>
+#include <sundials/sundials_matrix.hpp>
+#include <sundials/sundials_nvector.hpp>
+#include <sundials/sundials_types.h>
+#include <sunlinsol/sunlinsol_dense.h>
+#include <sunmatrix/sunmatrix_dense.h>
+
+#include "ida/ida_impl.h"
+
+int res(sunrealtype t, N_Vector y, N_Vector ydot, N_Vector residual,
+        void* user_data)
+{
+  NV_Ith_S(residual, 0) = NV_Ith_S(ydot, 0) - std::cos(t);
+  return 0;
+}
+
+TEST(IDAGetInterpData, ReturnsInterpolationDataForLastStep)
+{
+  using namespace sundials::experimental;
+
+  SUNErrCode sunerr;
+
+  const sunrealtype t0    = 0.0;
+  const sunrealtype y0    = 0.0;
+  const sunrealtype ydot0 = 1.0;
+
+  sundials::Context sunctx(SUN_COMM_NULL);
+
+  NVectorView y            = N_VNew_Serial(1, sunctx);
+  NV_Ith_S(y.Convert(), 0) = y0;
+
+  NVectorView ydot            = N_VNew_Serial(1, sunctx);
+  NV_Ith_S(ydot.Convert(), 0) = ydot0;
+
+  std::unique_ptr<void, std::function<void(void*)>> ida_mem(IDACreate(sunctx),
+                                                            [](void* p)
+                                                            { IDAFree(&p); });
+
+  ASSERT_EQ(IDAInit(ida_mem.get(), res, t0, y, ydot), 0);
+  ASSERT_EQ(IDASStolerances(ida_mem.get(), 1e-6, 1e-10), 0);
+
+  SUNMatrixView A        = SUNDenseMatrix(1, 1, sunctx);
+  SUNLinearSolverView LS = SUNLinSol_Dense(y, A, sunctx);
+  ASSERT_EQ(IDASetLinearSolver(ida_mem.get(), LS, A), 0);
+
+  const int N_STEPS      = 10;
+  const sunrealtype tout = 1.0;
+  sunrealtype t;
+  for (int n_step = 0; n_step < N_STEPS; ++n_step)
+  {
+    ASSERT_EQ(IDASolve(ida_mem.get(), tout, &t, y, ydot, IDA_ONE_STEP), 0);
+
+    N_Vector* phi;
+    sunrealtype* psi;
+    int kused;
+    sunrealtype hused;
+    sunrealtype tn;
+    ASSERT_EQ(IDAGetInterpData(ida_mem.get(), &phi, &psi, &kused, &hused, &tn),
+              0);
+
+    int ida_kused         = -1;
+    sunrealtype ida_hused = -1.0;
+    sunrealtype ida_tn    = -1.0;
+    IDAGetLastOrder(ida_mem.get(), &ida_kused);
+    IDAGetLastStep(ida_mem.get(), &ida_hused);
+    IDAGetCurrentTime(ida_mem.get(), &ida_tn);
+
+    auto ida_phi = static_cast<IDAMemRec*>(ida_mem.get())->ida_phi;
+    auto ida_psi = static_cast<IDAMemRec*>(ida_mem.get())->ida_psi;
+
+    ASSERT_EQ(phi, ida_phi);
+    ASSERT_EQ(psi, ida_psi);
+    ASSERT_EQ(kused, ida_kused);
+    ASSERT_EQ(hused, ida_hused);
+    ASSERT_EQ(tn, ida_tn);
+  }
+}


### PR DESCRIPTION
Adds new public API function `IDAGetInterpData` to `ida.h` (implemented in `ida_io.cpp`) permitting access to IDA polynomial interpolant constructed during the last successful solver step.  This permits users to extract and save the necessary data to construct a piecewise-defined interpolant across multiple steps.  This can be useful for offline evaluation, checkpointing, custom output, etc.

SUNDIALS PR Checklist:
- [x] Please target the `develop` branch not `main`.
- [x] Review our [Contributing Guide](https://github.com/LLNL/sundials/blob/main/CONTRIBUTING.md), and ensure that you sign your last commit (at minimum) as per the guide.
- [x] Provide a concise description of what your pull request does, and why it is needed/benefical.
- [x] Add a note about your change to the `CHANGELOG.md` and `docs/shared/RecentChanges.rst` files. Notice that the former is a markdown file and the latter is reStructuredText, so the formatting is slightly different.
- [ ] After your PR is opened, ensure that all of the tests are passing (a SUNDIALS developer will have to allow the testing to run).

