### PR TITLE
run ci only if [run-ci] is in commit message

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -10,6 +10,8 @@ concurrency:
 
 jobs:
   format_check:
+    if: contains(github.event.head_commit.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
+
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/llnl/sundials_spack_cache:llvm-17.0.4-h4lflucc3v2vage45opbo2didtcuigsn.spack

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   format_check:
-    if: contains(github.event.head_commit.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
+    if: contains(github.event.commits.*.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/check-spelling.yml
+++ b/.github/workflows/check-spelling.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   spelling_check:
-    if: contains(github.event.head_commit.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
+    if: contains(github.event.commits.*.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check-spelling.yml
+++ b/.github/workflows/check-spelling.yml
@@ -10,6 +10,8 @@ concurrency:
 
 jobs:
   spelling_check:
+    if: contains(github.event.head_commit.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
+
     runs-on: ubuntu-latest
     steps:
       - name: Install python3-pip

--- a/.github/workflows/check-swig.yml
+++ b/.github/workflows/check-swig.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   swig_check:
-    if: contains(github.event.head_commit.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
+    if: contains(github.event.commits.*.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check-swig.yml
+++ b/.github/workflows/check-swig.yml
@@ -10,6 +10,8 @@ concurrency:
 
 jobs:
   swig_check:
+    if: contains(github.event.head_commit.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
+
     runs-on: ubuntu-latest
     steps:
       - name: Install pcre

--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build_and_test:
-    if: contains(github.event.head_commit.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
+    if: contains(github.event.commits.*.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
 
     # The CMake configure and build commands are platform agnostic and should work equally
     # well on Windows or Mac.  You can convert this to a matrix build if you need

--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -15,6 +15,8 @@ env:
 
 jobs:
   build_and_test:
+    if: contains(github.event.head_commit.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
+
     # The CMake configure and build commands are platform agnostic and should work equally
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.

--- a/.github/workflows/test-address-sanitizer.yml
+++ b/.github/workflows/test-address-sanitizer.yml
@@ -16,6 +16,8 @@ concurrency:
 
 jobs:
   sanitizer_build_and_test:
+    if: contains(github.event.head_commit.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
+
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/llnl/sundials-ci-int${{ matrix.indexsize }}-${{ matrix.precision }}:latest

--- a/.github/workflows/test-address-sanitizer.yml
+++ b/.github/workflows/test-address-sanitizer.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   sanitizer_build_and_test:
-    if: contains(github.event.head_commit.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
+    if: contains(github.event.commits.*.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/ubuntu-latest-clang.yml
+++ b/.github/workflows/ubuntu-latest-clang.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build_cycle_log_levels:
-    if: contains(github.event.head_commit.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
+    if: contains(github.event.commits.*.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
 
     runs-on: ubuntu-latest
 
@@ -77,7 +77,7 @@ jobs:
           ${{ github.workspace }}/build/Testing/
 
   build_cycle_profiling:
-    if: contains(github.event.head_commit.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
+    if: contains(github.event.commits.*.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ubuntu-latest-clang.yml
+++ b/.github/workflows/ubuntu-latest-clang.yml
@@ -15,6 +15,8 @@ env:
 
 jobs:
   build_cycle_log_levels:
+    if: contains(github.event.head_commit.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
+
     runs-on: ubuntu-latest
 
     strategy:
@@ -75,6 +77,8 @@ jobs:
           ${{ github.workspace }}/build/Testing/
 
   build_cycle_profiling:
+    if: contains(github.event.head_commit.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
+
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/ubuntu-latest-oneapi.yml
+++ b/.github/workflows/ubuntu-latest-oneapi.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    if: contains(github.event.head_commit.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
+    if: contains(github.event.commits.*.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
 
     strategy:
       matrix:

--- a/.github/workflows/ubuntu-latest-oneapi.yml
+++ b/.github/workflows/ubuntu-latest-oneapi.yml
@@ -15,6 +15,8 @@ env:
 
 jobs:
   build:
+    if: contains(github.event.head_commit.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
+
     strategy:
       matrix:
         ONEAPI_VERSION: [

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -16,6 +16,8 @@ concurrency:
 
 jobs:
   build_and_test:
+    if: contains(github.event.head_commit.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
+
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/llnl/sundials-ci-int${{ matrix.indexsize }}-${{ matrix.precision }}:latest

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build_and_test:
-    if: contains(github.event.head_commit.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
+    if: contains(github.event.commits.*.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/windows-latest-intel.yml
+++ b/.github/workflows/windows-latest-intel.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build_and_test:
-    if: contains(github.event.head_commit.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
+    if: contains(github.event.commits.*.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
 
     runs-on: windows-latest
 

--- a/.github/workflows/windows-latest-intel.yml
+++ b/.github/workflows/windows-latest-intel.yml
@@ -15,6 +15,8 @@ env:
 
 jobs:
   build_and_test:
+    if: contains(github.event.head_commit.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
+
     runs-on: windows-latest
 
     steps:

--- a/.github/workflows/windows-latest-mingw.yml
+++ b/.github/workflows/windows-latest-mingw.yml
@@ -14,6 +14,8 @@ env:
 
 jobs:
   build_and_test:
+    if: contains(github.event.head_commit.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
+
     runs-on: windows-latest
 
     defaults:

--- a/.github/workflows/windows-latest-mingw.yml
+++ b/.github/workflows/windows-latest-mingw.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build_and_test:
-    if: contains(github.event.head_commit.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
+    if: contains(github.event.commits.*.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
 
     runs-on: windows-latest
 

--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build_and_test:
-    if: contains(github.event.head_commit.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
+    if: contains(github.event.commits.*.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
 
     runs-on: windows-latest
 

--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -14,6 +14,8 @@ env:
 
 jobs:
   build_and_test:
+    if: contains(github.event.head_commit.message, '[run-ci]') # This job only runs if commit message contains '[run-ci]'
+
     runs-on: windows-latest
 
     steps:


### PR DESCRIPTION
This will limit the GitHub actions CI to only commits with "[run-ci]" in the commit message. This will ensure we are not running the GitHub actions CI more than necessary. 