### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # SUNDIALS: SUite of Nonlinear and DIfferential/ALgebraic equation Solvers #
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/llnl/sundials)
 
 [![track SUNDIALS downloads](https://github.com/sundials-codes/sundials-download-tracker/actions/workflows/nightly.yml/badge.svg)](https://github.com/sundials-codes/sundials-download-tracker/actions/workflows/nightly.yml)
 


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/llnl/sundials) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.