### PR TITLE
use readthedocs env variable instead

### DIFF
--- a/doc/superbuild/source/conf.py
+++ b/doc/superbuild/source/conf.py
@@ -55,7 +55,7 @@ intersphinx_mapping = {
 
 # Only setup Google analytics for the readthedocs being deployed (not local).
 # We can do this by checking if we are running in GitHub actions.
-if os.getenv("GITHUB_ACTIONS"):
+if os.getenv("READTHEDOCS"):
     extensions.append("sphinxcontrib.googleanalytics")
     googleanalytics_id = "G-3KESEG9QED"
     googleanalytics_enabled = True


### PR DESCRIPTION
I forgot that our RTD deployment is built on RTD not in GitHub actions, so `GITHUB_ACTIONS` was the wrong variable to check. 