### PR TITLE
add google analytics back

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,3 +4,4 @@ sphinx_rtd_theme
 sphinxcontrib.bibtex
 sphinx-copybutton
 sphinx-toolbox
+sphinxcontrib-googleanalytics

--- a/doc/superbuild/source/conf.py
+++ b/doc/superbuild/source/conf.py
@@ -53,6 +53,12 @@ intersphinx_mapping = {
     "sphinx": ("https://www.sphinx-doc.org/en/master", ("../objects.inv", None))
 }
 
+# Google analytics
+if os.getenv("GITHUB_ACTIONS"):
+    extensions.append("sphinxcontrib-googleanalytics")
+    googleanalytics_id = "G-3KESEG9QED"
+    googleanalytics_enabled = True
+
 # No non-external references will be resolved by intersphinx
 intersphinx_disabled_reftypes = ["*"]
 

--- a/doc/superbuild/source/conf.py
+++ b/doc/superbuild/source/conf.py
@@ -53,7 +53,7 @@ intersphinx_mapping = {
     "sphinx": ("https://www.sphinx-doc.org/en/master", ("../objects.inv", None))
 }
 
-# Google analytics
+# Only setup Google analytics for the deplpoyed readthedocs (not local)
 if os.getenv("GITHUB_ACTIONS"):
     extensions.append("sphinxcontrib.googleanalytics")
     googleanalytics_id = "G-3KESEG9QED"

--- a/doc/superbuild/source/conf.py
+++ b/doc/superbuild/source/conf.py
@@ -55,7 +55,7 @@ intersphinx_mapping = {
 
 # Google analytics
 if os.getenv("GITHUB_ACTIONS"):
-    extensions.append("sphinxcontrib-googleanalytics")
+    extensions.append("sphinxcontrib.googleanalytics")
     googleanalytics_id = "G-3KESEG9QED"
     googleanalytics_enabled = True
 

--- a/doc/superbuild/source/conf.py
+++ b/doc/superbuild/source/conf.py
@@ -53,7 +53,8 @@ intersphinx_mapping = {
     "sphinx": ("https://www.sphinx-doc.org/en/master", ("../objects.inv", None))
 }
 
-# Only setup Google analytics for the deplpoyed readthedocs (not local)
+# Only setup Google analytics for the readthedocs being deployed (not local).
+# We can do this by checking if we are running in GitHub actions.
 if os.getenv("GITHUB_ACTIONS"):
     extensions.append("sphinxcontrib.googleanalytics")
     googleanalytics_id = "G-3KESEG9QED"


### PR DESCRIPTION
readthedocs stopped supporting google analytics natively, so this is the only way to get it back.