### PR TITLE
Bugfix: KINSOL initialize Anderson acceleration depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ solving a problem multiple times with the same KINSOL instance. In this use
 case, the current Anderson acceleration depth from the initial solve was not
 reinitialized on subsequent solves.
 
-Fixed a logging bug in KINSOL where logging messages would not but output.
+Fixed a logging bug in KINSOL where logging messages would not be output.
 
 Fixed a bug in the `suntools.logs` Python module where the `get_history`
 function, when given a `step_status` for filtering output from a multirate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ solving a problem multiple times with the same KINSOL instance. In this use
 case, the current Anderson acceleration depth from the initial solve was not
 reinitialized on subsequent solves.
 
+Fixed a logging bug in KINSOL where logging messages would not but output.
+
 Fixed a bug in the `suntools.logs` Python module where the `get_history`
 function, when given a `step_status` for filtering output from a multirate
 method, would only extract values from the fast time scale if the slow time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The latter method requires building with LAPACK support enabled.
 Added the function `LSRKStepSetDomEigEstimator` in LSRKStep to attach a
 `SUNDomEigEstimator`, when using Runge-Kutta-Chebyshev or Runge-Kutta-Legendre
 methods, as an alternative to supplying a user-defined function to compute the dominant
-eigenvalue. 
+eigenvalue.
 
 ### New Features and Enhancements
 
@@ -47,6 +47,11 @@ erroneous forcing terms.
 Fixed a bug in `ARKodeSetDefaults` with LSRKStep where the stored spectral
 radius data was reset to zero, flags to update the dominant eigenvalue were
 reset to true, and a flag indicating if an SSP is being used was reset to false.
+
+Fixed a bug introduced in v7.3.0 in KINSOL when using Anderson acceleration and
+solving a problem multiple times with the same KINSOL instance. In this use
+case, the current Anderson acceleration depth from the initial solve was not
+reinitialized on subsequent solves.
 
 Fixed a bug in the `suntools.logs` Python module where the `get_history`
 function, when given a `step_status` for filtering output from a multirate

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -53,6 +53,8 @@ solving a problem multiple times with the same KINSOL instance. In this use
 case, the current Anderson acceleration depth from the initial solve was not
 reinitialized on subsequent solves.
 
+Fixed a logging bug in KINSOL where logging messages would not but output.
+
 Fixed a bug in the ``suntools.logs`` Python module where the ``get_history``
 function, when given a ``step_status`` for filtering output from a multirate
 method, would only extract values from the fast time scale if the slow time

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -48,6 +48,11 @@ spectral radius data was reset to zero, flags to update the dominant eigenvalue
 were reset to true, and a flag indicating if an SSP is being used was reset to
 false.
 
+Fixed a bug introduced in v7.3.0 in KINSOL when using Anderson acceleration and
+solving a problem multiple times with the same KINSOL instance. In this use
+case, the current Anderson acceleration depth from the initial solve was not
+reinitialized on subsequent solves.
+
 Fixed a bug in the ``suntools.logs`` Python module where the ``get_history``
 function, when given a ``step_status`` for filtering output from a multirate
 method, would only extract values from the fast time scale if the slow time

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -53,7 +53,7 @@ solving a problem multiple times with the same KINSOL instance. In this use
 case, the current Anderson acceleration depth from the initial solve was not
 reinitialized on subsequent solves.
 
-Fixed a logging bug in KINSOL where logging messages would not but output.
+Fixed a logging bug in KINSOL where logging messages would not be output.
 
 Fixed a bug in the ``suntools.logs`` Python module where the ``get_history``
 function, when given a ``step_status`` for filtering output from a multirate

--- a/src/kinsol/kinsol.c
+++ b/src/kinsol/kinsol.c
@@ -149,6 +149,7 @@
 #define PRNT_BETA      10
 #define PRNT_ALPHABETA 11
 #define PRNT_ADJ       12
+#define PRNT_OTHER     13
 
 /*=================================================================*/
 /* Shortcuts                                                       */
@@ -2722,6 +2723,11 @@ static int AndersonAcc(KINMem kin_mem, N_Vector gval, N_Vector fv, N_Vector x,
     kin_mem->kin_current_depth++;
   }
 
