### PR TITLE
Bugfix: Ginkgo Batch Interface with 64-bit Index Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,18 @@
 
 ### Bug Fixes
 
-The SPRKStep module now accounts for zero coefficients in the SPRK tables, eliminating
-extraneous function evaluations.
+The interface to Ginkgo batched linear solvers has been updated to fix build
+errors when using 64-bit index types. Note, only the batched dense matrix in
+Ginkgo is currently compatible with 64-bit indexing (as of Ginkgo 1.10).
 
-A bug preventing a user supplied `SUNStepper_ResetCheckpointIndex` function from being
-called was fixed. 
+The interface to Ginkgo batched linear solvers has been updated to fix build
+errors when using 64-bit index types.
+
+The SPRKStep module now accounts for zero coefficients in the SPRK tables,
+eliminating extraneous function evaluations.
+
+A bug preventing a user supplied `SUNStepper_ResetCheckpointIndex` function from
+being called was fixed.
 
 ### Deprecation Notices
 

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -7,10 +7,14 @@
 
 **Bug Fixes**
 
-The SPRKStep module now accounts for zero coefficients in the SPRK tables, eliminating
-extraneous function evaluations.
+The interface to Ginkgo batched linear solvers has been updated to fix build
+errors when using 64-bit index types. Note, only the batched dense matrix in
+Ginkgo is currently compatible with 64-bit indexing (as of Ginkgo 1.10).
 
-A bug preventing a user supplied :c:func:`SUNStepper_ResetCheckpointIndex` function from being
-called was fixed. 
+The SPRKStep module now accounts for zero coefficients in the SPRK tables,
+eliminating extraneous function evaluations.
+
+A bug preventing a user supplied :c:func:`SUNStepper_ResetCheckpointIndex`
+function from being called was fixed.
 
 **Deprecation Notices**

--- a/examples/cvode/ginkgo/CMakeLists.txt
+++ b/examples/cvode/ginkgo/CMakeLists.txt
@@ -18,8 +18,11 @@
 # Example lists are tuples "name\;args\;type"
 
 # Examples that support CPU and GPU Ginkgo backends
-set(cpu_gpu_examples "cv_heat2D_ginkgo.cpp\;\;develop"
-                     "cv_bruss_batched_ginkgo.cpp\;\;develop")
+set(cpu_gpu_examples "cv_heat2D_ginkgo.cpp\;\;develop")
+
+if(SUNDIALS_INDEX_SIZE STREQUAL "32")
+  list(APPEND cpu_gpu_examples "cv_bruss_batched_ginkgo.cpp\;\;develop")
+endif()
 
 sundials_add_examples_ginkgo(
   cpu_gpu_examples

--- a/include/sunlinsol/sunlinsol_ginkgobatch.hpp
+++ b/include/sunlinsol/sunlinsol_ginkgobatch.hpp
@@ -409,8 +409,8 @@ public:
                                        iter_count_array_.get_data());
     auto iter_count = iter_count_array_.get_data();
 
