### PR TITLE
Properly handle unmanaged Kokkos views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ eliminating extraneous function evaluations.
 A bug preventing a user supplied `SUNStepper_ResetCheckpointIndex` function from
 being called was fixed.
 
+The Kokkos N_Vector now properly handles unmanaged views.
+
 ### Deprecation Notices
 
 ## Changes to SUNDIALS in release 7.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ eliminating extraneous function evaluations.
 A bug preventing a user supplied `SUNStepper_ResetCheckpointIndex` function from
 being called was fixed.
 
-The Kokkos N_Vector now properly handles unmanaged views.
+The Kokkos N_Vector now properly handles unmanaged views. Previously, if a
+Kokkos `N_Vector` was created from an unmanaged view, the view would become a
+managed view and the data would be freed unexpectedly.
 
 ### Deprecation Notices
 

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -17,4 +17,6 @@ eliminating extraneous function evaluations.
 A bug preventing a user supplied :c:func:`SUNStepper_ResetCheckpointIndex`
 function from being called was fixed.
 
+The Kokkos N_Vector now properly handles unmanaged views.
+
 **Deprecation Notices**

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -17,6 +17,8 @@ eliminating extraneous function evaluations.
 A bug preventing a user supplied :c:func:`SUNStepper_ResetCheckpointIndex`
 function from being called was fixed.
 
-The Kokkos N_Vector now properly handles unmanaged views.
+The Kokkos N_Vector now properly handles unmanaged views. Previously, if a
+Kokkos ``N_Vector`` was created from an unmanaged view, the view would become a
+managed view and the data would be freed unexpectedly.
 
 **Deprecation Notices**

--- a/include/nvector/nvector_kokkos.hpp
+++ b/include/nvector/nvector_kokkos.hpp
@@ -579,15 +579,19 @@ public:
   // Static routines to create clones of the vector that are always managed
 
   static Vector<exec_space, memory_space, Kokkos::MemoryManaged>* Clone(
-    const Vector<exec_space, memory_space, Kokkos::MemoryManaged>& that_vector, SUNContext sunctx)
+    const Vector<exec_space, memory_space, Kokkos::MemoryManaged>& that_vector,
+    SUNContext sunctx)
   {
-    return new Vector<exec_space, memory_space, Kokkos::MemoryManaged>(that_vector.Length(), sunctx);
+    return new Vector<exec_space, memory_space,
+                      Kokkos::MemoryManaged>(that_vector.Length(), sunctx);
   }
 
-  static Vector<exec_space, memory_space, Kokkos::MemoryManaged> *Clone(
-    const Vector<exec_space, memory_space, Kokkos::MemoryUnmanaged>& that_vector, SUNContext sunctx)
+  static Vector<exec_space, memory_space, Kokkos::MemoryManaged>* Clone(
+    const Vector<exec_space, memory_space, Kokkos::MemoryUnmanaged>& that_vector,
+    SUNContext sunctx)
   {
-    return new Vector<exec_space, memory_space, Kokkos::MemoryManaged>(that_vector.Length(), sunctx);
+    return new Vector<exec_space, memory_space,
+                      Kokkos::MemoryManaged>(that_vector.Length(), sunctx);
   }
 
 private:

--- a/include/nvector/nvector_kokkos.hpp
+++ b/include/nvector/nvector_kokkos.hpp
@@ -28,7 +28,7 @@ namespace sundials {
 namespace kokkos {
 
 // Forward declaration
-template<class ExecutionSpace, class MemorySpace>
+template<class ExecutionSpace, class MemorySpace, class MemoryTraits>
 class Vector;
 
 // Get the Kokkos vector wrapped by an N_Vector
@@ -77,7 +77,7 @@ template<class VectorType>
 N_Vector N_VClone_Kokkos(N_Vector w)
 {
   auto vec{GetVec<VectorType>(w)};
-  auto new_vec{new VectorType(*vec)};
+  auto new_vec = VectorType::Clone(*vec, w->sunctx);
   return new_vec->Convert();
 }
 
@@ -473,17 +473,19 @@ sunrealtype N_VWrmsNormMask_Kokkos(N_Vector x, N_Vector w, N_Vector id)
 // =============================================================================
 
 template<class ExecutionSpace = Kokkos::DefaultExecutionSpace,
-         class MemorySpace    = typename ExecutionSpace::memory_space>
+         class MemorySpace    = typename ExecutionSpace::memory_space,
+         class MemoryTraits   = Kokkos::MemoryManaged>
 class Vector : public sundials::impl::BaseNVector,
                public sundials::ConvertibleTo<N_Vector>
 {
 public:
-  using view_type      = Kokkos::View<sunrealtype*, MemorySpace>;
-  using size_type      = typename view_type::size_type;
+  using view_type      = Kokkos::View<sunrealtype*, MemorySpace, MemoryTraits>;
   using host_view_type = typename view_type::HostMirror;
   using memory_space   = MemorySpace;
+  using memory_traits  = MemoryTraits;
   using exec_space     = typename MemorySpace::execution_space;
   using range_policy   = Kokkos::RangePolicy<exec_space>;
+  using size_type      = typename view_type::size_type;
 
   // Default constructor
   Vector() = default;
@@ -574,13 +576,27 @@ public:
 
   N_Vector Convert() const override { return object_.get(); }
 
+  // Static routines to create clones of the vector that are always managed
+
+  static Vector<exec_space, memory_space, Kokkos::MemoryManaged>* Clone(
+    const Vector<exec_space, memory_space, Kokkos::MemoryManaged>& that_vector, SUNContext sunctx)
+  {
+    return new Vector<exec_space, memory_space, Kokkos::MemoryManaged>(that_vector.Length(), sunctx);
+  }
+
+  static Vector<exec_space, memory_space, Kokkos::MemoryManaged> *Clone(
+    const Vector<exec_space, memory_space, Kokkos::MemoryUnmanaged>& that_vector, SUNContext sunctx)
+  {
+    return new Vector<exec_space, memory_space, Kokkos::MemoryManaged>(that_vector.Length(), sunctx);
+  }
+
 private:
   view_type view_;
   host_view_type host_view_;
 
   void initNvector()
   {
-    using this_type = Vector<ExecutionSpace, MemorySpace>;
+    using this_type = Vector<ExecutionSpace, MemorySpace, MemoryTraits>;
 
     this->object_->content = this;
 


### PR DESCRIPTION
Previously, if you created our Kokkos N_Vector from an unmanaged view, it would become a managed view and the data would be freed unexpectedly. 