+#if SUNDIALS_LOGGING_LEVEL >= SUNDIALS_LOGLEVEL_INFO
+  KINPrintInfo(kin_mem, PRNT_OTHER, "KINSOL", __func__,
+               "current_depth = %i", kin_mem->kin_current_depth);
+#endif
+
   N_VScale(ONE, gval, kin_mem->kin_gold_aa);
   N_VScale(ONE, fv, kin_mem->kin_fold_aa);
 
@@ -2796,6 +2802,11 @@ static int AndersonAcc(KINMem kin_mem, N_Vector gval, N_Vector fv, N_Vector x,
 
     new_depth = SUNMIN(new_depth, kin_mem->kin_current_depth);
     new_depth = SUNMAX(new_depth, 0);
+
+#if SUNDIALS_LOGGING_LEVEL >= SUNDIALS_LOGLEVEL_INFO
+  KINPrintInfo(kin_mem, PRNT_OTHER, "KINSOL", __func__,
+               "new_depth = %i", new_depth);
+#endif
 
     if (new_depth == 0)
     {

--- a/src/kinsol/kinsol.c
+++ b/src/kinsol/kinsol.c
@@ -2127,7 +2127,10 @@ void KINPrintInfo(SUNDIALS_MAYBE_UNUSED KINMem kin_mem, int info_code,
     vsnprintf(msg, sizeof msg, msgfmt, ap);
   }
 
-  SUNLogInfo(KIN_LOGGER, "KINSOL", fname, "%s", msg);
+  /* Call QueueMsg directly rather than using the SUNLogInfo macro in order to
+     use the passed in function name */
+  SUNLogger_QueueMsg(KIN_LOGGER, SUN_LOGLEVEL_INFO, fname, "KINSOL",
+                     "%s", msg);
 
   /* finalize argument processing */
 

--- a/src/kinsol/kinsol.c
+++ b/src/kinsol/kinsol.c
@@ -2130,8 +2130,7 @@ void KINPrintInfo(SUNDIALS_MAYBE_UNUSED KINMem kin_mem, int info_code,
 
   /* Call QueueMsg directly rather than using the SUNLogInfo macro in order to
      use the passed in function name */
-  SUNLogger_QueueMsg(KIN_LOGGER, SUN_LOGLEVEL_INFO, fname, "KINSOL",
-                     "%s", msg);
+  SUNLogger_QueueMsg(KIN_LOGGER, SUN_LOGLEVEL_INFO, fname, "KINSOL", "%s", msg);
 
   /* finalize argument processing */
 
@@ -2724,8 +2723,8 @@ static int AndersonAcc(KINMem kin_mem, N_Vector gval, N_Vector fv, N_Vector x,
   }
 
 #if SUNDIALS_LOGGING_LEVEL >= SUNDIALS_LOGLEVEL_INFO
-  KINPrintInfo(kin_mem, PRNT_OTHER, "KINSOL", __func__,
-               "current_depth = %i", kin_mem->kin_current_depth);
+  KINPrintInfo(kin_mem, PRNT_OTHER, "KINSOL", __func__, "current_depth = %i",
+               kin_mem->kin_current_depth);
 #endif
 
   N_VScale(ONE, gval, kin_mem->kin_gold_aa);
@@ -2804,8 +2803,8 @@ static int AndersonAcc(KINMem kin_mem, N_Vector gval, N_Vector fv, N_Vector x,
     new_depth = SUNMAX(new_depth, 0);
 
 #if SUNDIALS_LOGGING_LEVEL >= SUNDIALS_LOGLEVEL_INFO
-  KINPrintInfo(kin_mem, PRNT_OTHER, "KINSOL", __func__,
-               "new_depth = %i", new_depth);
+    KINPrintInfo(kin_mem, PRNT_OTHER, "KINSOL", __func__, "new_depth = %i",
+                 new_depth);
 #endif
 
     if (new_depth == 0)

--- a/src/kinsol/kinsol_aa.c
+++ b/src/kinsol/kinsol_aa.c
@@ -27,6 +27,9 @@ int KINInitAA(KINMem kin_mem)
     kin_mem->kin_m_aa = kin_mem->kin_mxiter - 1;
   }
 
+  // Initialize the current depth
+  kin_mem->kin_current_depth = 0;
+
   // Do we need to (re)allocate the AA workspace?
   sunbooleantype allocate = kin_mem->kin_m_aa > kin_mem->kin_m_aa_alloc;
 

--- a/test/unit_tests/kinsol/C_serial/CMakeLists.txt
+++ b/test/unit_tests/kinsol/C_serial/CMakeLists.txt
@@ -15,7 +15,10 @@
 # ---------------------------------------------------------------
 
 # List of test tuples of the form "name\;args"
-set(unit_tests "kin_test_getuserdata\;")
+set(unit_tests
+    "kin_test_getuserdata\;"
+    "kin_test_reuse_fp\;0"
+    "kin_test_reuse_fp\;1")
 
 # Add the build and install targets for each test
 foreach(test_tuple ${unit_tests})

--- a/test/unit_tests/kinsol/C_serial/CMakeLists.txt
+++ b/test/unit_tests/kinsol/C_serial/CMakeLists.txt
@@ -15,10 +15,8 @@
 # ---------------------------------------------------------------
 
 # List of test tuples of the form "name\;args"
-set(unit_tests
-    "kin_test_getuserdata\;"
-    "kin_test_reuse_fp\;0"
-    "kin_test_reuse_fp\;1")
+set(unit_tests "kin_test_getuserdata\;" "kin_test_reuse_fp\;0"
+               "kin_test_reuse_fp\;1")
 
 # Add the build and install targets for each test
 foreach(test_tuple ${unit_tests})

--- a/test/unit_tests/kinsol/C_serial/kin_test_reuse_fp.c
+++ b/test/unit_tests/kinsol/C_serial/kin_test_reuse_fp.c
@@ -1,0 +1,221 @@
+/* -----------------------------------------------------------------------------
+ * Programmer(s): David J. Gardner @ LLNL
+ * -----------------------------------------------------------------------------
+ * SUNDIALS Copyright Start
+ * Copyright (c) 2002-2025, Lawrence Livermore National Security
+ * and Southern Methodist University.
+ * All rights reserved.
+ *
+ * See the top-level LICENSE and NOTICE files for details.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SUNDIALS Copyright End
+ * -----------------------------------------------------------------------------
+ * Unit test for reusing a KINSOL instance based on bug report in the MFEM repo
+ * https://github.com/mfem/mfem/issues/5004
+ * ---------------------------------------------------------------------------*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "kinsol/kinsol.h"
+#include "nvector/nvector_serial.h"
+
+/* Fixed point function g(x) = 0.5x^2 + 0.25
+ * x = 0.5 x^2 + 0.25 -> roots ~ 0.292893 and 1.707106.
+ * At x* ~ 0.292893, g'(x*) = x* < 1 => contraction. */
+static int gfun(N_Vector x, N_Vector g, void* user_data)
+{
+  sunrealtype* x_data = N_VGetArrayPointer(x);
+  if (!x_data) { return -1; }
+  sunrealtype* g_data = N_VGetArrayPointer(g);
+  if (!g_data) { return -1; }
+
+  const double xv = x_data[0];
+  g_data[0]       = SUN_RCONST(0.5) * xv * xv + SUN_RCONST(0.25);
+
+  return 0;
+}
+
+int main(int argc, char* argv[])
+{
+  SUNContext sunctx = NULL;
+  int retval        = SUNContext_Create(SUN_COMM_NULL, &sunctx);
+  if (retval)
+  {
+    printf("ERROR: SUNContext_Create returned %i", retval);
+    return 1;
+  }
+
+  // Initial guess/solution vector
+  N_Vector x = N_VNew_Serial(1, sunctx);
+  if (!x)
+  {
+    printf("ERROR: N_VNew_Serial returned NULL");
+    return 1;
+  }
+
+  // Scaling vector
+  N_Vector scale = N_VClone(x);
+  if (!scale)
+  {
+    printf("ERROR: N_VClone returned NULL");
+    return 1;
+  }
+  N_VConst(1.0, scale);
+
+  // Create KINSOL
+  void* kmem = KINCreate(sunctx);
+  if (!kmem)
+  {
+    printf("ERROR: KINCreate returned NULL");
+    return 1;
+  }
+
+  retval = KINInit(kmem, gfun, x);
+  if (retval)
+  {
+    printf("ERROR: KINInit returned %i", retval);
+    return 1;
+  }
+
+  // Set options
+  int maa = 0;
+  if (argc > 1) { maa = atoi(argv[1]); }
+  printf("Anderson acceleration depth = %i\n", maa);
+  retval = KINSetMAA(kmem, maa);
+  if (retval)
+  {
+    printf("ERROR: KINSetMAA returned %i", retval);
+    return 1;
+  }
+
+  // -------
+  // Solve 1
+  // -------
+
+  // Set the initial guess
+  sunrealtype* x_data = N_VGetArrayPointer(x);
+  if (!x_data)
+  {
+    printf("ERROR: N_VGetArrayPointer returned NULL");
+    return 1;
+  }
+  x_data[0] = SUN_RCONST(0.10);
+
+  // Solve the system
+  retval = KINSol(kmem, x, KIN_FP, scale, scale);
+  if (retval)
+  {
+    printf("ERROR: KINSol returned %i", retval);
+    return 1;
+  }
+
+  printf("\nSolution 1:\n");
+  N_VPrint(x);
+  sunrealtype sol_1 = x_data[0];
+
+  // Get solver stats
+  long int nni_1;
+  retval = KINGetNumNonlinSolvIters(kmem, &nni_1);
+  if (retval)
+  {
+    printf("ERROR: KINGetNumNonlinSolvIters returned %i", retval);
+    return 1;
+  }
+
+  long int nfe_1;
+  retval = KINGetNumFuncEvals(kmem, &nfe_1);
+  if (retval)
+  {
+    printf("ERROR: KINGetNumFuncEvals returned %i", retval);
+    return 1;
+  }
+
+  printf("\nFinal Statistics:\n");
+  printf("Number of nonlinear iterations: %6ld\n", nni_1);
+  printf("Number of function evaluations: %6ld\n", nfe_1);
+
+  // -------
+  // Solve 2
+  // -------
+
+  // Reset the initial guess
+  x_data[0] = SUN_RCONST(0.10);
+
+  // Solve the system
+  retval = KINSol(kmem, x, KIN_FP, scale, scale);
+  if (retval)
+  {
+    printf("ERROR: KINSol returned %i", retval);
+    return 1;
+  }
+
+  printf("\nSolution 2:\n");
+  N_VPrint(x);
+  sunrealtype sol_2 = x_data[0];
+
+  // Get solver stats
+  long int nni_2;
+  retval = KINGetNumNonlinSolvIters(kmem, &nni_2);
+  if (retval)
+  {
+    printf("ERROR: KINGetNumNonlinSolvIters returned %i", retval);
+    return 1;
+  }
+
+  long int nfe_2;
+  retval = KINGetNumFuncEvals(kmem, &nfe_2);
+  if (retval)
+  {
+    printf("ERROR: KINGetNumFuncEvals returned %i", retval);
+    return 1;
+  }
+
+  printf("\nFinal Statistics:\n");
+  printf("Number of nonlinear iterations: %6ld\n", nni_2);
+  printf("Number of function evaluations: %6ld\n", nfe_2);
+
+  // --------------
+  // Compare solves
+  // --------------
+
+  // Solutions should be identical
+  if (sol_1 != sol_2)
+  {
+    printf("\nERROR: Solutions differ!\n");
+    printf("Solution 1: " SUN_FORMAT_G "\n", sol_1);
+    printf("Solution 2: " SUN_FORMAT_G "\n", sol_2);
+    return 1;
+  }
+
+  // Iterations should be identical
+  if (nni_1 != nni_2)
+  {
+    printf("\nERROR: Number of iterations differ!\n");
+    printf("Iterations 1: %ld\n", nni_1);
+    printf("Iterations 2: %ld\n", nni_2);
+    return 1;
+  }
+
+  // Evaluations should be identical
+  if (nfe_1 != nfe_2)
+  {
+    printf("\nERROR: Number of function evaluations differ!\n");
+    printf("Evaluations 1: %ld\n", nfe_1);
+    printf("Evaluations 2: %ld\n", nfe_2);
+    return 1;
+  }
+
+  // -----------
+  // Free memory
+  // -----------
+
+  N_VDestroy(x);
+  N_VDestroy(scale);
+  KINFree(&kmem);
+  SUNContext_Free(&sunctx);
+
+  return 0;
+}


### PR DESCRIPTION
* Initialize the Anderson acceleration depth every `KINSol` call
* Fix a logging bug where KINSOL logging messages would not be output