-    sunindextype max_iter_count{0};
-    sunindextype min_iter_count{max_iters_};
+    int max_iter_count{0};
+    int min_iter_count{max_iters_};
     avg_iter_count_ = sunrealtype{0.0};
     for (gko::size_type i = 0; i < num_batches_; i++)
     {
@@ -468,7 +468,7 @@ private:
   gko::size_type num_batches_;
   int max_iters_;
   gko::array<sunrealtype> res_norm_array_;
-  gko::array<sunindextype> iter_count_array_;
+  gko::array<int> iter_count_array_;
   sunrealtype avg_iter_count_;
   sunrealtype sum_of_avg_iters_;
   sunrealtype stddev_iter_count_;

--- a/include/sunmatrix/sunmatrix_ginkgobatch.hpp
+++ b/include/sunmatrix/sunmatrix_ginkgobatch.hpp
@@ -34,9 +34,10 @@ namespace sundials {
 namespace ginkgo {
 
 using GkoBatchDenseMat = gko::batch::matrix::Dense<sunrealtype>;
-using GkoBatchCsrMat   = gko::batch::matrix::Csr<sunrealtype, sunindextype>;
 #ifdef SUNDIALS_INT32_T
-// Ginkgo currently (v1.10) supports only 32-bit index types with batch Ell
+// Ginkgo currently (v1.10) supports only 32-bit index types with the batch Ell
+// and CSR matrix
+using GkoBatchCsrMat   = gko::batch::matrix::Csr<sunrealtype, sunindextype>;
 using GkoBatchEllMat   = gko::batch::matrix::Ell<sunrealtype, sunindextype>;
 #endif
 using GkoBatchVecType  = gko::batch::MultiVector<sunrealtype>;
@@ -61,10 +62,10 @@ void Matvec(BatchMatrix<GkoBatchMatType>& A, N_Vector x, N_Vector y);
 void ScaleAdd(const sunrealtype c, BatchMatrix<GkoBatchDenseMat>& A,
               BatchMatrix<GkoBatchDenseMat>& B);
 
+#ifdef SUNDIALS_INT32_T
 void ScaleAdd(const sunrealtype c, BatchMatrix<GkoBatchCsrMat>& A,
               BatchMatrix<GkoBatchCsrMat>& B);
 
-#ifdef SUNDIALS_INT32_T
 void ScaleAdd(const sunrealtype c, BatchMatrix<GkoBatchEllMat>& A,
               BatchMatrix<GkoBatchEllMat>& B);
 #endif
@@ -247,6 +248,7 @@ inline BatchMatrix<GkoBatchDenseMat>::BatchMatrix(
   initSUNMatrix();
 }
 
+#ifdef SUNDIALS_INT32_T
 template<>
 inline BatchMatrix<GkoBatchCsrMat>::BatchMatrix(
   gko::size_type num_batches, sunindextype M, sunindextype N,
@@ -261,7 +263,6 @@ inline BatchMatrix<GkoBatchCsrMat>::BatchMatrix(
   initSUNMatrix();
 }
 
-#ifdef SUNDIALS_INT32_T
 template<>
 inline BatchMatrix<GkoBatchEllMat>::BatchMatrix(
   gko::size_type num_batches, sunindextype M, sunindextype N,
@@ -353,6 +354,7 @@ void ScaleAdd(const sunrealtype c, BatchMatrix<GkoBatchDenseMat>& A,
   A.GkoMtx()->scale_add(cmat.get(), B.GkoMtx().get());
 }
 
+#ifdef SUNDIALS_INT32_T
 void ScaleAdd(const sunrealtype c, BatchMatrix<GkoBatchCsrMat>& A,
               BatchMatrix<GkoBatchCsrMat>& B)
 {
@@ -360,7 +362,6 @@ void ScaleAdd(const sunrealtype c, BatchMatrix<GkoBatchCsrMat>& A,
   throw("scale_add not implemented for gko::batch::matrix::Csr");
 }
 
-#ifdef SUNDIALS_INT32_T
 void ScaleAdd(const sunrealtype c, BatchMatrix<GkoBatchEllMat>& A,
               BatchMatrix<GkoBatchEllMat>& B)
 {

--- a/include/sunmatrix/sunmatrix_ginkgobatch.hpp
+++ b/include/sunmatrix/sunmatrix_ginkgobatch.hpp
@@ -35,8 +35,7 @@ namespace ginkgo {
 
 using GkoBatchDenseMat = gko::batch::matrix::Dense<sunrealtype>;
 #ifdef SUNDIALS_INT32_T
-// Ginkgo currently (v1.10) supports only 32-bit index types with the batch Ell
-// and CSR matrix
+// Currently (Ginkgo v1.10) only the dense matrix supports 64-bit index types
 using GkoBatchCsrMat   = gko::batch::matrix::Csr<sunrealtype, sunindextype>;
 using GkoBatchEllMat   = gko::batch::matrix::Ell<sunrealtype, sunindextype>;
 #endif

--- a/include/sunmatrix/sunmatrix_ginkgobatch.hpp
+++ b/include/sunmatrix/sunmatrix_ginkgobatch.hpp
@@ -23,6 +23,7 @@
 #include <ginkgo/core/base/batch_multi_vector.hpp>
 #include <ginkgo/ginkgo.hpp>
 
+#include <sundials/sundials_config.h>
 #include <sundials/sundials_matrix.hpp>
 
 #if (GKO_VERSION_MAJOR < 1) || (GKO_VERSION_MAJOR == 1 && GKO_VERSION_MINOR < 9)
@@ -34,7 +35,10 @@ namespace ginkgo {
 
 using GkoBatchDenseMat = gko::batch::matrix::Dense<sunrealtype>;
 using GkoBatchCsrMat   = gko::batch::matrix::Csr<sunrealtype, sunindextype>;
+#ifdef SUNDIALS_INT32_T
+// Ginkgo currently (v1.10) supports only 32-bit index types with batch Ell
 using GkoBatchEllMat   = gko::batch::matrix::Ell<sunrealtype, sunindextype>;
+#endif
 using GkoBatchVecType  = gko::batch::MultiVector<sunrealtype>;
 
 // Forward declare BatchMatrix class
@@ -60,8 +64,10 @@ void ScaleAdd(const sunrealtype c, BatchMatrix<GkoBatchDenseMat>& A,
 void ScaleAdd(const sunrealtype c, BatchMatrix<GkoBatchCsrMat>& A,
               BatchMatrix<GkoBatchCsrMat>& B);
 
+#ifdef SUNDIALS_INT32_T
 void ScaleAdd(const sunrealtype c, BatchMatrix<GkoBatchEllMat>& A,
               BatchMatrix<GkoBatchEllMat>& B);
+#endif
 
 template<class GkoBatchMatType>
 void ScaleAddI(const sunrealtype c, BatchMatrix<GkoBatchMatType>& A);
@@ -255,6 +261,7 @@ inline BatchMatrix<GkoBatchCsrMat>::BatchMatrix(
   initSUNMatrix();
 }
 
+#ifdef SUNDIALS_INT32_T
 template<>
 inline BatchMatrix<GkoBatchEllMat>::BatchMatrix(
   gko::size_type num_batches, sunindextype M, sunindextype N,
@@ -268,6 +275,7 @@ inline BatchMatrix<GkoBatchEllMat>::BatchMatrix(
 {
   initSUNMatrix();
 }
+#endif
 
 // =============================================================================
 // Everything in the implementation (impl) namespace is private and should not
@@ -352,12 +360,14 @@ void ScaleAdd(const sunrealtype c, BatchMatrix<GkoBatchCsrMat>& A,
   throw("scale_add not implemented for gko::batch::matrix::Csr");
 }
 
+#ifdef SUNDIALS_INT32_T
 void ScaleAdd(const sunrealtype c, BatchMatrix<GkoBatchEllMat>& A,
               BatchMatrix<GkoBatchEllMat>& B)
 {
   // NOTE: This is not implemented by Ginkgo for BatchEll yet
   throw("scale_add not implemented for gko::batch::matrix::Ell");
 }
+#endif
 
 template<class GkoBatchMatType>
 void ScaleAddI(const sunrealtype c, BatchMatrix<GkoBatchMatType>& A)

--- a/include/sunmatrix/sunmatrix_ginkgobatch.hpp
+++ b/include/sunmatrix/sunmatrix_ginkgobatch.hpp
@@ -36,10 +36,10 @@ namespace ginkgo {
 using GkoBatchDenseMat = gko::batch::matrix::Dense<sunrealtype>;
 #ifdef SUNDIALS_INT32_T
 // Currently (Ginkgo v1.10) only the dense matrix supports 64-bit index types
-using GkoBatchCsrMat   = gko::batch::matrix::Csr<sunrealtype, sunindextype>;
-using GkoBatchEllMat   = gko::batch::matrix::Ell<sunrealtype, sunindextype>;
+using GkoBatchCsrMat = gko::batch::matrix::Csr<sunrealtype, sunindextype>;
+using GkoBatchEllMat = gko::batch::matrix::Ell<sunrealtype, sunindextype>;
 #endif
-using GkoBatchVecType  = gko::batch::MultiVector<sunrealtype>;
+using GkoBatchVecType = gko::batch::MultiVector<sunrealtype>;
 
 // Forward declare BatchMatrix class
 template<class GkoBatchMatType>

--- a/test/env/jenkins.sh
+++ b/test/env/jenkins.sh
@@ -219,15 +219,9 @@ fi
 
 if [ "$SUNDIALS_PRECISION" != "extended" ]; then
     if [ "$SUNDIALS_CUDA" == "ON" ]; then
-        if [ "$SUNDIALS_INDEX_SIZE" == "32" ]; then
-            export SUNDIALS_GINKGO=ON
-            export GINKGO_ROOT="$(spack location -i ginkgo@master +cuda)"
-            export GINKGO_BACKENDS="REF;OMP;CUDA"
-        else
-            export SUNDIALS_GINKGO=OFF
-            unset GINKGO_ROOT
-            unset GINKGO_BACKENDS
-        fi
+        export SUNDIALS_GINKGO=ON
+        export GINKGO_ROOT="$(spack location -i ginkgo@master +cuda)"
+        export GINKGO_BACKENDS="REF;OMP;CUDA"
     else
         export SUNDIALS_GINKGO=ON
         export GINKGO_ROOT="$(spack location -i ginkgo@master ~cuda)"

--- a/test/unit_tests/sunlinsol/ginkgo/CMakeLists.txt
+++ b/test/unit_tests/sunlinsol/ginkgo/CMakeLists.txt
@@ -28,8 +28,12 @@ set(examples
     "test_sunlinsol_ginkgo.cpp\;idr dense 100 0 100 0\;"
     "test_sunlinsol_ginkgo.cpp\;bicgstab csr 100 0 100 0\;"
     "test_sunlinsol_ginkgo.cpp\;bicgstab dense 100 0 100 0\;"
-    "test_sunlinsol_ginkgo_batch.cpp\;bicgstab csr 50 10 2 500 0\;"
     "test_sunlinsol_ginkgo_batch.cpp\;bicgstab dense 50 10 2 500 0\;")
+
+if(SUNDIALS_INDEX_SIZE STREQUAL "32")
+  list(APPEND examples
+       "test_sunlinsol_ginkgo_batch.cpp\;bicgstab csr 50 10 2 500 0\;")
+endif()
 
 # Add source directory to include directories
 include_directories(..)

--- a/test/unit_tests/sunlinsol/ginkgo/test_sunlinsol_ginkgo_batch.cpp
+++ b/test/unit_tests/sunlinsol/ginkgo/test_sunlinsol_ginkgo_batch.cpp
@@ -152,6 +152,14 @@ int main(int argc, char* argv[])
   std::transform(matrix_type.begin(), matrix_type.end(), matrix_type.begin(),
                  [](unsigned char c) { return std::tolower(c); });
 
+#ifdef SUNDIALS_INT64_T
+  if (matrix_type == "csr")
+  {
+    std::cerr << "ERROR: the CSR matrix type is not compatible with 64-bit index types\n";
+    return 1;
+  }
+#endif
+
   if (!matrix_types.count(matrix_type))
   {
     std::cerr << "ERROR: matrix type must be one of ";
@@ -243,6 +251,7 @@ int main(int argc, char* argv[])
 
   if (matrix_type == "csr")
   {
+#ifdef SUNDIALS_INT32_T
     using GkoMatrixType = gko::matrix::Csr<sunrealtype, sunindextype>;
     using GkoBatchMatrixType = gko::batch::matrix::Csr<sunrealtype, sunindextype>;
 
@@ -266,6 +275,9 @@ int main(int argc, char* argv[])
       sundials::ginkgo::BatchMatrix<GkoBatchMatrixType>>(std::move(
                                                            gko_batch_matrix),
                                                          sunctx);
+#else
+    return 1;
+#endif
   }
   else if (matrix_type == "dense")
   {
@@ -324,6 +336,7 @@ int main(int argc, char* argv[])
     using GkoSolverType = gko::batch::solver::Bicgstab<sunrealtype>;
     if (matrix_type == "csr")
     {
+#ifdef SUNDIALS_INT32_T
       using GkoBatchMatrixType = gko::batch::matrix::Csr<sunrealtype>;
       using SUNGkoLinearSolverType =
         BatchLinearSolver<GkoSolverType, GkoBatchMatrixType>;
@@ -332,6 +345,9 @@ int main(int argc, char* argv[])
                                                  gko::batch::stop::tolerance_type::absolute,
                                                  precond_factory, max_iters,
                                                  num_batches, sunctx);
+#else
+      return 1;
+#endif
     }
     else if (matrix_type == "dense")
     {

--- a/test/unit_tests/sunlinsol/ginkgo/test_sunlinsol_ginkgo_batch.cpp
+++ b/test/unit_tests/sunlinsol/ginkgo/test_sunlinsol_ginkgo_batch.cpp
@@ -71,7 +71,7 @@ const std::unordered_map<std::string, int> matrix_types{{"csr", 0}, {"dense", 1}
 constexpr sunrealtype solve_tolerance =
   1000 * std::numeric_limits<sunrealtype>::epsilon();
 
-static void fill_matrix_data(gko::matrix_data<sunrealtype>& data)
+static void fill_matrix_data(gko::matrix_data<sunrealtype, sunindextype>& data)
 {
   auto num_rows = data.size[0];
   for (gko::size_type row = 0; row < num_rows; ++row)
@@ -243,7 +243,7 @@ int main(int argc, char* argv[])
                                              gko::remove_complex<sunrealtype>{
                                                matcond},
                                              distribution_real, engine)
-      : gko::matrix_data<sunrealtype>(matrix_dim);
+      : gko::matrix_data<sunrealtype, sunindextype>(matrix_dim);
 
   if (matcond <= 0) { fill_matrix_data(gko_matdata); }
 

--- a/test/unit_tests/sunlinsol/ginkgo/test_sunlinsol_ginkgo_batch.cpp
+++ b/test/unit_tests/sunlinsol/ginkgo/test_sunlinsol_ginkgo_batch.cpp
@@ -155,7 +155,8 @@ int main(int argc, char* argv[])
 #ifdef SUNDIALS_INT64_T
   if (matrix_type == "csr")
   {
-    std::cerr << "ERROR: the CSR matrix type is not compatible with 64-bit index types\n";
+    std::cerr << "ERROR: the CSR matrix type is not compatible with 64-bit "
+                 "index types\n";
     return 1;
   }
 #endif

--- a/test/unit_tests/sunmatrix/ginkgo/CMakeLists.txt
+++ b/test/unit_tests/sunmatrix/ginkgo/CMakeLists.txt
@@ -28,9 +28,8 @@ set(examples
     "test_sunmatrix_ginkgo_batch.cpp\;10 100 10 1\;")
 
 if(SUNDIALS_INDEX_SIZE STREQUAL "32")
-  list(APPEND examples
-      "test_sunmatrix_ginkgo_batch.cpp\;10 10 10 0\;"
-      "test_sunmatrix_ginkgo_batch.cpp\;10 100 10 0\;")
+  list(APPEND examples "test_sunmatrix_ginkgo_batch.cpp\;10 10 10 0\;"
+       "test_sunmatrix_ginkgo_batch.cpp\;10 100 10 0\;")
 endif()
 
 # Add source directory to include directories

--- a/test/unit_tests/sunmatrix/ginkgo/CMakeLists.txt
+++ b/test/unit_tests/sunmatrix/ginkgo/CMakeLists.txt
@@ -24,10 +24,14 @@ set(examples
     "test_sunmatrix_ginkgo.cpp\;100 100 1\;"
     "test_sunmatrix_ginkgo.cpp\;100 10 1\;"
     "test_sunmatrix_ginkgo.cpp\;10 100 1\;"
-    "test_sunmatrix_ginkgo_batch.cpp\;10 10 10 0\;"
     "test_sunmatrix_ginkgo_batch.cpp\;10 10 10 1\;"
-    "test_sunmatrix_ginkgo_batch.cpp\;10 100 10 0\;"
     "test_sunmatrix_ginkgo_batch.cpp\;10 100 10 1\;")
+
+if(SUNDIALS_INDEX_SIZE STREQUAL "32")
+  list(APPEND examples
+      "test_sunmatrix_ginkgo_batch.cpp\;10 10 10 0\;"
+      "test_sunmatrix_ginkgo_batch.cpp\;10 100 10 0\;")
+endif()
 
 # Add source directory to include directories
 include_directories(..)

--- a/test/unit_tests/sunmatrix/ginkgo/test_sunmatrix_ginkgo_batch.cpp
+++ b/test/unit_tests/sunmatrix/ginkgo/test_sunmatrix_ginkgo_batch.cpp
@@ -50,7 +50,9 @@ using namespace sundials;
 using namespace sundials::ginkgo;
 
 using GkoDenseMat = gko::matrix::Dense<sunrealtype>;
+#ifdef SUNDIALS_INT32_T
 using GkoCsrMat   = gko::matrix::Csr<sunrealtype, sunindextype>;
+#endif
 using GkoVecType  = GkoDenseMat;
 
 bool using_csr_matrix_type   = false;
@@ -110,6 +112,7 @@ int main(int argc, char* argv[])
                                                         gko::OmpExecutor::create()))};
 
   /* check input and set vector length */
+#ifdef SUNDIALS_INT32_T
   if (argc < 5)
   {
     std::cerr << "ERROR: FOUR (4) Input required: matrix rows, matrix cols, "
@@ -117,6 +120,15 @@ int main(int argc, char* argv[])
                  "(0 = csr, 1 = dense)\n";
     return 1;
   }
+#else
+  if (argc < 4)
+  {
+    // Currently (Ginkgo v1.10) only the dense matrix supports 64-bit index types
+    std::cerr << "ERROR: FOUR (4) Input required: matrix rows, matrix cols, "
+                 "number of batches (batch entries)\n";
+    return 1;
+  }
+#endif
 
   int argi{0};
 
@@ -136,7 +148,11 @@ int main(int argc, char* argv[])
 
   auto num_batches{static_cast<gko::size_type>(atol(argv[++argi]))};
 
+#ifdef SUNDIALS_INT32_T
   auto format{static_cast<int>(atoi(argv[++argi]))};
+#else
+  auto format{1};
+#endif
   if (format != 0 && format != 1)
   {
     std::cerr << "ERROR: format must be 0 (csr) or 1 (dense) \n";
@@ -200,6 +216,7 @@ int main(int argc, char* argv[])
   SUNMatrix Aref{SUNDenseMatrix(tot_rows, tot_cols, sunctx)};
   if (using_csr_matrix_type)
   {
+#ifdef SUNDIALS_INT32_T
     auto gko_matrix{GkoCsrMat::create(gko_exec, matrix_dim)};
     gko_matrix->read(gko_matdata);
     auto num_nnz     = gko_matrix->get_num_stored_elements();
@@ -252,6 +269,9 @@ int main(int argc, char* argv[])
                                                       sunctx);
     I = std::make_unique<BatchMatrix<GkoBatchCsrMat>>(std::move(gko_batch_ident),
                                                       sunctx);
+#else
+    return 1;
+#endif
   }
   else if (using_dense_matrix_type)
   {
@@ -338,6 +358,7 @@ int main(int argc, char* argv[])
  * --------------------------------------------------------------------*/
 static int check_matrix_csr(SUNMatrix A, SUNMatrix B, sunrealtype tol)
 {
+#ifdef SUNDIALS_INT32_T
   int failure{0};
   auto Amat{static_cast<BatchMatrix<GkoBatchCsrMat>*>(A->content)->GkoMtx()};
   auto Bmat{static_cast<BatchMatrix<GkoBatchCsrMat>*>(B->content)->GkoMtx()};
@@ -362,6 +383,9 @@ static int check_matrix_csr(SUNMatrix A, SUNMatrix B, sunrealtype tol)
   }
 
   return failure > 0;
+#else
+  return 1;
+#endif
 }
 
 static int check_matrix_dense(SUNMatrix A, SUNMatrix B, sunrealtype tol)
@@ -408,6 +432,7 @@ extern "C" int check_matrix(SUNMatrix A, SUNMatrix B, sunrealtype tol)
 
 static int check_matrix_entry_csr(SUNMatrix A, sunrealtype val, sunrealtype tol)
 {
+#ifdef SUNDIALS_INT32_T
   int failure{0};
   auto Amat{static_cast<BatchMatrix<GkoBatchCsrMat>*>(A->content)->GkoMtx()};
   auto Amat_ref = Amat->clone(Amat->get_executor()->get_master());
@@ -422,6 +447,9 @@ static int check_matrix_entry_csr(SUNMatrix A, sunrealtype val, sunrealtype tol)
   }
 
   return failure > 0;
+#else
+  return 1;
+#endif
 }
 
 static int check_matrix_entry_dense(SUNMatrix A, sunrealtype val, sunrealtype tol)
@@ -504,8 +532,12 @@ extern "C" sunbooleantype has_data(SUNMatrix A)
 {
   if (using_csr_matrix_type)
   {
+#ifdef SUNDIALS_INT32_T
     auto Amat{static_cast<BatchMatrix<GkoBatchCsrMat>*>(A->content)->GkoMtx()};
     return !(Amat->get_values() == NULL || Amat->get_num_batch_items() == 0);
+#endif
+    return SUNFALSE;
+#endif
   }
   else if (using_dense_matrix_type)
   {
@@ -519,6 +551,7 @@ extern "C" sunbooleantype is_square(SUNMatrix A)
 {
   if (using_csr_matrix_type)
   {
+#ifdef SUNDIALS_INT32_T
     auto Amat{static_cast<BatchMatrix<GkoBatchCsrMat>*>(A->content)->GkoMtx()};
     if (Amat->get_size().get_common_size()[0] !=
         Amat->get_size().get_common_size()[1])
@@ -526,6 +559,9 @@ extern "C" sunbooleantype is_square(SUNMatrix A)
       return SUNFALSE;
     }
     return SUNTRUE;
+#else
+    return SUNFALSE;
+#endif
   }
   else if (using_dense_matrix_type)
   {

--- a/test/unit_tests/sunmatrix/ginkgo/test_sunmatrix_ginkgo_batch.cpp
+++ b/test/unit_tests/sunmatrix/ginkgo/test_sunmatrix_ginkgo_batch.cpp
@@ -112,7 +112,6 @@ int main(int argc, char* argv[])
                                                         gko::OmpExecutor::create()))};
 
   /* check input and set vector length */
-#ifdef SUNDIALS_INT32_T
   if (argc < 5)
   {
     std::cerr << "ERROR: FOUR (4) Input required: matrix rows, matrix cols, "
@@ -120,15 +119,6 @@ int main(int argc, char* argv[])
                  "(0 = csr, 1 = dense)\n";
     return 1;
   }
-#else
-  if (argc < 4)
-  {
-    // Currently (Ginkgo v1.10) only the dense matrix supports 64-bit index types
-    std::cerr << "ERROR: FOUR (4) Input required: matrix rows, matrix cols, "
-                 "number of batches (batch entries)\n";
-    return 1;
-  }
-#endif
 
   int argi{0};
 
@@ -148,16 +138,21 @@ int main(int argc, char* argv[])
 
   auto num_batches{static_cast<gko::size_type>(atol(argv[++argi]))};
 
-#ifdef SUNDIALS_INT32_T
   auto format{static_cast<int>(atoi(argv[++argi]))};
-#else
-  auto format{1};
-#endif
+#ifdef SUNDIALS_INT32_T
   if (format != 0 && format != 1)
   {
     std::cerr << "ERROR: format must be 0 (csr) or 1 (dense) \n";
     return 1;
   }
+#else
+  if (format != 1)
+  {
+    std::cerr << "ERROR: format must be 1 (dense) with 64-bit index types\n";
+    return 1;
+  }
+#endif
+
 
   if (format == 0) { using_csr_matrix_type = true; }
   else if (format == 1) { using_dense_matrix_type = true; }

--- a/test/unit_tests/sunmatrix/ginkgo/test_sunmatrix_ginkgo_batch.cpp
+++ b/test/unit_tests/sunmatrix/ginkgo/test_sunmatrix_ginkgo_batch.cpp
@@ -51,9 +51,9 @@ using namespace sundials::ginkgo;
 
 using GkoDenseMat = gko::matrix::Dense<sunrealtype>;
 #ifdef SUNDIALS_INT32_T
-using GkoCsrMat   = gko::matrix::Csr<sunrealtype, sunindextype>;
+using GkoCsrMat = gko::matrix::Csr<sunrealtype, sunindextype>;
 #endif
-using GkoVecType  = GkoDenseMat;
+using GkoVecType = GkoDenseMat;
 
 bool using_csr_matrix_type   = false;
 bool using_dense_matrix_type = false;
@@ -152,7 +152,6 @@ int main(int argc, char* argv[])
     return 1;
   }
 #endif
-
 
   if (format == 0) { using_csr_matrix_type = true; }
   else if (format == 1) { using_dense_matrix_type = true; }

--- a/test/unit_tests/sunmatrix/ginkgo/test_sunmatrix_ginkgo_batch.cpp
+++ b/test/unit_tests/sunmatrix/ginkgo/test_sunmatrix_ginkgo_batch.cpp
@@ -535,7 +535,7 @@ extern "C" sunbooleantype has_data(SUNMatrix A)
 #ifdef SUNDIALS_INT32_T
     auto Amat{static_cast<BatchMatrix<GkoBatchCsrMat>*>(A->content)->GkoMtx()};
     return !(Amat->get_values() == NULL || Amat->get_num_batch_items() == 0);
-#endif
+#else
     return SUNFALSE;
 #endif
   }


### PR DESCRIPTION
* Only the batch dense matrix in Ginkgo currently (v1.10) supports 64-bit index types 
* Fix type mismatch in `copy_from`, Ginkgo iteration counts are always `int`
* Enable Ginkgo in 64-bit index type tests
* Fixes #797