### PR TITLE
CMake: Set SUPERLUMT_WORKS=TRUE after success

### DIFF
--- a/cmake/tpl/SundialsSuperLUMT.cmake
+++ b/cmake/tpl/SundialsSuperLUMT.cmake
@@ -86,6 +86,9 @@ if(NOT SUPERLUMT_WORKS)
   # Check the result
   if(COMPILE_OK)
     message(CHECK_PASS "success")
+    set(SUPERLUMT_WORKS
+        TRUE
+        CACHE BOOL "SUPERLUMT works with SUNDIALS as configured" FORCE)
   else()
     message(CHECK_FAIL "failed")
     file(WRITE ${TEST_DIR}/compile.out "${COMPILE_OUTPUT}")


### PR DESCRIPTION
Amends #803

if SUPERLUMT_WORKS is not set to TRUE after a successful compilation test then it is considered disabled

/cc @gardner48


