### PR TITLE
Feature: stageprocessing updates

### DIFF
--- a/include/arkode/arkode.h
+++ b/include/arkode/arkode.h
@@ -128,9 +128,9 @@ extern "C" {
 #define ARK_POSTPROCESS_FAIL             -37
 #define ARK_POSTPROCESS_STEP_FAIL        -37
 #define ARK_POSTPROCESS_STAGE_FAIL       -38
-#define ARK_POSTPROCESS_FAILED_STEP_FAIL -39
-#define ARK_PREPROCESS_STEP_FAIL         -40
-#define ARK_PREPROCESS_RHS_FAIL          -41
+#define ARK_PRESTEPFN_FAIL               -39
+#define ARK_POSTSTEPFN_FAIL              -40
+#define ARK_PRERHSFN_FAIL                -41
 
 #define ARK_USER_PREDICT_FAIL -42
 #define ARK_INTERP_FAIL       -43
@@ -186,7 +186,13 @@ typedef int (*ARKExpStabFn)(N_Vector y, sunrealtype t, sunrealtype* hstab,
 
 typedef int (*ARKVecResizeFn)(N_Vector y, N_Vector ytemplate, void* user_data);
 
+typedef int (*ARKPreStepFn)(sunrealtype t, N_Vector y, long int step, int attempt, void* user_data);
+
+typedef int (*ARKPostStepFn)(sunrealtype t, N_Vector y, long int step, void* user_data);
+
 typedef int (*ARKPostProcessFn)(sunrealtype t, N_Vector y, void* user_data);
+
+typedef int (*ARKPreRhsFn)(sunrealtype t, N_Vector y, void* user_data);
 
 typedef int (*ARKStagePredictFn)(sunrealtype t, N_Vector zpred, void* user_data);
 
@@ -279,14 +285,14 @@ SUNDIALS_EXPORT int ARKodeClearStopTime(void* arkode_mem);
 SUNDIALS_EXPORT int ARKodeSetFixedStep(void* arkode_mem, sunrealtype hfixed);
 SUNDIALS_EXPORT int ARKodeSetStepDirection(void* arkode_mem, sunrealtype stepdir);
 SUNDIALS_EXPORT int ARKodeSetUserData(void* arkode_mem, void* user_data);
-SUNDIALS_EXPORT int ARKodeSetPreprocessStepFn(void* arkode_mem,
-                                              ARKPostProcessFn ProcessStep);
+SUNDIALS_EXPORT int ARKodeSetPreStepFn(void* arkode_mem,
+                                       ARKPreStepFn prestep_fn);
+SUNDIALS_EXPORT int ARKodeSetPostStepFn(void* arkode_mem,
+                                        ARKPostStepFn poststep_fn);
+SUNDIALS_EXPORT int ARKodeSetPreRhsFn(void* arkode_mem,
+                                      ARKPreRhsFn prerhs_fn);
 SUNDIALS_EXPORT int ARKodeSetPostprocessStepFn(void* arkode_mem,
                                                ARKPostProcessFn ProcessStep);
-SUNDIALS_EXPORT int ARKodeSetPostprocessStepFailFn(void* arkode_mem,
-                                                   ARKPostProcessFn ProcessStep);
-SUNDIALS_EXPORT int ARKodeSetPreRHSProcessFn(void* arkode_mem,
-                                             ARKPostProcessFn PreRHSProcess);
 SUNDIALS_EXPORT int ARKodeSetPostprocessStageFn(void* arkode_mem,
                                                 ARKPostProcessFn ProcessStage);
 

--- a/include/arkode/arkode.h
+++ b/include/arkode/arkode.h
@@ -187,7 +187,7 @@ typedef int (*ARKExpStabFn)(N_Vector y, sunrealtype t, sunrealtype* hstab,
 typedef int (*ARKVecResizeFn)(N_Vector y, N_Vector ytemplate, void* user_data);
 
 typedef int (*ARKPreStepFn)(sunrealtype t, N_Vector y, long int step,
-                            long int attempt, void* user_data);
+                            int attempt, void* user_data);
 
 typedef int (*ARKPostStepFn)(sunrealtype t, N_Vector y, long int step,
                              void* user_data);

--- a/include/arkode/arkode.h
+++ b/include/arkode/arkode.h
@@ -125,12 +125,12 @@ extern "C" {
 
 /* ARK_POSTPROCESS_FAIL equals ARK_POSTPROCESS_STEP_FAIL
    for backwards compatibility. */
-#define ARK_POSTPROCESS_FAIL             -37
-#define ARK_POSTPROCESS_STEP_FAIL        -37
-#define ARK_POSTPROCESS_STAGE_FAIL       -38
-#define ARK_PRESTEPFN_FAIL               -39
-#define ARK_POSTSTEPFN_FAIL              -40
-#define ARK_PRERHSFN_FAIL                -41
+#define ARK_POSTPROCESS_FAIL       -37
+#define ARK_POSTPROCESS_STEP_FAIL  -37
+#define ARK_POSTPROCESS_STAGE_FAIL -38
+#define ARK_PRESTEPFN_FAIL         -39
+#define ARK_POSTSTEPFN_FAIL        -40
+#define ARK_PRERHSFN_FAIL          -41
 
 #define ARK_USER_PREDICT_FAIL -42
 #define ARK_INTERP_FAIL       -43
@@ -186,9 +186,11 @@ typedef int (*ARKExpStabFn)(N_Vector y, sunrealtype t, sunrealtype* hstab,
 
 typedef int (*ARKVecResizeFn)(N_Vector y, N_Vector ytemplate, void* user_data);
 
-typedef int (*ARKPreStepFn)(sunrealtype t, N_Vector y, long int step, int attempt, void* user_data);
+typedef int (*ARKPreStepFn)(sunrealtype t, N_Vector y, long int step,
+                            int attempt, void* user_data);
 
-typedef int (*ARKPostStepFn)(sunrealtype t, N_Vector y, long int step, void* user_data);
+typedef int (*ARKPostStepFn)(sunrealtype t, N_Vector y, long int step,
+                             void* user_data);
 
 typedef int (*ARKPostProcessFn)(sunrealtype t, N_Vector y, void* user_data);
 
@@ -285,12 +287,10 @@ SUNDIALS_EXPORT int ARKodeClearStopTime(void* arkode_mem);
 SUNDIALS_EXPORT int ARKodeSetFixedStep(void* arkode_mem, sunrealtype hfixed);
 SUNDIALS_EXPORT int ARKodeSetStepDirection(void* arkode_mem, sunrealtype stepdir);
 SUNDIALS_EXPORT int ARKodeSetUserData(void* arkode_mem, void* user_data);
-SUNDIALS_EXPORT int ARKodeSetPreStepFn(void* arkode_mem,
-                                       ARKPreStepFn prestep_fn);
+SUNDIALS_EXPORT int ARKodeSetPreStepFn(void* arkode_mem, ARKPreStepFn prestep_fn);
 SUNDIALS_EXPORT int ARKodeSetPostStepFn(void* arkode_mem,
                                         ARKPostStepFn poststep_fn);
-SUNDIALS_EXPORT int ARKodeSetPreRhsFn(void* arkode_mem,
-                                      ARKPreRhsFn prerhs_fn);
+SUNDIALS_EXPORT int ARKodeSetPreRhsFn(void* arkode_mem, ARKPreRhsFn prerhs_fn);
 SUNDIALS_EXPORT int ARKodeSetPostprocessStepFn(void* arkode_mem,
                                                ARKPostProcessFn ProcessStep);
 SUNDIALS_EXPORT int ARKodeSetPostprocessStageFn(void* arkode_mem,

--- a/include/arkode/arkode.h
+++ b/include/arkode/arkode.h
@@ -187,7 +187,7 @@ typedef int (*ARKExpStabFn)(N_Vector y, sunrealtype t, sunrealtype* hstab,
 typedef int (*ARKVecResizeFn)(N_Vector y, N_Vector ytemplate, void* user_data);
 
 typedef int (*ARKPreStepFn)(sunrealtype t, N_Vector y, long int step,
-                            int attempt, void* user_data);
+                            long int attempt, void* user_data);
 
 typedef int (*ARKPostStepFn)(sunrealtype t, N_Vector y, long int step,
                              void* user_data);

--- a/src/arkode/arkode.c
+++ b/src/arkode/arkode.c
@@ -915,7 +915,7 @@ int ARKodeEvolve(void* arkode_mem, sunrealtype tout, N_Vector yout,
       if (ark_mem->PreStepFn)
       {
         retval = ark_mem->PreStepFn(ark_mem->tcur, ark_mem->ycur, ark_mem->nst,
-                                    ark_mem->nst_attempts, ark_mem->user_data);
+                                    attempts, ark_mem->user_data);
         if (retval != 0) { return (ARK_PRESTEPFN_FAIL); }
       }
 

--- a/src/arkode/arkode.c
+++ b/src/arkode/arkode.c
@@ -2888,16 +2888,16 @@ int arkHandleFailure(ARKodeMem ark_mem, int flag)
                     __FILE__, MSG_ARK_POSTPROCESS_STAGE_FAIL, ark_mem->tcur);
     break;
   case ARK_PRESTEPFN_FAIL:
-    arkProcessError(ark_mem, ARK_PRESTEPFN_FAIL, __LINE__, __func__,
-                    __FILE__, MSG_ARK_PRESTEPFN_FAIL, ark_mem->tcur);
+    arkProcessError(ark_mem, ARK_PRESTEPFN_FAIL, __LINE__, __func__, __FILE__,
+                    MSG_ARK_PRESTEPFN_FAIL, ark_mem->tcur);
     break;
   case ARK_POSTSTEPFN_FAIL:
-    arkProcessError(ark_mem, ARK_POSTSTEPFN_FAIL, __LINE__, __func__,
-                    __FILE__, MSG_ARK_POSTSTEPFN_FAIL, ark_mem->tcur);
+    arkProcessError(ark_mem, ARK_POSTSTEPFN_FAIL, __LINE__, __func__, __FILE__,
+                    MSG_ARK_POSTSTEPFN_FAIL, ark_mem->tcur);
     break;
   case ARK_PRERHSFN_FAIL:
-    arkProcessError(ark_mem, ARK_PRERHSFN_FAIL, __LINE__, __func__,
-                    __FILE__, MSG_ARK_PRERHSFN_FAIL, ark_mem->tcur);
+    arkProcessError(ark_mem, ARK_PRERHSFN_FAIL, __LINE__, __func__, __FILE__,
+                    MSG_ARK_PRERHSFN_FAIL, ark_mem->tcur);
     break;
   case ARK_INTERP_FAIL:
     arkProcessError(ark_mem, ARK_INTERP_FAIL, __LINE__, __func__, __FILE__,

--- a/src/arkode/arkode.c
+++ b/src/arkode/arkode.c
@@ -663,7 +663,6 @@ int ARKodeEvolve(void* arkode_mem, sunrealtype tout, N_Vector yout,
   int ewtsetOK;
   sunrealtype troundoff, nrm;
   sunbooleantype inactive_roots;
-  sunbooleantype skip_preprocess;
   sunrealtype dsm;
   int nflag, ncf, nef, constrfails;
   int relax_fails;
@@ -888,11 +887,10 @@ int ARKodeEvolve(void* arkode_mem, sunrealtype tout, N_Vector yout,
     }
 
     /* Looping point for step attempts */
-    dsm             = ZERO;
-    kflag           = ARK_SUCCESS;
-    skip_preprocess = SUNFALSE;
-    relax_fails     = 0;
-    nflag           = FIRST_CALL;
+    dsm         = ZERO;
+    kflag       = ARK_SUCCESS;
+    relax_fails = 0;
+    nflag       = FIRST_CALL;
     attempts = ncf = nef = constrfails = ark_mem->last_kflag = 0;
     for (;;)
     {
@@ -913,14 +911,13 @@ int ARKodeEvolve(void* arkode_mem, sunrealtype tout, N_Vector yout,
       /* fill tcur with the last accepted step time */
       ark_mem->tcur = ark_mem->tn;
 
-      /* call the user-supplied step preprocessing function (if it exists) */
-      if (ark_mem->PreProcessStep != NULL && !skip_preprocess)
+      /* call the user-supplied pre-step function (if it exists) */
+      if (ark_mem->PreStepFn)
       {
-        retval = ark_mem->PreProcessStep(ark_mem->tcur, ark_mem->ycur,
-                                         ark_mem->ps_data);
-        if (retval != 0) { return (ARK_PREPROCESS_STEP_FAIL); }
+        retval = ark_mem->PreStepFn(ark_mem->tcur, ark_mem->ycur, ark_mem->nst,
+                                    ark_mem->nst_attempts, ark_mem->user_data);
+        if (retval != 0) { return (ARK_PRESTEPFN_FAIL); }
       }
-      skip_preprocess = SUNFALSE;
 
       /* Call time stepper module to attempt a step:
             0 => step completed successfully
@@ -1018,16 +1015,6 @@ int ARKodeEvolve(void* arkode_mem, sunrealtype tout, N_Vector yout,
       /* update h, hprime and next_h for next iteration */
       ark_mem->h *= ark_mem->eta;
       ark_mem->next_h = ark_mem->hprime = ark_mem->h;
-
-      /* since the previous step attempt failed, call the user-supplied
-         step failure postprocessing function (if it exists) */
-      if (ark_mem->PostProcessStepFail != NULL)
-      {
-        retval = ark_mem->PostProcessStepFail(ark_mem->tn, ark_mem->yn,
-                                              ark_mem->ps_data);
-        if (retval != 0) { return (ARK_POSTPROCESS_FAILED_STEP_FAIL); }
-        skip_preprocess = SUNTRUE;
-      }
 
       /* reset (tcur,ycur) to last saved state before reattempting step */
       ark_mem->tcur = ark_mem->tn;
@@ -1619,15 +1606,16 @@ ARKodeMem arkCreate(SUNContext sunctx)
   ark_mem->VRabstolMallocDone = SUNFALSE;
   ark_mem->MallocDone         = SUNFALSE;
 
-  /* No user-supplied step pre- or post-processing functions yet */
-  ark_mem->PreProcessStep      = NULL;
-  ark_mem->PostProcessStep     = NULL;
-  ark_mem->PostProcessStepFail = NULL;
-  ark_mem->ps_data             = NULL;
+  /* No user-supplied pre- or post-step functions yet */
+  ark_mem->PreStepFn  = NULL;
+  ark_mem->PostStepFn = NULL;
 
-  /* No user-supplied stage pre- or post-processing functions yet */
-  ark_mem->PreRHSProcess    = NULL;
-  ark_mem->PostProcessStage = NULL;
+  /* No user-supplied pre-RHS function yet */
+  ark_mem->PreRhsFn = NULL;
+
+  /* No user-supplied stage/step post-processing functions yet */
+  ark_mem->PostProcessStepFn  = NULL;
+  ark_mem->PostProcessStageFn = NULL;
 
   /* No user_data pointer yet */
   ark_mem->user_data = NULL;
@@ -2761,12 +2749,12 @@ int arkCompleteStep(ARKodeMem ark_mem, sunrealtype dsm)
     else /* ARK_ACCUMERROR_AVG */ { ark_mem->AccumError += (dsm * ark_mem->h); }
   }
 
-  /* apply user-supplied step postprocessing function (if supplied) */
-  if (ark_mem->PostProcessStep != NULL)
+  /* call the user-supplied post-step function (if supplied) */
+  if (ark_mem->PostStepFn)
   {
-    retval = ark_mem->PostProcessStep(ark_mem->tcur, ark_mem->ycur,
-                                      ark_mem->ps_data);
-    if (retval != 0) { return (ARK_POSTPROCESS_STEP_FAIL); }
+    retval = ark_mem->PostStepFn(ark_mem->tcur, ark_mem->ycur, ark_mem->nst,
+                                 ark_mem->user_data);
+    if (retval != 0) { return (ARK_POSTSTEPFN_FAIL); }
   }
 
   /* update interpolation structure
@@ -2899,18 +2887,17 @@ int arkHandleFailure(ARKodeMem ark_mem, int flag)
     arkProcessError(ark_mem, ARK_POSTPROCESS_STAGE_FAIL, __LINE__, __func__,
                     __FILE__, MSG_ARK_POSTPROCESS_STAGE_FAIL, ark_mem->tcur);
     break;
-  case ARK_POSTPROCESS_FAILED_STEP_FAIL:
-    arkProcessError(ark_mem, ARK_POSTPROCESS_FAILED_STEP_FAIL, __LINE__,
-                    __func__, __FILE__, MSG_ARK_POSTPROCESS_FAILED_STEP_FAIL,
-                    ark_mem->tcur);
+  case ARK_PRESTEPFN_FAIL:
+    arkProcessError(ark_mem, ARK_PRESTEPFN_FAIL, __LINE__, __func__,
+                    __FILE__, MSG_ARK_PRESTEPFN_FAIL, ark_mem->tcur);
     break;
-  case ARK_PREPROCESS_STEP_FAIL:
-    arkProcessError(ark_mem, ARK_PREPROCESS_STEP_FAIL, __LINE__, __func__,
-                    __FILE__, MSG_ARK_PREPROCESS_STEP_FAIL, ark_mem->tcur);
+  case ARK_POSTSTEPFN_FAIL:
+    arkProcessError(ark_mem, ARK_POSTSTEPFN_FAIL, __LINE__, __func__,
+                    __FILE__, MSG_ARK_POSTSTEPFN_FAIL, ark_mem->tcur);
     break;
-  case ARK_PREPROCESS_RHS_FAIL:
-    arkProcessError(ark_mem, ARK_PREPROCESS_RHS_FAIL, __LINE__, __func__,
-                    __FILE__, MSG_ARK_PREPROCESS_RHS_FAIL, ark_mem->tcur);
+  case ARK_PRERHSFN_FAIL:
+    arkProcessError(ark_mem, ARK_PRERHSFN_FAIL, __LINE__, __func__,
+                    __FILE__, MSG_ARK_PRERHSFN_FAIL, ark_mem->tcur);
     break;
   case ARK_INTERP_FAIL:
     arkProcessError(ark_mem, ARK_INTERP_FAIL, __LINE__, __func__, __FILE__,

--- a/src/arkode/arkode_arkstep.c
+++ b/src/arkode/arkode_arkstep.c
@@ -1869,7 +1869,8 @@ int arkStep_TakeStep_Z(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
         /* call the user-supplied pre-RHS function (if supplied) */
         if (ark_mem->PreRhsFn)
         {
-          retval = ark_mem->PreRhsFn(ark_mem->tn, ark_mem->yn, ark_mem->user_data);
+          retval = ark_mem->PreRhsFn(ark_mem->tn, ark_mem->yn,
+                                     ark_mem->user_data);
           if (retval != 0)
           {
             SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -2049,7 +2050,8 @@ int arkStep_TakeStep_Z(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
        step postprocessing function instead (if supplied) */
     /* NOTE: with internally inconsistent IMEX methods (c_i^E != c_i^I) the value
        of tcur corresponds to the stage time from the implicit table (c_i^I). */
-    if (is == step_mem->stages - 1 && stiffly_accurate && ark_mem->PostProcessStepFn)
+    if (is == step_mem->stages - 1 && stiffly_accurate &&
+        ark_mem->PostProcessStepFn)
     {
       retval = ark_mem->PostProcessStepFn(ark_mem->tcur, ark_mem->ycur,
                                           ark_mem->user_data);
@@ -2120,7 +2122,8 @@ int arkStep_TakeStep_Z(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
     {
       if ((step_mem->implicit && !deduce_stage) || (step_mem->explicit))
       {
-        retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur, ark_mem->user_data);
+        retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur,
+                                   ark_mem->user_data);
         if (retval != 0)
         {
           SUNLogInfo(ARK_LOGGER, "end-stages-list",

--- a/src/arkode/arkode_arkstep.c
+++ b/src/arkode/arkode_arkstep.c
@@ -2044,10 +2044,23 @@ int arkStep_TakeStep_Z(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
                           "z_%i(:) =", is);
     }
 
-    /* apply user-supplied stage postprocessing function (if supplied) */
+    /* apply user-supplied stage postprocessing function (if supplied) unless
+       this is the last stage of a FSAL method, then apply the user-supplied
+       step postprocessing function instead (if supplied) */
     /* NOTE: with internally inconsistent IMEX methods (c_i^E != c_i^I) the value
        of tcur corresponds to the stage time from the implicit table (c_i^I). */
-    if (ark_mem->PostProcessStageFn)
+    if (is == step_mem->stages - 1 && stiffly_accurate && ark_mem->PostProcessStepFn)
+    {
+      retval = ark_mem->PostProcessStepFn(ark_mem->tcur, ark_mem->ycur,
+                                          ark_mem->user_data);
+      if (retval != 0)
+      {
+        SUNLogInfo(ARK_LOGGER, "end-stages-list",
+                   "status = failed postprocess step, retval = %i", retval);
+        return (ARK_POSTPROCESS_STEP_FAIL);
+      }
+    }
+    else if (ark_mem->PostProcessStageFn)
     {
       retval = ark_mem->PostProcessStageFn(ark_mem->tcur, ark_mem->ycur,
                                            ark_mem->user_data);
@@ -2221,6 +2234,8 @@ int arkStep_TakeStep_Z(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
   /* compute time-evolved solution (in ark_ycur), error estimate (in dsm).
      This can fail recoverably due to nonconvergence of the mass matrix solve,
      so handle that appropriately. */
+  ark_mem->tcur = ark_mem->tn + ark_mem->h;
+
   if (step_mem->mass_type == MASS_FIXED)
   {
     *nflagPtr = arkStep_ComputeSolutions_MassFixed(ark_mem, dsmPtr);
@@ -2232,19 +2247,6 @@ int arkStep_TakeStep_Z(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
 
   if (*nflagPtr < 0) { return (*nflagPtr); }
   if (*nflagPtr > 0) { return (TRY_AGAIN); }
-
-  /* apply user-supplied stage postprocessing function (if supplied) */
-  if (ark_mem->PostProcessStageFn)
-  {
-    retval = ark_mem->PostProcessStageFn(ark_mem->tcur, ark_mem->ycur,
-                                         ark_mem->user_data);
-    if (retval != 0)
-    {
-      SUNLogInfo(ARK_LOGGER, "end-stages-list",
-                 "status = failed postprocess stage, retval = %i", retval);
-      return (ARK_POSTPROCESS_STAGE_FAIL);
-    }
-  }
 
   if (ark_mem->checkpoint_scheme)
   {
@@ -3327,6 +3329,13 @@ int arkStep_ComputeSolutions(ARKodeMem ark_mem, sunrealtype* dsmPtr)
     /*   call fused vector operation to do the work */
     retval = N_VLinearCombination(nvec, cvals, Xvecs, y);
     if (retval != 0) { return (ARK_VECTOROP_ERR); }
+
+    if (ark_mem->PostProcessStepFn)
+    {
+      retval = ark_mem->PostProcessStepFn(ark_mem->tcur, ark_mem->ycur,
+                                          ark_mem->user_data);
+      if (retval != 0) { return (ARK_POSTPROCESS_STEP_FAIL); }
+    }
   }
 
   /* Compute yerr (if temporal error estimation is enabled). */
@@ -3487,6 +3496,13 @@ int arkStep_ComputeSolutions_MassFixed(ARKodeMem ark_mem, sunrealtype* dsmPtr)
 
     /* compute y = yn + update */
     N_VLinearSum(ONE, ark_mem->yn, ONE, y, y);
+
+    if (ark_mem->PostProcessStepFn)
+    {
+      retval = ark_mem->PostProcessStepFn(ark_mem->tcur, ark_mem->ycur,
+                                          ark_mem->user_data);
+      if (retval != 0) { return (ARK_POSTPROCESS_STEP_FAIL); }
+    }
   }
 
   /* compute yerr (if step adaptivity enabled) */

--- a/src/arkode/arkode_arkstep.c
+++ b/src/arkode/arkode_arkstep.c
@@ -1330,11 +1330,11 @@ int arkStep_FullRHS(ARKodeMem ark_mem, sunrealtype t, N_Vector y, N_Vector f,
     /* compute the full RHS */
     if (!(ark_mem->fn_is_current))
     {
-      /* apply user-supplied stage preprocessing function (if supplied) */
-      if (ark_mem->PreRHSProcess != NULL)
+      /* call the user-supplied pre-RHS function (if supplied) */
+      if (ark_mem->PreRhsFn)
       {
-        retval = ark_mem->PreRHSProcess(t, y, ark_mem->user_data);
-        if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+        retval = ark_mem->PreRhsFn(t, y, ark_mem->user_data);
+        if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
       }
 
       /* compute the implicit component */
@@ -1462,11 +1462,11 @@ int arkStep_FullRHS(ARKodeMem ark_mem, sunrealtype t, N_Vector y, N_Vector f,
       /* recompute RHS functions */
       if (recomputeRHS)
       {
-        /* apply user-supplied stage preprocessing function (if supplied) */
-        if (ark_mem->PreRHSProcess != NULL)
+        /* call the user-supplied pre-RHS function (if supplied) */
+        if (ark_mem->PreRhsFn)
         {
-          retval = ark_mem->PreRHSProcess(t, y, ark_mem->user_data);
-          if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+          retval = ark_mem->PreRhsFn(t, y, ark_mem->user_data);
+          if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
         }
 
         /* compute the implicit component */
@@ -1578,11 +1578,11 @@ int arkStep_FullRHS(ARKodeMem ark_mem, sunrealtype t, N_Vector y, N_Vector f,
 
   case ARK_FULLRHS_OTHER:
 
-    /* apply user-supplied stage preprocessing function (if supplied) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(t, y, ark_mem->user_data);
-      if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+      retval = ark_mem->PreRhsFn(t, y, ark_mem->user_data);
+      if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
     }
 
     /* compute the implicit component and store in sdata */
@@ -1866,16 +1866,15 @@ int arkStep_TakeStep_Z(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
       }
       else
       {
-        /* apply user-supplied stage preprocessing function (if supplied) */
-        if (ark_mem->PreRHSProcess != NULL)
+        /* call the user-supplied pre-RHS function (if supplied) */
+        if (ark_mem->PreRhsFn)
         {
-          retval = ark_mem->PreRHSProcess(ark_mem->tn, ark_mem->yn,
-                                          ark_mem->user_data);
+          retval = ark_mem->PreRhsFn(ark_mem->tn, ark_mem->yn, ark_mem->user_data);
           if (retval != 0)
           {
             SUNLogInfo(ARK_LOGGER, "end-stages-list",
                        "status = failed preprocess rhs, retval = %i", retval);
-            return (ARK_PREPROCESS_RHS_FAIL);
+            return (ARK_PRERHSFN_FAIL);
           }
         }
         retval = step_mem->fi(ark_mem->tn, ark_mem->yn, step_mem->Fi[0],
@@ -2048,10 +2047,10 @@ int arkStep_TakeStep_Z(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
     /* apply user-supplied stage postprocessing function (if supplied) */
     /* NOTE: with internally inconsistent IMEX methods (c_i^E != c_i^I) the value
        of tcur corresponds to the stage time from the implicit table (c_i^I). */
-    if (ark_mem->PostProcessStage != NULL)
+    if (ark_mem->PostProcessStageFn)
     {
-      retval = ark_mem->PostProcessStage(ark_mem->tcur, ark_mem->ycur,
-                                         ark_mem->user_data);
+      retval = ark_mem->PostProcessStageFn(ark_mem->tcur, ark_mem->ycur,
+                                           ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -2101,20 +2100,19 @@ int arkStep_TakeStep_Z(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
       }
     }
 
-    /* apply user-supplied stage preprocessing function (if supplied) */
+    /* call the user-supplied pre-RHS function (if supplied) */
     /* NOTE: with internally inconsistent IMEX methods (c_i^E != c_i^I) the value
        of tcur corresponds to the stage time from the implicit table (c_i^I). */
-    if (ark_mem->PreRHSProcess != NULL)
+    if (ark_mem->PreRhsFn)
     {
       if ((step_mem->implicit && !deduce_stage) || (step_mem->explicit))
       {
-        retval = ark_mem->PreRHSProcess(ark_mem->tcur, ark_mem->ycur,
-                                        ark_mem->user_data);
+        retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur, ark_mem->user_data);
         if (retval != 0)
         {
           SUNLogInfo(ARK_LOGGER, "end-stages-list",
                      "status = failed preprocess rhs, retval = %i", retval);
-          return (ARK_PREPROCESS_RHS_FAIL);
+          return (ARK_PRERHSFN_FAIL);
         }
       }
     }
@@ -2236,10 +2234,10 @@ int arkStep_TakeStep_Z(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
   if (*nflagPtr > 0) { return (TRY_AGAIN); }
 
   /* apply user-supplied stage postprocessing function (if supplied) */
-  if (ark_mem->PostProcessStage != NULL)
+  if (ark_mem->PostProcessStageFn)
   {
-    retval = ark_mem->PostProcessStage(ark_mem->tcur, ark_mem->ycur,
-                                       ark_mem->user_data);
+    retval = ark_mem->PostProcessStageFn(ark_mem->tcur, ark_mem->ycur,
+                                         ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",

--- a/src/arkode/arkode_arkstep_nls.c
+++ b/src/arkode/arkode_arkstep_nls.c
@@ -584,12 +584,11 @@ int arkStep_NlsResidual_MassIdent(N_Vector zcor, N_Vector r, void* arkode_mem)
   /* update 'ycur' value as stored predictor + current corrector */
   N_VLinearSum(ONE, step_mem->zpred, ONE, zcor, ark_mem->ycur);
 
-  /* apply user-supplied RHS preprocessing function (if supplied), and then call RHS */
-  if (ark_mem->PreRHSProcess != NULL)
+  /* call the user-supplied pre-RHS function (if supplied), then call RHS */
+  if (ark_mem->PreRhsFn)
   {
-    retval = ark_mem->PreRHSProcess(ark_mem->tcur, ark_mem->ycur,
-                                    ark_mem->user_data);
-    if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+    retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur, ark_mem->user_data);
+    if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
   }
   retval = step_mem->nls_fi(ark_mem->tcur, ark_mem->ycur,
                             step_mem->Fi[step_mem->istage], ark_mem->user_data);
@@ -637,12 +636,11 @@ int arkStep_NlsResidual_MassIdent_TrivialPredAutonomous(N_Vector zcor, N_Vector 
   }
   else
   {
-    /* apply user-supplied RHS preprocessing function (if supplied), and then call RHS */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied), then call RHS */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(ark_mem->tcur, ark_mem->ycur,
-                                      ark_mem->user_data);
-      if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+      retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur, ark_mem->user_data);
+      if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
     }
     retval = step_mem->nls_fi(ark_mem->tcur, ark_mem->ycur,
                               step_mem->Fi[step_mem->istage], ark_mem->user_data);
@@ -711,12 +709,11 @@ int arkStep_NlsResidual_MassFixed(N_Vector zcor, N_Vector r, void* arkode_mem)
   /* update 'ycur' value as stored predictor + current corrector */
   N_VLinearSum(ONE, step_mem->zpred, ONE, zcor, ark_mem->ycur);
 
-  /* apply user-supplied RHS preprocessing function (if supplied), and then call RHS */
-  if (ark_mem->PreRHSProcess != NULL)
+  /* call the user-supplied pre-RHS function (if supplied), then call RHS */
+  if (ark_mem->PreRhsFn)
   {
-    retval = ark_mem->PreRHSProcess(ark_mem->tcur, ark_mem->ycur,
-                                    ark_mem->user_data);
-    if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+    retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur, ark_mem->user_data);
+    if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
   }
   retval = step_mem->nls_fi(ark_mem->tcur, ark_mem->ycur,
                             step_mem->Fi[step_mem->istage], ark_mem->user_data);
@@ -767,12 +764,11 @@ int arkStep_NlsResidual_MassFixed_TrivialPredAutonomous(N_Vector zcor, N_Vector 
   }
   else
   {
-    /* apply user-supplied RHS preprocessing function (if supplied), and then call RHS */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied), then call RHS */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(ark_mem->tcur, ark_mem->ycur,
-                                      ark_mem->user_data);
-      if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+      retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur, ark_mem->user_data);
+      if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
     }
     retval = step_mem->nls_fi(ark_mem->tcur, ark_mem->ycur,
                               step_mem->Fi[step_mem->istage], ark_mem->user_data);
@@ -847,12 +843,11 @@ int arkStep_NlsResidual_MassTDep(N_Vector zcor, N_Vector r, void* arkode_mem)
   retval = step_mem->mmult((void*)ark_mem, step_mem->Fi[step_mem->istage], r);
   if (retval != ARK_SUCCESS) { return (ARK_MASSMULT_FAIL); }
 
-  /* apply user-supplied RHS preprocessing function (if supplied), and then call RHS */
-  if (ark_mem->PreRHSProcess != NULL)
+  /* call the user-supplied pre-RHS function (if supplied), then call RHS */
+  if (ark_mem->PreRhsFn)
   {
-    retval = ark_mem->PreRHSProcess(ark_mem->tcur, ark_mem->ycur,
-                                    ark_mem->user_data);
-    if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+    retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur, ark_mem->user_data);
+    if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
   }
   retval = step_mem->nls_fi(ark_mem->tcur, ark_mem->ycur,
                             step_mem->Fi[step_mem->istage], ark_mem->user_data);
@@ -918,12 +913,11 @@ int arkStep_NlsFPFunction_MassIdent(N_Vector zcor, N_Vector g, void* arkode_mem)
   /* update 'ycur' value as stored predictor + current corrector */
   N_VLinearSum(ONE, step_mem->zpred, ONE, zcor, ark_mem->ycur);
 
-  /* apply user-supplied RHS preprocessing function (if supplied), and then call RHS */
-  if (ark_mem->PreRHSProcess != NULL)
+  /* call the user-supplied pre-RHS function (if supplied), then call RHS */
+  if (ark_mem->PreRhsFn)
   {
-    retval = ark_mem->PreRHSProcess(ark_mem->tcur, ark_mem->ycur,
-                                    ark_mem->user_data);
-    if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+    retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur, ark_mem->user_data);
+    if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
   }
   retval = step_mem->nls_fi(ark_mem->tcur, ark_mem->ycur,
                             step_mem->Fi[step_mem->istage], ark_mem->user_data);
@@ -964,12 +958,11 @@ int arkStep_NlsFPFunction_MassIdent_TrivialPredAutonomous(N_Vector zcor,
   }
   else
   {
-    /* apply user-supplied RHS preprocessing function (if supplied), and then call RHS */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied), then call RHS */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(ark_mem->tcur, ark_mem->ycur,
-                                      ark_mem->user_data);
-      if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+      retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur, ark_mem->user_data);
+      if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
     }
     retval = step_mem->nls_fi(ark_mem->tcur, ark_mem->ycur,
                               step_mem->Fi[step_mem->istage], ark_mem->user_data);
@@ -1039,12 +1032,11 @@ int arkStep_NlsFPFunction_MassFixed(N_Vector zcor, N_Vector g, void* arkode_mem)
   /* update 'ycur' value as stored predictor + current corrector */
   N_VLinearSum(ONE, step_mem->zpred, ONE, zcor, ark_mem->ycur);
 
-  /* apply user-supplied RHS preprocessing function (if supplied), and then call RHS */
-  if (ark_mem->PreRHSProcess != NULL)
+  /* call the user-supplied pre-RHS function (if supplied), then call RHS */
+  if (ark_mem->PreRhsFn)
   {
-    retval = ark_mem->PreRHSProcess(ark_mem->tcur, ark_mem->ycur,
-                                    ark_mem->user_data);
-    if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+    retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur, ark_mem->user_data);
+    if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
   }
   retval = step_mem->nls_fi(ark_mem->tcur, ark_mem->ycur,
                             step_mem->Fi[step_mem->istage], ark_mem->user_data);
@@ -1090,12 +1082,11 @@ int arkStep_NlsFPFunction_MassFixed_TrivialPredAutonomous(N_Vector zcor,
   }
   else
   {
-    /* apply user-supplied RHS preprocessing function (if supplied), and then call RHS */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied), then call RHS */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(ark_mem->tcur, ark_mem->ycur,
-                                      ark_mem->user_data);
-      if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+      retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur, ark_mem->user_data);
+      if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
     }
     retval = step_mem->nls_fi(ark_mem->tcur, ark_mem->ycur,
                               step_mem->Fi[step_mem->istage], ark_mem->user_data);
@@ -1166,12 +1157,11 @@ int arkStep_NlsFPFunction_MassTDep(N_Vector zcor, N_Vector g, void* arkode_mem)
   /* update 'ycur' value as stored predictor + current corrector */
   N_VLinearSum(ONE, step_mem->zpred, ONE, zcor, ark_mem->ycur);
 
-  /* apply user-supplied RHS preprocessing function (if supplied), and then call RHS */
-  if (ark_mem->PreRHSProcess != NULL)
+  /* call the user-supplied pre-RHS function (if supplied), then call RHS */
+  if (ark_mem->PreRhsFn)
   {
-    retval = ark_mem->PreRHSProcess(ark_mem->tcur, ark_mem->ycur,
-                                    ark_mem->user_data);
-    if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+    retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur, ark_mem->user_data);
+    if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
   }
   retval = step_mem->nls_fi(ark_mem->tcur, ark_mem->ycur,
                             step_mem->Fi[step_mem->istage], ark_mem->user_data);

--- a/src/arkode/arkode_arkstep_nls.c
+++ b/src/arkode/arkode_arkstep_nls.c
@@ -639,7 +639,8 @@ int arkStep_NlsResidual_MassIdent_TrivialPredAutonomous(N_Vector zcor, N_Vector 
     /* call the user-supplied pre-RHS function (if supplied), then call RHS */
     if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur, ark_mem->user_data);
+      retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur,
+                                 ark_mem->user_data);
       if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
     }
     retval = step_mem->nls_fi(ark_mem->tcur, ark_mem->ycur,
@@ -767,7 +768,8 @@ int arkStep_NlsResidual_MassFixed_TrivialPredAutonomous(N_Vector zcor, N_Vector 
     /* call the user-supplied pre-RHS function (if supplied), then call RHS */
     if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur, ark_mem->user_data);
+      retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur,
+                                 ark_mem->user_data);
       if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
     }
     retval = step_mem->nls_fi(ark_mem->tcur, ark_mem->ycur,
@@ -961,7 +963,8 @@ int arkStep_NlsFPFunction_MassIdent_TrivialPredAutonomous(N_Vector zcor,
     /* call the user-supplied pre-RHS function (if supplied), then call RHS */
     if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur, ark_mem->user_data);
+      retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur,
+                                 ark_mem->user_data);
       if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
     }
     retval = step_mem->nls_fi(ark_mem->tcur, ark_mem->ycur,
@@ -1085,7 +1088,8 @@ int arkStep_NlsFPFunction_MassFixed_TrivialPredAutonomous(N_Vector zcor,
     /* call the user-supplied pre-RHS function (if supplied), then call RHS */
     if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur, ark_mem->user_data);
+      retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur,
+                                 ark_mem->user_data);
       if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
     }
     retval = step_mem->nls_fi(ark_mem->tcur, ark_mem->ycur,

--- a/src/arkode/arkode_bandpre.c
+++ b/src/arkode/arkode_bandpre.c
@@ -538,11 +538,11 @@ static int ARKBandPDQJac(ARKBandPrecData pdata, sunrealtype t, N_Vector y,
       ytemp_data[j] += inc;
     }
 
-    /* apply user-supplied RHS preprocessing function (if supplied), and then call RHS */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied), then call RHS */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(t, ytemp, ark_mem->user_data);
-      if (retval != 0) { return (ARK_POSTPROCESS_STAGE_FAIL); }
+      retval = ark_mem->PreRhsFn(t, ytemp, ark_mem->user_data);
+      if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
     }
     retval = fi(t, ytemp, ftemp, ark_mem->user_data);
     pdata->nfeBP++;

--- a/src/arkode/arkode_erkstep.c
+++ b/src/arkode/arkode_erkstep.c
@@ -910,7 +910,8 @@ int erkStep_TakeStep(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
     /* call the user-supplied pre-RHS function (if supplied) */
     if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur, ark_mem->user_data);
+      retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur,
+                                 ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -1518,8 +1519,8 @@ int erkStep_ComputeSolutions(ARKodeMem ark_mem, sunrealtype* dsmPtr)
         step_mem->stage_times[j] = ark_mem->tn + step_mem->B->c[j] * ark_mem->h;
         step_mem->stage_coefs[j] = ark_mem->h * step_mem->B->b[j];
       }
-      erkStep_ApplyForcing(step_mem, step_mem->stage_times, step_mem->stage_coefs,
-                           step_mem->stages, &nvec);
+      erkStep_ApplyForcing(step_mem, step_mem->stage_times,
+                           step_mem->stage_coefs, step_mem->stages, &nvec);
     }
 
     /* call fused vector operation to do the work */

--- a/src/arkode/arkode_erkstep.c
+++ b/src/arkode/arkode_erkstep.c
@@ -614,11 +614,11 @@ int erkStep_FullRHS(ARKodeMem ark_mem, sunrealtype t, N_Vector y, N_Vector f,
     /* compute the RHS if needed */
     if (!(ark_mem->fn_is_current))
     {
-      /* apply user-supplied stage preprocessing function (if supplied) */
-      if (ark_mem->PreRHSProcess != NULL)
+      /* call the user-supplied pre-RHS function (if supplied) */
+      if (ark_mem->PreRhsFn)
       {
-        retval = ark_mem->PreRHSProcess(t, y, ark_mem->user_data);
-        if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+        retval = ark_mem->PreRhsFn(t, y, ark_mem->user_data);
+        if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
       }
 
       /* call f */
@@ -660,11 +660,11 @@ int erkStep_FullRHS(ARKodeMem ark_mem, sunrealtype t, N_Vector y, N_Vector f,
       /* base RHS call on recomputeRHS argument */
       if (recomputeRHS)
       {
-        /* apply user-supplied stage preprocessing function (if supplied) */
-        if (ark_mem->PreRHSProcess != NULL)
+        /* call the user-supplied pre-RHS function (if supplied) */
+        if (ark_mem->PreRhsFn)
         {
-          retval = ark_mem->PreRHSProcess(t, y, ark_mem->user_data);
-          if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+          retval = ark_mem->PreRhsFn(t, y, ark_mem->user_data);
+          if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
         }
 
         /* call f */
@@ -697,11 +697,11 @@ int erkStep_FullRHS(ARKodeMem ark_mem, sunrealtype t, N_Vector y, N_Vector f,
 
   case ARK_FULLRHS_OTHER:
 
-    /* apply user-supplied stage preprocessing function (if supplied) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(t, y, ark_mem->user_data);
-      if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+      retval = ark_mem->PreRhsFn(t, y, ark_mem->user_data);
+      if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
     }
 
     /* call f */
@@ -879,10 +879,10 @@ int erkStep_TakeStep(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
     }
 
     /* apply user-supplied stage postprocessing function (if supplied) */
-    if (ark_mem->PostProcessStage != NULL)
+    if (ark_mem->PostProcessStageFn)
     {
-      retval = ark_mem->PostProcessStage(ark_mem->tcur, ark_mem->ycur,
-                                         ark_mem->user_data);
+      retval = ark_mem->PostProcessStageFn(ark_mem->tcur, ark_mem->ycur,
+                                           ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -891,16 +891,15 @@ int erkStep_TakeStep(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
       }
     }
 
-    /* apply user-supplied stage preprocessing function (if supplied) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(ark_mem->tcur, ark_mem->ycur,
-                                      ark_mem->user_data);
+      retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
                    "status = failed preprocess RHS, retval = %i", retval);
-        return (ARK_PREPROCESS_RHS_FAIL);
+        return (ARK_PRERHSFN_FAIL);
       }
     }
 
@@ -969,10 +968,10 @@ int erkStep_TakeStep(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
   }
 
   /* apply user-supplied stage postprocessing function (if supplied) */
-  if (ark_mem->PostProcessStage != NULL)
+  if (ark_mem->PostProcessStageFn)
   {
-    retval = ark_mem->PostProcessStage(ark_mem->tcur, ark_mem->ycur,
-                                       ark_mem->user_data);
+    retval = ark_mem->PostProcessStageFn(ark_mem->tcur, ark_mem->ycur,
+                                         ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",

--- a/src/arkode/arkode_erkstep.c
+++ b/src/arkode/arkode_erkstep.c
@@ -769,6 +769,9 @@ int erkStep_TakeStep(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
   retval = erkStep_AccessStepMem(ark_mem, __func__, &step_mem);
   if (retval != ARK_SUCCESS) { return (retval); }
 
+  /* determine if method has fsal property */
+  sunbooleantype fsal = ARKodeButcherTable_IsStifflyAccurate(step_mem->B);
+
   /* local shortcuts for fused vector operations */
   cvals = step_mem->cvals;
   Xvecs = step_mem->Xvecs;
@@ -878,8 +881,21 @@ int erkStep_TakeStep(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
       return (ARK_VECTOROP_ERR);
     }
 
-    /* apply user-supplied stage postprocessing function (if supplied) */
-    if (ark_mem->PostProcessStageFn)
+    /* apply user-supplied stage postprocessing function (if supplied) unless
+       this is the last stage of a FSAL method, then apply the user-supplied
+       step postprocessing function (if supplied) */
+    if (is == step_mem->stages - 1 && fsal && ark_mem->PostProcessStepFn)
+    {
+      retval = ark_mem->PostProcessStepFn(ark_mem->tcur, ark_mem->ycur,
+                                          ark_mem->user_data);
+      if (retval != 0)
+      {
+        SUNLogInfo(ARK_LOGGER, "end-stages-list",
+                   "status = failed postprocess step, retval = %i", retval);
+        return (ARK_POSTPROCESS_STEP_FAIL);
+      }
+    }
+    else if (ark_mem->PostProcessStageFn)
     {
       retval = ark_mem->PostProcessStageFn(ark_mem->tcur, ark_mem->ycur,
                                            ark_mem->user_data);
@@ -959,25 +975,14 @@ int erkStep_TakeStep(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
   SUNLogInfo(ARK_LOGGER, "begin-compute-solution", "");
 
   /* compute time-evolved solution (in ark_ycur), error estimate (in dsm) */
+  ark_mem->tcur = ark_mem->tn + ark_mem->h;
+
   retval = erkStep_ComputeSolutions(ark_mem, dsmPtr);
   if (retval < 0)
   {
     SUNLogInfo(ARK_LOGGER, "end-compute-solution",
                "status = failed compute solution, retval = %i", retval);
     return (retval);
-  }
-
-  /* apply user-supplied stage postprocessing function (if supplied) */
-  if (ark_mem->PostProcessStageFn)
-  {
-    retval = ark_mem->PostProcessStageFn(ark_mem->tcur, ark_mem->ycur,
-                                         ark_mem->user_data);
-    if (retval != 0)
-    {
-      SUNLogInfo(ARK_LOGGER, "end-stages-list",
-                 "status = failed postprocess stage, retval = %i", retval);
-      return (ARK_POSTPROCESS_STAGE_FAIL);
-    }
   }
 
   SUNLogExtraDebugVec(ARK_LOGGER, "updated solution", ark_mem->ycur, "ycur(:) =");
@@ -1486,34 +1491,49 @@ int erkStep_ComputeSolutions(ARKodeMem ark_mem, sunrealtype* dsmPtr)
   /* initialize output */
   *dsmPtr = ZERO;
 
-  /* Compute time step solution */
-  /*   set arrays for fused vector operation */
-  nvec = 0;
-  for (j = 0; j < step_mem->stages; j++)
-  {
-    cvals[nvec] = ark_mem->h * step_mem->B->b[j];
-    Xvecs[nvec] = step_mem->F[j];
-    nvec += 1;
-  }
-  cvals[nvec] = ONE;
-  Xvecs[nvec] = ark_mem->yn;
-  nvec += 1;
+  /* determine if method has fsal property */
+  sunbooleantype fsal = ARKodeButcherTable_IsStifflyAccurate(step_mem->B);
 
-  /* apply external polynomial forcing */
-  if (step_mem->nforcing > 0)
+  /* Compute time step solution. For FSAL methods, ycur already contains the new
+     solution. */
+  if (!fsal)
   {
+    /* set arrays for fused vector operation */
+    nvec = 0;
     for (j = 0; j < step_mem->stages; j++)
     {
-      step_mem->stage_times[j] = ark_mem->tn + step_mem->B->c[j] * ark_mem->h;
-      step_mem->stage_coefs[j] = ark_mem->h * step_mem->B->b[j];
+      cvals[nvec] = ark_mem->h * step_mem->B->b[j];
+      Xvecs[nvec] = step_mem->F[j];
+      nvec += 1;
     }
-    erkStep_ApplyForcing(step_mem, step_mem->stage_times, step_mem->stage_coefs,
-                         step_mem->stages, &nvec);
-  }
+    cvals[nvec] = ONE;
+    Xvecs[nvec] = ark_mem->yn;
+    nvec += 1;
 
-  /*   call fused vector operation to do the work */
-  retval = N_VLinearCombination(nvec, cvals, Xvecs, y);
-  if (retval != 0) { return (ARK_VECTOROP_ERR); }
+    /* apply external polynomial forcing */
+    if (step_mem->nforcing > 0)
+    {
+      for (j = 0; j < step_mem->stages; j++)
+      {
+        step_mem->stage_times[j] = ark_mem->tn + step_mem->B->c[j] * ark_mem->h;
+        step_mem->stage_coefs[j] = ark_mem->h * step_mem->B->b[j];
+      }
+      erkStep_ApplyForcing(step_mem, step_mem->stage_times, step_mem->stage_coefs,
+                           step_mem->stages, &nvec);
+    }
+
+    /* call fused vector operation to do the work */
+    retval = N_VLinearCombination(nvec, cvals, Xvecs, y);
+    if (retval != 0) { return (ARK_VECTOROP_ERR); }
+
+    /* apply user-supplied step postprocessing function (if supplied) */
+    if (ark_mem->PostProcessStepFn)
+    {
+      retval = ark_mem->PostProcessStepFn(ark_mem->tcur, ark_mem->ycur,
+                                          ark_mem->user_data);
+      if (retval != 0) { return (ARK_POSTPROCESS_STEP_FAIL); }
+    }
+  }
 
   /* Compute yerr (if step adaptivity or error accumulation enabled) */
   if (!ark_mem->fixedstep || (ark_mem->AccumErrorType != ARK_ACCUMERROR_NONE))

--- a/src/arkode/arkode_impl.h
+++ b/src/arkode/arkode_impl.h
@@ -565,16 +565,15 @@ struct ARKodeMemRec
   ARKodeRelaxMem relax_mem;     /* relaxation data structure */
 
   /* User-supplied step solution pre/post-processing functions */
-  ARKPostProcessFn PreProcessStep;
-  ARKPostProcessFn PostProcessStep;
-  ARKPostProcessFn PostProcessStepFail;
-  void* ps_data; /* pointer to user_data */
-
-  /* User-supplied stage solution post-processing function */
-  ARKPostProcessFn PostProcessStage;
+  ARKPreStepFn PreStepFn;
+  ARKPostStepFn PostStepFn;
 
   /* User-supplied RHS function pre-processing function */
-  ARKPostProcessFn PreRHSProcess;
+  ARKPreRhsFn PreRhsFn;
+
+  /* User-supplied stage and step solution post-processing function */
+  ARKPostProcessFn PostProcessStepFn;
+  ARKPostProcessFn PostProcessStageFn;
 
   sunbooleantype use_compensated_sums;
 
@@ -815,21 +814,21 @@ void arkode_user_supplied_fn_table_destroy(void* ptr);
 #define MSG_ARK_VECTOROP_ERR "At " MSG_TIME ", a vector operation failed."
 #define MSG_ARK_INNERSTEP_FAILED \
   "At " MSG_TIME ", the inner stepper failed in an unrecoverable manner."
-#define MSG_ARK_PREPROCESS_STEP_FAIL \
+#define MSG_ARK_PRESTEPFN_FAIL \
   "At " MSG_TIME                     \
-  ", the step preprocessing routine failed in an unrecoverable manner."
+  ", the pre-step function failed in an unrecoverable manner."
+#define MSG_ARK_POSTSTEPFN_FAIL \
+  "At " MSG_TIME                     \
+  ", the post-step function failed in an unrecoverable manner."
 #define MSG_ARK_POSTPROCESS_STEP_FAIL \
   "At " MSG_TIME                      \
   ", the step postprocessing routine failed in an unrecoverable manner."
-#define MSG_ARK_POSTPROCESS_FAILED_STEP_FAIL                              \
-  "At " MSG_TIME ", the failed step postprocessing routine failed in an " \
-  "unrecoverable manner."
 #define MSG_ARK_POSTPROCESS_STAGE_FAIL \
   "At " MSG_TIME                       \
   ", the stage postprocessing routine failed in an unrecoverable manner."
-#define MSG_ARK_PREPROCESS_RHS_FAIL \
+#define MSG_ARK_PRERHSFN_FAIL \
   "At " MSG_TIME                    \
-  ", the RHS preprocessing routine failed in an unrecoverable manner."
+  ", the pre-RHS function failed in an unrecoverable manner."
 #define MSG_ARK_NULL_SUNCTX "sunctx = NULL illegal."
 #define MSG_ARK_CONTEXT_MISMATCH \
   "Outer and inner steppers have different contexts."

--- a/src/arkode/arkode_impl.h
+++ b/src/arkode/arkode_impl.h
@@ -815,11 +815,9 @@ void arkode_user_supplied_fn_table_destroy(void* ptr);
 #define MSG_ARK_INNERSTEP_FAILED \
   "At " MSG_TIME ", the inner stepper failed in an unrecoverable manner."
 #define MSG_ARK_PRESTEPFN_FAIL \
-  "At " MSG_TIME                     \
-  ", the pre-step function failed in an unrecoverable manner."
+  "At " MSG_TIME ", the pre-step function failed in an unrecoverable manner."
 #define MSG_ARK_POSTSTEPFN_FAIL \
-  "At " MSG_TIME                     \
-  ", the post-step function failed in an unrecoverable manner."
+  "At " MSG_TIME ", the post-step function failed in an unrecoverable manner."
 #define MSG_ARK_POSTPROCESS_STEP_FAIL \
   "At " MSG_TIME                      \
   ", the step postprocessing routine failed in an unrecoverable manner."
@@ -827,8 +825,7 @@ void arkode_user_supplied_fn_table_destroy(void* ptr);
   "At " MSG_TIME                       \
   ", the stage postprocessing routine failed in an unrecoverable manner."
 #define MSG_ARK_PRERHSFN_FAIL \
-  "At " MSG_TIME                    \
-  ", the pre-RHS function failed in an unrecoverable manner."
+  "At " MSG_TIME ", the pre-RHS function failed in an unrecoverable manner."
 #define MSG_ARK_NULL_SUNCTX "sunctx = NULL illegal."
 #define MSG_ARK_CONTEXT_MISMATCH \
   "Outer and inner steppers have different contexts."

--- a/src/arkode/arkode_io.c
+++ b/src/arkode/arkode_io.c
@@ -873,13 +873,6 @@ int ARKodeSetUserData(void* arkode_mem, void* user_data)
   /* Set data for root finding */
   if (ark_mem->root_mem != NULL) { ark_mem->root_mem->root_data = user_data; }
 
-  /* Set data for post-processing a step */
-  if ((ark_mem->PreProcessStep != NULL) || (ark_mem->PostProcessStep != NULL) ||
-      (ark_mem->PostProcessStepFail != NULL))
-  {
-    ark_mem->ps_data = user_data;
-  }
-
   /* Set user data into stepper (if provided) */
   if (ark_mem->step_setuserdata)
   {
@@ -1493,25 +1486,19 @@ int ARKodeSetNoInactiveRootWarn(void* arkode_mem)
   return (ARK_SUCCESS);
 }
 
-/*---------------------------------------------------------------
-  ARKodeSetPreprocessStepFn:
-  ARKodeSetPostprocessStepFn:
-  ARKodeSetPostprocessStepFailFn:
+/*------------------------------------------------------------------------------
+  ARKodeSetPreStepFn:
+  ARKodeSetPostStepFn:
 
-  Specifies user-provided step pre- and post-processing functions
-  having type ARKPostProcessFn.  A NULL input function disables step
-  pre- or post-step processing.
+  Specifies user-provided step pre- and post-step functions.
 
-  The "Preprocess" function is called just prior to taking a step,
-  while the "Postprocess" function is called immediately after
-  a successful step.  The "PostprocessStepFail" function is called
-  immediately after a failed step.
+  The pre-step function is called just prior to taking a step and the post-step
+  function is called immediately after completing a successful step.
 
-  IF THE SUPPLIED FUNCTION MODIFIES ANY OF THE ACTIVE STATE DATA,
-  THEN ALL THEORETICAL GUARANTEES OF SOLUTION ACCURACY AND
-  STABILITY ARE LOST.
-  ---------------------------------------------------------------*/
-int ARKodeSetPreprocessStepFn(void* arkode_mem, ARKPostProcessFn ProcessStep)
+  IF THE SUPPLIED FUNCTION MODIFIES ANY OF THE ACTIVE STATE DATA, THEN ALL
+  THEORETICAL GUARANTEES OF SOLUTION ACCURACY AND STABILITY ARE LOST.
+  ----------------------------------------------------------------------------*/
+int ARKodeSetPreStepFn(void* arkode_mem, ARKPreStepFn prestep_fn)
 {
   ARKodeMem ark_mem;
   if (arkode_mem == NULL)
@@ -1522,13 +1509,80 @@ int ARKodeSetPreprocessStepFn(void* arkode_mem, ARKPostProcessFn ProcessStep)
   }
   ark_mem = (ARKodeMem)arkode_mem;
 
-  /* NULL argument sets default, otherwise set inputs */
-  ark_mem->PreProcessStep = ProcessStep;
-  ark_mem->ps_data        = ark_mem->user_data;
+  /* NULL argument disables the pre-step function */
+  ark_mem->PreStepFn = prestep_fn;
 
   return (ARK_SUCCESS);
 }
 
+int ARKodeSetPostStepFn(void* arkode_mem, ARKPostStepFn poststep_fn)
+{
+  ARKodeMem ark_mem;
+  if (arkode_mem == NULL)
+  {
+    arkProcessError(NULL, ARK_MEM_NULL, __LINE__, __func__, __FILE__,
+                    MSG_ARK_NO_MEM);
+    return (ARK_MEM_NULL);
+  }
+  ark_mem = (ARKodeMem)arkode_mem;
+
+  /* NULL argument disables the post-step function */
+  ark_mem->PostStepFn = poststep_fn;
+
+  return (ARK_SUCCESS);
+}
+
+
+/*------------------------------------------------------------------------------
+  ARKodeSetPreRhsFn:
+
+  Specifies user-provided pre-RHS function.
+
+  The pre-RHS function is called on a state vector just prior to computing the
+  RHS. For problems with partitioned RHS functions that are called with
+  identical inputs, this is only called before the first RHS evaluation.
+
+  IF THE SUPPLIED FUNCTION MODIFIES ANY OF THE ACTIVE STATE DATA, THEN ALL
+  THEORETICAL GUARANTEES OF SOLUTION ACCURACY AND STABILITY ARE LOST.
+  ---------------------------------------------------------------*/
+int ARKodeSetPreRhsFn(void* arkode_mem, ARKPreRhsFn prerhs_fn)
+{
+  ARKodeMem ark_mem;
+  if (arkode_mem == NULL)
+  {
+    arkProcessError(NULL, ARK_MEM_NULL, __LINE__, __func__, __FILE__,
+                    MSG_ARK_NO_MEM);
+    return (ARK_MEM_NULL);
+  }
+  ark_mem = (ARKodeMem)arkode_mem;
+
+  /* NULL argument disables the pre-RHS function */
+  ark_mem->PreRhsFn = prerhs_fn;
+
+  return (ARK_SUCCESS);
+}
+
+
+/*------------------------------------------------------------------------------
+  ARKodeSetPostprocessStepFn:
+  ARKodeSetPostprocessStageFn:
+
+  Specifies user-provided step and stage post-processing functions.
+
+  These functions are called immediately after computing a stage or the new step
+  solution (before error checks or other post-step actions e.g., constraint
+  handling or relaxation).
+
+  IF THE SUPPLIED FUNCTION MODIFIES ANY OF THE ACTIVE STATE DATA, THEN ALL
+  THEORETICAL GUARANTEES OF SOLUTION ACCURACY AND STABILITY ARE LOST.
+
+  While it is possible to perform stage postprocessing when
+  ARKodeSetDeduceImplicitRhs is enabled, this can cause implicit RHS evaluations
+  to be inconsistent with the postprocessed values (this similarly applies when
+  using step post processing with FSAL methods). It is strongly recommended to
+  disable ARKodeSetDeduceImplicitRhs in order to guarantee postprocessing
+  constraints are enforced.
+  ----------------------------------------------------------------------------*/
 int ARKodeSetPostprocessStepFn(void* arkode_mem, ARKPostProcessFn ProcessStep)
 {
   ARKodeMem ark_mem;
@@ -1540,52 +1594,12 @@ int ARKodeSetPostprocessStepFn(void* arkode_mem, ARKPostProcessFn ProcessStep)
   }
   ark_mem = (ARKodeMem)arkode_mem;
 
-  /* NULL argument sets default, otherwise set inputs */
-  ark_mem->PostProcessStep = ProcessStep;
-  ark_mem->ps_data         = ark_mem->user_data;
+  /* NULL argument disables the postprocessing function */
+  ark_mem->PostProcessStepFn = ProcessStep;
 
   return (ARK_SUCCESS);
 }
 
-int ARKodeSetPostprocessStepFailFn(void* arkode_mem, ARKPostProcessFn ProcessStep)
-{
-  ARKodeMem ark_mem;
-  if (arkode_mem == NULL)
-  {
-    arkProcessError(NULL, ARK_MEM_NULL, __LINE__, __func__, __FILE__,
-                    MSG_ARK_NO_MEM);
-    return (ARK_MEM_NULL);
-  }
-  ark_mem = (ARKodeMem)arkode_mem;
-
-  /* NULL argument sets default, otherwise set inputs */
-  ark_mem->PostProcessStepFail = ProcessStep;
-  ark_mem->ps_data             = ark_mem->user_data;
-
-  return (ARK_SUCCESS);
-}
-
-/*---------------------------------------------------------------
-  ARKodeSetPostprocessStageFn:
-
-  Specifies user-provided stage post-processing
-  function having type ARKPostProcessFn.  A NULL input function
-  disables post-stage processing.
-
-  The "ProcessStage" function is called immediately after
-  computing a stage.
-
-  IF THE SUPPLIED FUNCTION MODIFIES ANY OF THE ACTIVE STATE DATA,
-  THEN ALL THEORETICAL GUARANTEES OF SOLUTION ACCURACY AND
-  STABILITY ARE LOST.
-
-  While it is possible to perform postprocessing when
-  ARKodeSetDeduceImplicitRhs is enabled, this can cause implicit
-  RHS evaluations to be inconsistent with the postprocessed stage
-  values.  It is strongly recommended to disable
-  ARKodeSetDeduceImplicitRhs in order to guarantee
-  postprocessing constraints are enforced.
-  ---------------------------------------------------------------*/
 int ARKodeSetPostprocessStageFn(void* arkode_mem, ARKPostProcessFn ProcessStage)
 {
   ARKodeMem ark_mem;
@@ -1597,43 +1611,8 @@ int ARKodeSetPostprocessStageFn(void* arkode_mem, ARKPostProcessFn ProcessStage)
   }
   ark_mem = (ARKodeMem)arkode_mem;
 
-  /* NULL argument sets default, otherwise set inputs */
-  ark_mem->PostProcessStage = ProcessStage;
-  ark_mem->ps_data          = ark_mem->user_data;
-
-  return (ARK_SUCCESS);
-}
-
-/*---------------------------------------------------------------
-  ARKodeSetPreRHSProcessFn:
-
-  Specifies user-provided pre-processing function having type
-  ARKPostProcessFn.  A NULL input function disables pre-RHS
-  processing.
-
-  The "PreRHSProcess" function is called on a state vector
-  just prior to computing the RHS.  For problems with partitioned
-  RHS functions that are called with identical inputs, this is
-  only called before the first RHS evaluation.
-
-  IF THE SUPPLIED FUNCTION MODIFIES ANY OF THE ACTIVE STATE DATA,
-  THEN ALL THEORETICAL GUARANTEES OF SOLUTION ACCURACY AND
-  STABILITY ARE LOST.
-  ---------------------------------------------------------------*/
-int ARKodeSetPreRHSProcessFn(void* arkode_mem, ARKPostProcessFn PreRHSProcess)
-{
-  ARKodeMem ark_mem;
-  if (arkode_mem == NULL)
-  {
-    arkProcessError(NULL, ARK_MEM_NULL, __LINE__, __func__, __FILE__,
-                    MSG_ARK_NO_MEM);
-    return (ARK_MEM_NULL);
-  }
-  ark_mem = (ARKodeMem)arkode_mem;
-
-  /* NULL argument sets default, otherwise set inputs */
-  ark_mem->PreRHSProcess = PreRHSProcess;
-  ark_mem->ps_data       = ark_mem->user_data;
+  /* NULL argument disables the postprocessing function */
+  ark_mem->PostProcessStageFn = ProcessStage;
 
   return (ARK_SUCCESS);
 }
@@ -3255,13 +3234,13 @@ char* ARKodeGetReturnFlagName(long int flag)
   case ARK_POSTPROCESS_STAGE_FAIL:
     sprintf(name, "ARK_POSTPROCESS_STAGE_FAIL");
     break;
-  case ARK_POSTPROCESS_FAILED_STEP_FAIL:
-    sprintf(name, "ARK_POSTPROCESS_FAILED_STEP_FAIL");
+  case ARK_PRESTEPFN_FAIL:
+    sprintf(name, "ARK_PRESTEPFN_FAIL");
     break;
-  case ARK_PREPROCESS_STEP_FAIL:
-    sprintf(name, "ARK_PREPROCESS_STEP_FAIL");
+  case ARK_POSTSTEPFN_FAIL:
+    sprintf(name, "ARK_POSTSTEPFN_FAIL");
     break;
-  case ARK_PREPROCESS_RHS_FAIL: sprintf(name, "ARK_PREPROCESS_RHS_FAIL"); break;
+  case ARK_PRERHSFN_FAIL: sprintf(name, "ARK_PRERHSFN_FAIL"); break;
   case ARK_USER_PREDICT_FAIL: sprintf(name, "ARK_USER_PREDICT_FAIL"); break;
   case ARK_INTERP_FAIL: sprintf(name, "ARK_INTERP_FAIL"); break;
   case ARK_INVALID_TABLE: sprintf(name, "ARK_INVALID_TABLE"); break;

--- a/src/arkode/arkode_io.c
+++ b/src/arkode/arkode_io.c
@@ -1532,7 +1532,6 @@ int ARKodeSetPostStepFn(void* arkode_mem, ARKPostStepFn poststep_fn)
   return (ARK_SUCCESS);
 }
 
-
 /*------------------------------------------------------------------------------
   ARKodeSetPreRhsFn:
 
@@ -1561,7 +1560,6 @@ int ARKodeSetPreRhsFn(void* arkode_mem, ARKPreRhsFn prerhs_fn)
 
   return (ARK_SUCCESS);
 }
-
 
 /*------------------------------------------------------------------------------
   ARKodeSetPostprocessStepFn:
@@ -3234,12 +3232,8 @@ char* ARKodeGetReturnFlagName(long int flag)
   case ARK_POSTPROCESS_STAGE_FAIL:
     sprintf(name, "ARK_POSTPROCESS_STAGE_FAIL");
     break;
-  case ARK_PRESTEPFN_FAIL:
-    sprintf(name, "ARK_PRESTEPFN_FAIL");
-    break;
-  case ARK_POSTSTEPFN_FAIL:
-    sprintf(name, "ARK_POSTSTEPFN_FAIL");
-    break;
+  case ARK_PRESTEPFN_FAIL: sprintf(name, "ARK_PRESTEPFN_FAIL"); break;
+  case ARK_POSTSTEPFN_FAIL: sprintf(name, "ARK_POSTSTEPFN_FAIL"); break;
   case ARK_PRERHSFN_FAIL: sprintf(name, "ARK_PRERHSFN_FAIL"); break;
   case ARK_USER_PREDICT_FAIL: sprintf(name, "ARK_USER_PREDICT_FAIL"); break;
   case ARK_INTERP_FAIL: sprintf(name, "ARK_INTERP_FAIL"); break;

--- a/src/arkode/arkode_ls.c
+++ b/src/arkode/arkode_ls.c
@@ -2695,11 +2695,11 @@ int arkLsDenseDQJac(sunrealtype t, N_Vector y, N_Vector fy, SUNMatrix Jac,
 
     y_data[j] += inc;
 
-    /* apply user-supplied RHS preprocessing function (if supplied), and then call RHS */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied), then call RHS */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(t, y, ark_mem->user_data);
-      if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+      retval = ark_mem->PreRhsFn(t, y, ark_mem->user_data);
+      if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
     }
     retval = fi(t, y, ftemp, ark_mem->user_data);
     arkls_mem->nfeDQ++;
@@ -2798,11 +2798,11 @@ int arkLsBandDQJac(sunrealtype t, N_Vector y, N_Vector fy, SUNMatrix Jac,
       ytemp_data[j] += inc;
     }
 
-    /* apply user-supplied RHS preprocessing function (if supplied), and then call RHS */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied), then call RHS */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(t, ytemp, ark_mem->user_data);
-      if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+      retval = ark_mem->PreRhsFn(t, ytemp, ark_mem->user_data);
+      if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
     }
     retval = fi(t, ytemp, ftemp, ark_mem->user_data);
     arkls_mem->nfeDQ++;
@@ -2870,11 +2870,11 @@ int arkLsDQJtimes(N_Vector v, N_Vector Jv, sunrealtype t, N_Vector y,
     /* Set work = y + sig*v */
     N_VLinearSum(sig, v, ONE, y, work);
 
-    /* Set Jv = f(tn, y+sig*v), after calling RHS preprocessing fcn (if supplied) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* Set Jv = f(tn, y+sig*v), after calling pre-RHS function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(t, work, ark_mem->user_data);
-      if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+      retval = ark_mem->PreRhsFn(t, work, ark_mem->user_data);
+      if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
     }
     retval = arkls_mem->Jt_f(t, work, Jv, ark_mem->user_data);
     arkls_mem->nfeDQ++;

--- a/src/arkode/arkode_lsrkstep.c
+++ b/src/arkode/arkode_lsrkstep.c
@@ -1346,8 +1346,8 @@ int lsrkStep_TakeStepSSPs2(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
     /* call the user-supplied pre-RHS function (if supplied) */
     if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRhsFn(ark_mem->tcur + ((sunrealtype)j - ONE) *
-                                                   sm1inv * ark_mem->h,
+      retval = ark_mem->PreRhsFn(ark_mem->tcur +
+                                   ((sunrealtype)j - ONE) * sm1inv * ark_mem->h,
                                  ark_mem->ycur, ark_mem->user_data);
       if (retval != 0)
       {
@@ -1582,8 +1582,8 @@ int lsrkStep_TakeStepSSPs3(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
     /* call the user-supplied pre-RHS function (if supplied) */
     if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRhsFn(ark_mem->tcur + ((sunrealtype)j - ONE) *
-                                                   rat * ark_mem->h,
+      retval = ark_mem->PreRhsFn(ark_mem->tcur +
+                                   ((sunrealtype)j - ONE) * rat * ark_mem->h,
                                  ark_mem->ycur, ark_mem->user_data);
       if (retval != 0)
       {
@@ -1640,9 +1640,9 @@ int lsrkStep_TakeStepSSPs3(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
     /* call the user-supplied pre-RHS function (if supplied) */
     if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRhsFn(ark_mem->tcur + ((sunrealtype)j - ONE) *
-                                                   rat * ark_mem->h,
-                                      ark_mem->ycur, ark_mem->user_data);
+      retval = ark_mem->PreRhsFn(ark_mem->tcur +
+                                   ((sunrealtype)j - ONE) * rat * ark_mem->h,
+                                 ark_mem->ycur, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -1694,10 +1694,9 @@ int lsrkStep_TakeStepSSPs3(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
   /* call the user-supplied pre-RHS function (if supplied) */
   if (ark_mem->PreRhsFn)
   {
-    retval =
-      ark_mem->PreRhsFn(ark_mem->tcur +
-                          rat * (rn * (rn + ONE) / TWO - ONE) * ark_mem->h,
-                        ark_mem->ycur, ark_mem->user_data);
+    retval = ark_mem->PreRhsFn(ark_mem->tcur +
+                                 rat * (rn * (rn + ONE) / TWO - ONE) * ark_mem->h,
+                               ark_mem->ycur, ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -1750,7 +1749,7 @@ int lsrkStep_TakeStepSSPs3(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
   {
     retval =
       ark_mem->PostProcessStageFn(ark_mem->tcur +
-                                  rat * (rn * (rn - ONE) / TWO) * ark_mem->h,
+                                    rat * (rn * (rn - ONE) / TWO) * ark_mem->h,
                                   ark_mem->ycur, ark_mem->user_data);
     if (retval != 0)
     {
@@ -1806,7 +1805,7 @@ int lsrkStep_TakeStepSSPs3(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
     if (j < step_mem->req_stages && ark_mem->PostProcessStageFn)
     {
       retval = ark_mem->PostProcessStageFn(ark_mem->tcur + ((sunrealtype)j - rn) *
-                                                           rat * ark_mem->h,
+                                                             rat * ark_mem->h,
                                            ark_mem->ycur, ark_mem->user_data);
       if (retval != 0)
       {
@@ -1817,8 +1816,8 @@ int lsrkStep_TakeStepSSPs3(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
     }
     else if (j == step_mem->req_stages && ark_mem->PostProcessStepFn)
     {
-      retval = ark_mem->PostProcessStepFn(ark_mem->tn + ark_mem->h, ark_mem->ycur,
-                                          ark_mem->user_data);
+      retval = ark_mem->PostProcessStepFn(ark_mem->tn + ark_mem->h,
+                                          ark_mem->ycur, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -1950,8 +1949,8 @@ int lsrkStep_TakeStepSSP43(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
   /* call the user-supplied pre-RHS function (if supplied) */
   if (ark_mem->PreRhsFn)
   {
-    retval = ark_mem->PreRhsFn(ark_mem->tcur + ark_mem->h * p5,
-                               ark_mem->ycur, ark_mem->user_data);
+    retval = ark_mem->PreRhsFn(ark_mem->tcur + ark_mem->h * p5, ark_mem->ycur,
+                               ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -2061,8 +2060,8 @@ int lsrkStep_TakeStepSSP43(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
   /* call the user-supplied pre-RHS function (if supplied) */
   if (ark_mem->PreRhsFn)
   {
-    retval = ark_mem->PreRhsFn(ark_mem->tcur + ark_mem->h * p5,
-                               ark_mem->ycur, ark_mem->user_data);
+    retval = ark_mem->PreRhsFn(ark_mem->tcur + ark_mem->h * p5, ark_mem->ycur,
+                               ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -2268,13 +2267,15 @@ int lsrkStep_TakeStepSSP104(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPt
     {
       if (j == 5)
       {
-        retval = ark_mem->PostProcessStageFn(ark_mem->tn + j * onesixth * ark_mem->h,
-                                             ark_mem->ycur, ark_mem->user_data);
+        retval =
+          ark_mem->PostProcessStageFn(ark_mem->tn + j * onesixth * ark_mem->h,
+                                      ark_mem->ycur, ark_mem->user_data);
       }
       else
       {
         retval = ark_mem->PostProcessStageFn(ark_mem->tn + SUN_RCONST(2.0) *
-                                                           onesixth * ark_mem->h,
+                                                             onesixth *
+                                                             ark_mem->h,
                                              ark_mem->ycur, ark_mem->user_data);
       }
       if (retval != 0)
@@ -2302,8 +2303,9 @@ int lsrkStep_TakeStepSSP104(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPt
   /* apply user-supplied stage postprocessing function (if supplied) */
   if (ark_mem->PostProcessStageFn)
   {
-    retval = ark_mem->PostProcessStageFn(ark_mem->tcur + TWO * onesixth * ark_mem->h,
-                                         ark_mem->ycur, ark_mem->user_data);
+    retval =
+      ark_mem->PostProcessStageFn(ark_mem->tcur + TWO * onesixth * ark_mem->h,
+                                  ark_mem->ycur, ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -2362,9 +2364,10 @@ int lsrkStep_TakeStepSSP104(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPt
     /* apply user-supplied stage postprocessing function (if supplied) */
     if (ark_mem->PostProcessStageFn)
     {
-      retval = ark_mem->PostProcessStageFn(ark_mem->tcur + ((sunrealtype)j - THREE) *
-                                                           onesixth * ark_mem->h,
-                                           ark_mem->ycur, ark_mem->user_data);
+      retval =
+        ark_mem->PostProcessStageFn(ark_mem->tcur + ((sunrealtype)j - THREE) *
+                                                      onesixth * ark_mem->h,
+                                    ark_mem->ycur, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",

--- a/src/arkode/arkode_lsrkstep.c
+++ b/src/arkode/arkode_lsrkstep.c
@@ -451,11 +451,11 @@ int lsrkStep_FullRHS(ARKodeMem ark_mem, sunrealtype t, N_Vector y, N_Vector f,
     /* compute the RHS */
     if (!ark_mem->fn_is_current)
     {
-      /* apply user-supplied stage preprocessing function (if supplied) */
-      if (ark_mem->PreRHSProcess != NULL)
+      /* call the user-supplied pre-rhs function (if supplied) */
+      if (ark_mem->PreRhsFn)
       {
-        retval = ark_mem->PreRHSProcess(t, y, ark_mem->user_data);
-        if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+        retval = ark_mem->PreRhsFn(t, y, ark_mem->user_data);
+        if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
       }
       retval = step_mem->fe(t, y, f, ark_mem->user_data);
       step_mem->nfe++;
@@ -476,11 +476,11 @@ int lsrkStep_FullRHS(ARKodeMem ark_mem, sunrealtype t, N_Vector y, N_Vector f,
        ark_mem->fn_is_current is changed by ARKODE. */
     if (step_mem->is_SSP)
     {
-      /* apply user-supplied stage preprocessing function (if supplied) */
-      if (ark_mem->PreRHSProcess != NULL)
+      /* call the user-supplied pre-rhs function (if supplied) */
+      if (ark_mem->PreRhsFn)
       {
-        retval = ark_mem->PreRHSProcess(t, y, ark_mem->user_data);
-        if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+        retval = ark_mem->PreRhsFn(t, y, ark_mem->user_data);
+        if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
       }
       retval = step_mem->fe(t, y, ark_mem->fn, ark_mem->user_data);
       step_mem->nfe++;
@@ -498,11 +498,11 @@ int lsrkStep_FullRHS(ARKodeMem ark_mem, sunrealtype t, N_Vector y, N_Vector f,
 
   case ARK_FULLRHS_OTHER:
 
-    /* apply user-supplied stage preprocessing function (if supplied) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-rhs function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(t, y, ark_mem->user_data);
-      if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+      retval = ark_mem->PreRhsFn(t, y, ark_mem->user_data);
+      if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
     }
 
     /* call f */
@@ -629,16 +629,15 @@ int lsrkStep_TakeStepRKC(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
   if ((!ark_mem->fn_is_current && ark_mem->initsetup) ||
       (step_mem->step_nst != ark_mem->nst))
   {
-    /* apply user-supplied stage preprocessing function (if supplied) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-rhs function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(ark_mem->tn, ark_mem->yn,
-                                      ark_mem->user_data);
+      retval = ark_mem->PreRhsFn(ark_mem->tn, ark_mem->yn, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
                    "status = failed preprocess rhs, retval = %i", retval);
-        return ARK_PREPROCESS_RHS_FAIL;
+        return ARK_PRERHSFN_FAIL;
       }
     }
 
@@ -685,10 +684,10 @@ int lsrkStep_TakeStepRKC(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
   N_VLinearSum(ONE, ark_mem->yn, ark_mem->h * mus, ark_mem->fn, ark_mem->tempv2);
 
   /* apply user-supplied stage postprocessing function (if supplied) */
-  if (ark_mem->PostProcessStage != NULL)
+  if (ark_mem->PostProcessStageFn)
   {
-    retval = ark_mem->PostProcessStage(ark_mem->tn + ark_mem->h * mus,
-                                       ark_mem->tempv2, ark_mem->user_data);
+    retval = ark_mem->PostProcessStageFn(ark_mem->tn + ark_mem->h * mus,
+                                         ark_mem->tempv2, ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -718,16 +717,16 @@ int lsrkStep_TakeStepRKC(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
     nu   = -bj / bjm2;
     mus  = mu * w1 / w0;
 
-    /* apply user-supplied stage preprocessing function (if supplied) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(ark_mem->tcur + ark_mem->h * thjm1,
-                                      ark_mem->tempv2, ark_mem->user_data);
+      retval = ark_mem->PreRhsFn(ark_mem->tcur + ark_mem->h * thjm1,
+                                 ark_mem->tempv2, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
                    "status = failed preprocess rhs, retval = %i", retval);
-        return ARK_PREPROCESS_RHS_FAIL;
+        return ARK_PRERHSFN_FAIL;
       }
     }
 
@@ -773,10 +772,10 @@ int lsrkStep_TakeStepRKC(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
     }
 
     /* apply user-supplied stage postprocessing function (if supplied) */
-    if (ark_mem->PostProcessStage != NULL)
+    if (ark_mem->PostProcessStageFn)
     {
-      retval = ark_mem->PostProcessStage(ark_mem->tcur + ark_mem->h * thj,
-                                         ark_mem->ycur, ark_mem->user_data);
+      retval = ark_mem->PostProcessStageFn(ark_mem->tcur + ark_mem->h * thj,
+                                           ark_mem->ycur, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -815,16 +814,16 @@ int lsrkStep_TakeStepRKC(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
   /* Compute yerr (if step adaptivity enabled) */
   if (!ark_mem->fixedstep)
   {
-    /* apply user-supplied stage preprocessing function (if supplied) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(ark_mem->tcur + ark_mem->h, ark_mem->ycur,
-                                      ark_mem->user_data);
+      retval = ark_mem->PreRhsFn(ark_mem->tcur + ark_mem->h, ark_mem->ycur,
+                                 ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-compute-embedding",
                    "status = failed preprocess rhs, retval = %i", retval);
-        return ARK_PREPROCESS_RHS_FAIL;
+        return ARK_PRERHSFN_FAIL;
       }
     }
 
@@ -861,16 +860,16 @@ int lsrkStep_TakeStepRKC(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
   }
   else
   {
-    /* apply user-supplied stage preprocessing function (if supplied) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(ark_mem->tcur + ark_mem->h, ark_mem->ycur,
-                                      ark_mem->user_data);
+      retval = ark_mem->PreRhsFn(ark_mem->tcur + ark_mem->h, ark_mem->ycur,
+                                 ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-compute-embedding",
                    "status = failed preprocess rhs, retval = %i", retval);
-        return ARK_PREPROCESS_RHS_FAIL;
+        return ARK_PRERHSFN_FAIL;
       }
     }
 
@@ -998,16 +997,15 @@ int lsrkStep_TakeStepRKL(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
   if ((!ark_mem->fn_is_current && ark_mem->initsetup) ||
       (step_mem->step_nst != ark_mem->nst))
   {
-    /* apply user-supplied stage preprocessing function (if supplied) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(ark_mem->tn, ark_mem->yn,
-                                      ark_mem->user_data);
+      retval = ark_mem->PreRhsFn(ark_mem->tn, ark_mem->yn, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
                    "status = failed preprocess rhs, retval = %i", retval);
-        return ARK_PREPROCESS_RHS_FAIL;
+        return ARK_PRERHSFN_FAIL;
       }
     }
     retval = step_mem->fe(ark_mem->tn, ark_mem->yn, ark_mem->fn,
@@ -1046,10 +1044,10 @@ int lsrkStep_TakeStepRKL(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
   N_VLinearSum(ONE, ark_mem->yn, ark_mem->h * mus, ark_mem->fn, ark_mem->tempv2);
 
   /* apply user-supplied stage postprocessing function (if supplied) */
-  if (ark_mem->PostProcessStage != NULL)
+  if (ark_mem->PostProcessStageFn)
   {
-    retval = ark_mem->PostProcessStage(ark_mem->tn + ark_mem->h * mus,
-                                       ark_mem->tempv2, ark_mem->user_data);
+    retval = ark_mem->PostProcessStageFn(ark_mem->tn + ark_mem->h * mus,
+                                         ark_mem->tempv2, ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -1069,16 +1067,16 @@ int lsrkStep_TakeStepRKL(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
     mus  = w1 * mu;
     cj   = temj * w1 / FOUR;
 
-    /* apply user-supplied stage preprocessing function (if supplied) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(ark_mem->tcur + ark_mem->h * cjm1,
-                                      ark_mem->tempv2, ark_mem->user_data);
+      retval = ark_mem->PreRhsFn(ark_mem->tcur + ark_mem->h * cjm1,
+                                 ark_mem->tempv2, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
                    "status = failed preprocess rhs, retval = %i", retval);
-        return ARK_PREPROCESS_RHS_FAIL;
+        return ARK_PRERHSFN_FAIL;
       }
     }
 
@@ -1120,10 +1118,10 @@ int lsrkStep_TakeStepRKL(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
     }
 
     /* apply user-supplied stage postprocessing function (if supplied) */
-    if (ark_mem->PostProcessStage != NULL)
+    if (ark_mem->PostProcessStageFn)
     {
-      retval = ark_mem->PostProcessStage(ark_mem->tcur + ark_mem->h * cj,
-                                         ark_mem->ycur, ark_mem->user_data);
+      retval = ark_mem->PostProcessStageFn(ark_mem->tcur + ark_mem->h * cj,
+                                           ark_mem->ycur, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -1152,16 +1150,16 @@ int lsrkStep_TakeStepRKL(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
   SUNLogExtraDebugVec(ARK_LOGGER, "updated solution", ark_mem->ycur, "ycur(:) =");
   SUNLogInfo(ARK_LOGGER, "begin-compute-embedding", "");
 
-  /* apply user-supplied stage preprocessing function (if supplied) */
-  if (ark_mem->PreRHSProcess != NULL)
+  /* call the user-supplied pre-RHS function (if supplied) */
+  if (ark_mem->PreRhsFn)
   {
-    retval = ark_mem->PreRHSProcess(ark_mem->tcur + ark_mem->h, ark_mem->ycur,
-                                    ark_mem->user_data);
+    retval = ark_mem->PreRhsFn(ark_mem->tcur + ark_mem->h, ark_mem->ycur,
+                               ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-compute-embedding",
                  "status = failed preprocess rhs, retval = %i", retval);
-      return ARK_PREPROCESS_RHS_FAIL;
+      return ARK_PRERHSFN_FAIL;
     }
   }
 
@@ -1270,16 +1268,15 @@ int lsrkStep_TakeStepSSPs2(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
      of the step unless a renewed step or ARKODE updated fn. */
   if (!ark_mem->fn_is_current)
   {
-    /* apply user-supplied stage preprocessing function (if supplied) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(ark_mem->tn, ark_mem->yn,
-                                      ark_mem->user_data);
+      retval = ark_mem->PreRhsFn(ark_mem->tn, ark_mem->yn, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
                    "status = failed preprocess rhs, retval = %i", retval);
-        return ARK_PREPROCESS_RHS_FAIL;
+        return ARK_PRERHSFN_FAIL;
       }
     }
 
@@ -1309,10 +1306,10 @@ int lsrkStep_TakeStepSSPs2(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
   }
 
   /* apply user-supplied stage postprocessing function (if supplied) */
-  if (ark_mem->PostProcessStage != NULL)
+  if (ark_mem->PostProcessStageFn)
   {
-    retval = ark_mem->PostProcessStage(ark_mem->tn + sm1inv * ark_mem->h,
-                                       ark_mem->ycur, ark_mem->user_data);
+    retval = ark_mem->PostProcessStageFn(ark_mem->tn + sm1inv * ark_mem->h,
+                                         ark_mem->ycur, ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -1324,17 +1321,17 @@ int lsrkStep_TakeStepSSPs2(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
   /* Evaluate stages j = 2,...,step_mem->req_stages - 1 */
   for (int j = 2; j < step_mem->req_stages; j++)
   {
-    /* apply user-supplied stage preprocessing function (if supplied) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(ark_mem->tcur + ((sunrealtype)j - ONE) *
-                                                        sm1inv * ark_mem->h,
-                                      ark_mem->ycur, ark_mem->user_data);
+      retval = ark_mem->PreRhsFn(ark_mem->tcur + ((sunrealtype)j - ONE) *
+                                                   sm1inv * ark_mem->h,
+                                 ark_mem->ycur, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
                    "status = failed preprocess rhs, retval = %i", retval);
-        return ARK_PREPROCESS_RHS_FAIL;
+        return ARK_PRERHSFN_FAIL;
       }
     }
 
@@ -1365,10 +1362,10 @@ int lsrkStep_TakeStepSSPs2(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
     }
 
     /* apply user-supplied stage postprocessing function (if supplied) */
-    if (ark_mem->PostProcessStage != NULL)
+    if (ark_mem->PostProcessStageFn)
     {
-      retval = ark_mem->PostProcessStage(ark_mem->tcur + j * sm1inv * ark_mem->h,
-                                         ark_mem->ycur, ark_mem->user_data);
+      retval = ark_mem->PostProcessStageFn(ark_mem->tcur + j * sm1inv * ark_mem->h,
+                                           ark_mem->ycur, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -1380,15 +1377,16 @@ int lsrkStep_TakeStepSSPs2(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
 
   /* Evaluate the last stage for j = step_mem->req_stages */
 
-  if (ark_mem->PreRHSProcess != NULL)
+  /* call the user-supplied pre-RHS function (if supplied) */
+  if (ark_mem->PreRhsFn)
   {
-    retval = ark_mem->PreRHSProcess(ark_mem->tcur + ark_mem->h, ark_mem->ycur,
-                                    ark_mem->user_data);
+    retval = ark_mem->PreRhsFn(ark_mem->tcur + ark_mem->h, ark_mem->ycur,
+                               ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
                  "status = failed preprocess rhs, retval = %i", retval);
-      return ARK_PREPROCESS_RHS_FAIL;
+      return ARK_PRERHSFN_FAIL;
     }
   }
   retval = step_mem->fe(ark_mem->tcur + ark_mem->h, ark_mem->ycur,
@@ -1423,10 +1421,10 @@ int lsrkStep_TakeStepSSPs2(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
   }
 
   /* apply user-supplied stage postprocessing function (if supplied) */
-  if (ark_mem->PostProcessStage != NULL)
+  if (ark_mem->PostProcessStageFn)
   {
-    retval = ark_mem->PostProcessStage(ark_mem->tn + ark_mem->h, ark_mem->ycur,
-                                       ark_mem->user_data);
+    retval = ark_mem->PostProcessStageFn(ark_mem->tn + ark_mem->h, ark_mem->ycur,
+                                         ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -1507,16 +1505,15 @@ int lsrkStep_TakeStepSSPs3(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
      of the step unless ARKODE updated fn. */
   if (!ark_mem->fn_is_current)
   {
-    /* apply user-supplied stage preprocessing function (if supplied) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(ark_mem->tn, ark_mem->yn,
-                                      ark_mem->user_data);
+      retval = ark_mem->PreRhsFn(ark_mem->tn, ark_mem->yn, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
                    "status = failed preprocess rhs, retval = %i", retval);
-        return ARK_PREPROCESS_RHS_FAIL;
+        return ARK_PRERHSFN_FAIL;
       }
     }
 
@@ -1545,10 +1542,10 @@ int lsrkStep_TakeStepSSPs3(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
   }
 
   /* apply user-supplied stage postprocessing function (if supplied) */
-  if (ark_mem->PostProcessStage != NULL)
+  if (ark_mem->PostProcessStageFn)
   {
-    retval = ark_mem->PostProcessStage(ark_mem->tn + ark_mem->h * rat,
-                                       ark_mem->ycur, ark_mem->user_data);
+    retval = ark_mem->PostProcessStageFn(ark_mem->tn + ark_mem->h * rat,
+                                         ark_mem->ycur, ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -1560,17 +1557,17 @@ int lsrkStep_TakeStepSSPs3(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
   /* Evaluate stages j = 2,...,step_mem->req_stages */
   for (int j = 2; j <= ((in - 1) * (in - 2) / 2); j++)
   {
-    /* apply user-supplied stage preprocessing function (if supplied) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(ark_mem->tcur + ((sunrealtype)j - ONE) *
-                                                        rat * ark_mem->h,
-                                      ark_mem->ycur, ark_mem->user_data);
+      retval = ark_mem->PreRhsFn(ark_mem->tcur + ((sunrealtype)j - ONE) *
+                                                   rat * ark_mem->h,
+                                 ark_mem->ycur, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
                    "status = failed preprocess rhs, retval = %i", retval);
-        return ARK_PREPROCESS_RHS_FAIL;
+        return ARK_PRERHSFN_FAIL;
       }
     }
 
@@ -1601,10 +1598,10 @@ int lsrkStep_TakeStepSSPs3(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
     }
 
     /* apply user-supplied stage postprocessing function (if supplied) */
-    if (ark_mem->PostProcessStage != NULL)
+    if (ark_mem->PostProcessStageFn)
     {
-      retval = ark_mem->PostProcessStage(ark_mem->tcur + j * rat * ark_mem->h,
-                                         ark_mem->ycur, ark_mem->user_data);
+      retval = ark_mem->PostProcessStageFn(ark_mem->tcur + j * rat * ark_mem->h,
+                                           ark_mem->ycur, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -1618,17 +1615,17 @@ int lsrkStep_TakeStepSSPs3(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
 
   for (int j = ((in - 1) * (in - 2) / 2 + 1); j <= (in * (in + 1) / 2 - 1); j++)
   {
-    /* apply user-supplied stage preprocessing function (if supplied) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(ark_mem->tcur + ((sunrealtype)j - ONE) *
-                                                        rat * ark_mem->h,
+      retval = ark_mem->PreRhsFn(ark_mem->tcur + ((sunrealtype)j - ONE) *
+                                                   rat * ark_mem->h,
                                       ark_mem->ycur, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
                    "status = failed preprocess rhs, retval = %i", retval);
-        return ARK_PREPROCESS_RHS_FAIL;
+        return ARK_PRERHSFN_FAIL;
       }
     }
 
@@ -1659,10 +1656,10 @@ int lsrkStep_TakeStepSSPs3(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
     }
 
     /* apply user-supplied stage postprocessing function (if supplied) */
-    if (ark_mem->PostProcessStage != NULL)
+    if (ark_mem->PostProcessStageFn)
     {
-      retval = ark_mem->PostProcessStage(ark_mem->tcur + j * rat * ark_mem->h,
-                                         ark_mem->ycur, ark_mem->user_data);
+      retval = ark_mem->PostProcessStageFn(ark_mem->tcur + j * rat * ark_mem->h,
+                                           ark_mem->ycur, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -1672,18 +1669,18 @@ int lsrkStep_TakeStepSSPs3(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
     }
   }
 
-  /* apply user-supplied stage preprocessing function (if supplied) */
-  if (ark_mem->PreRHSProcess != NULL)
+  /* call the user-supplied pre-RHS function (if supplied) */
+  if (ark_mem->PreRhsFn)
   {
     retval =
-      ark_mem->PreRHSProcess(ark_mem->tcur +
-                               rat * (rn * (rn + ONE) / TWO - ONE) * ark_mem->h,
-                             ark_mem->ycur, ark_mem->user_data);
+      ark_mem->PreRhsFn(ark_mem->tcur +
+                          rat * (rn * (rn + ONE) / TWO - ONE) * ark_mem->h,
+                        ark_mem->ycur, ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
                  "status = failed preprocess rhs, retval = %i", retval);
-      return ARK_PREPROCESS_RHS_FAIL;
+      return ARK_PRERHSFN_FAIL;
     }
   }
 
@@ -1727,12 +1724,12 @@ int lsrkStep_TakeStepSSPs3(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
   }
 
   /* apply user-supplied stage postprocessing function (if supplied) */
-  if (ark_mem->PostProcessStage != NULL)
+  if (ark_mem->PostProcessStageFn)
   {
     retval =
-      ark_mem->PostProcessStage(ark_mem->tcur +
+      ark_mem->PostProcessStageFn(ark_mem->tcur +
                                   rat * (rn * (rn - ONE) / TWO) * ark_mem->h,
-                                ark_mem->ycur, ark_mem->user_data);
+                                  ark_mem->ycur, ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -1743,17 +1740,17 @@ int lsrkStep_TakeStepSSPs3(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
 
   for (int j = (in * (in + 1) / 2 + 1); j <= step_mem->req_stages; j++)
   {
-    /* apply user-supplied stage preprocessing function (if supplied) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(ark_mem->tcur + ((sunrealtype)j - rn - ONE) *
-                                                        rat * ark_mem->h,
-                                      ark_mem->ycur, ark_mem->user_data);
+      retval = ark_mem->PreRhsFn(ark_mem->tcur + ((sunrealtype)j - rn - ONE) *
+                                                   rat * ark_mem->h,
+                                 ark_mem->ycur, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
                    "status = failed preprocess rhs, retval = %i", retval);
-        return ARK_PREPROCESS_RHS_FAIL;
+        return ARK_PRERHSFN_FAIL;
       }
     }
 
@@ -1784,11 +1781,11 @@ int lsrkStep_TakeStepSSPs3(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
     }
 
     /* apply user-supplied stage postprocessing function (if supplied) */
-    if (ark_mem->PostProcessStage != NULL)
+    if (ark_mem->PostProcessStageFn)
     {
-      retval = ark_mem->PostProcessStage(ark_mem->tcur + ((sunrealtype)j - rn) *
+      retval = ark_mem->PostProcessStageFn(ark_mem->tcur + ((sunrealtype)j - rn) *
                                                            rat * ark_mem->h,
-                                         ark_mem->ycur, ark_mem->user_data);
+                                           ark_mem->ycur, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -1868,16 +1865,15 @@ int lsrkStep_TakeStepSSP43(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
      of the step unless ARKODE updated fn. */
   if (!ark_mem->fn_is_current)
   {
-    /* apply user-supplied stage preprocessing function (if supplied) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(ark_mem->tn, ark_mem->yn,
-                                      ark_mem->user_data);
+      retval = ark_mem->PreRhsFn(ark_mem->tn, ark_mem->yn, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
                    "status = failed preprocess rhs, retval = %i", retval);
-        return ARK_PREPROCESS_RHS_FAIL;
+        return ARK_PRERHSFN_FAIL;
       }
     }
 
@@ -1906,10 +1902,10 @@ int lsrkStep_TakeStepSSP43(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
   }
 
   /* apply user-supplied stage postprocessing function (if supplied) */
-  if (ark_mem->PostProcessStage != NULL)
+  if (ark_mem->PostProcessStageFn)
   {
-    retval = ark_mem->PostProcessStage(ark_mem->tn + ark_mem->h * p5,
-                                       ark_mem->ycur, ark_mem->user_data);
+    retval = ark_mem->PostProcessStageFn(ark_mem->tn + ark_mem->h * p5,
+                                         ark_mem->ycur, ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -1918,16 +1914,16 @@ int lsrkStep_TakeStepSSP43(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
     }
   }
 
-  /* apply user-supplied stage preprocessing function (if supplied) */
-  if (ark_mem->PreRHSProcess != NULL)
+  /* call the user-supplied pre-RHS function (if supplied) */
+  if (ark_mem->PreRhsFn)
   {
-    retval = ark_mem->PreRHSProcess(ark_mem->tcur + ark_mem->h * p5,
-                                    ark_mem->ycur, ark_mem->user_data);
+    retval = ark_mem->PreRhsFn(ark_mem->tcur + ark_mem->h * p5,
+                               ark_mem->ycur, ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
                  "status = failed preprocess rhs, retval = %i", retval);
-      return ARK_PREPROCESS_RHS_FAIL;
+      return ARK_PRERHSFN_FAIL;
     }
   }
 
@@ -1955,10 +1951,10 @@ int lsrkStep_TakeStepSSP43(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
   }
 
   /* apply user-supplied stage postprocessing function (if supplied) */
-  if (ark_mem->PostProcessStage != NULL)
+  if (ark_mem->PostProcessStageFn)
   {
-    retval = ark_mem->PostProcessStage(ark_mem->tcur + ark_mem->h,
-                                       ark_mem->ycur, ark_mem->user_data);
+    retval = ark_mem->PostProcessStageFn(ark_mem->tcur + ark_mem->h,
+                                         ark_mem->ycur, ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -1967,16 +1963,16 @@ int lsrkStep_TakeStepSSP43(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
     }
   }
 
-  /* apply user-supplied stage preprocessing function (if supplied) */
-  if (ark_mem->PreRHSProcess != NULL)
+  /* call the user-supplied pre-RHS function (if supplied) */
+  if (ark_mem->PreRhsFn)
   {
-    retval = ark_mem->PreRHSProcess(ark_mem->tcur + ark_mem->h, ark_mem->ycur,
-                                    ark_mem->user_data);
+    retval = ark_mem->PreRhsFn(ark_mem->tcur + ark_mem->h, ark_mem->ycur,
+                               ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
                  "status = failed preprocess rhs, retval = %i", retval);
-      return ARK_PREPROCESS_RHS_FAIL;
+      return ARK_PRERHSFN_FAIL;
     }
   }
 
@@ -2017,10 +2013,10 @@ int lsrkStep_TakeStepSSP43(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
   }
 
   /* apply user-supplied stage postprocessing function (if supplied) */
-  if (ark_mem->PostProcessStage != NULL)
+  if (ark_mem->PostProcessStageFn)
   {
-    retval = ark_mem->PostProcessStage(ark_mem->tcur + ark_mem->h * p5,
-                                       ark_mem->ycur, ark_mem->user_data);
+    retval = ark_mem->PostProcessStageFn(ark_mem->tcur + ark_mem->h * p5,
+                                         ark_mem->ycur, ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -2029,16 +2025,16 @@ int lsrkStep_TakeStepSSP43(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
     }
   }
 
-  /* apply user-supplied stage preprocessing function (if supplied) */
-  if (ark_mem->PreRHSProcess != NULL)
+  /* call the user-supplied pre-RHS function (if supplied) */
+  if (ark_mem->PreRhsFn)
   {
-    retval = ark_mem->PreRHSProcess(ark_mem->tcur + ark_mem->h * p5,
-                                    ark_mem->ycur, ark_mem->user_data);
+    retval = ark_mem->PreRhsFn(ark_mem->tcur + ark_mem->h * p5,
+                               ark_mem->ycur, ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
                  "status = failed preprocess rhs, retval = %i", retval);
-      return ARK_PREPROCESS_RHS_FAIL;
+      return ARK_PRERHSFN_FAIL;
     }
   }
 
@@ -2061,10 +2057,10 @@ int lsrkStep_TakeStepSSP43(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
                ark_mem->ycur);
 
   /* apply user-supplied stage postprocessing function (if supplied) */
-  if (ark_mem->PostProcessStage != NULL)
+  if (ark_mem->PostProcessStageFn)
   {
-    retval = ark_mem->PostProcessStage(ark_mem->tn + ark_mem->h, ark_mem->ycur,
-                                       ark_mem->user_data);
+    retval = ark_mem->PostProcessStageFn(ark_mem->tn + ark_mem->h, ark_mem->ycur,
+                                         ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -2138,16 +2134,15 @@ int lsrkStep_TakeStepSSP104(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPt
      of the step unless ARKODE updated fn. */
   if (!ark_mem->fn_is_current)
   {
-    /* apply user-supplied stage preprocessing function (if supplied) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(ark_mem->tn, ark_mem->yn,
-                                      ark_mem->user_data);
+      retval = ark_mem->PreRhsFn(ark_mem->tn, ark_mem->yn, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
                    "status = failed preprocess rhs, retval = %i", retval);
-        return ARK_PREPROCESS_RHS_FAIL;
+        return ARK_PRERHSFN_FAIL;
       }
     }
 
@@ -2180,10 +2175,10 @@ int lsrkStep_TakeStepSSP104(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPt
   }
 
   /* apply user-supplied stage postprocessing function (if supplied) */
-  if (ark_mem->PostProcessStage != NULL)
+  if (ark_mem->PostProcessStageFn)
   {
-    retval = ark_mem->PostProcessStage(ark_mem->tn + onesixth * ark_mem->h,
-                                       ark_mem->ycur, ark_mem->user_data);
+    retval = ark_mem->PostProcessStageFn(ark_mem->tn + onesixth * ark_mem->h,
+                                         ark_mem->ycur, ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -2195,17 +2190,17 @@ int lsrkStep_TakeStepSSP104(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPt
   /* Evaluate stages j = 2,...,step_mem->req_stages */
   for (int j = 2; j <= 5; j++)
   {
-    /* apply user-supplied stage preprocessing function (if supplied) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(ark_mem->tcur + ((sunrealtype)j - ONE) *
-                                                        onesixth * ark_mem->h,
-                                      ark_mem->ycur, ark_mem->user_data);
+      retval = ark_mem->PreRhsFn(ark_mem->tcur + ((sunrealtype)j - ONE) *
+                                                   onesixth * ark_mem->h,
+                                 ark_mem->ycur, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
                    "status = failed preprocess rhs, retval = %i", retval);
-        return ARK_PREPROCESS_RHS_FAIL;
+        return ARK_PRERHSFN_FAIL;
       }
     }
 
@@ -2236,18 +2231,18 @@ int lsrkStep_TakeStepSSP104(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPt
     }
 
     /* apply user-supplied stage postprocessing function (if supplied) */
-    if (ark_mem->PostProcessStage != NULL)
+    if (ark_mem->PostProcessStageFn)
     {
       if (j == 5)
       {
-        retval = ark_mem->PostProcessStage(ark_mem->tn + j * onesixth * ark_mem->h,
-                                           ark_mem->ycur, ark_mem->user_data);
+        retval = ark_mem->PostProcessStageFn(ark_mem->tn + j * onesixth * ark_mem->h,
+                                             ark_mem->ycur, ark_mem->user_data);
       }
       else
       {
-        retval = ark_mem->PostProcessStage(ark_mem->tn + SUN_RCONST(2.0) *
+        retval = ark_mem->PostProcessStageFn(ark_mem->tn + SUN_RCONST(2.0) *
                                                            onesixth * ark_mem->h,
-                                           ark_mem->ycur, ark_mem->user_data);
+                                             ark_mem->ycur, ark_mem->user_data);
       }
       if (retval != 0)
       {
@@ -2272,10 +2267,10 @@ int lsrkStep_TakeStepSSP104(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPt
                ark_mem->ycur, ark_mem->ycur);
 
   /* apply user-supplied stage postprocessing function (if supplied) */
-  if (ark_mem->PostProcessStage != NULL)
+  if (ark_mem->PostProcessStageFn)
   {
-    retval = ark_mem->PostProcessStage(ark_mem->tcur + TWO * onesixth * ark_mem->h,
-                                       ark_mem->ycur, ark_mem->user_data);
+    retval = ark_mem->PostProcessStageFn(ark_mem->tcur + TWO * onesixth * ark_mem->h,
+                                         ark_mem->ycur, ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -2286,17 +2281,17 @@ int lsrkStep_TakeStepSSP104(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPt
 
   for (int j = 6; j <= 9; j++)
   {
-    /* apply user-supplied stage preprocessing function (if supplied) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(ark_mem->tcur + ((sunrealtype)j - FOUR) *
-                                                        onesixth * ark_mem->h,
-                                      ark_mem->ycur, ark_mem->user_data);
+      retval = ark_mem->PreRhsFn(ark_mem->tcur + ((sunrealtype)j - FOUR) *
+                                                   onesixth * ark_mem->h,
+                                 ark_mem->ycur, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
                    "status = failed preprocess rhs, retval = %i", retval);
-        return ARK_PREPROCESS_RHS_FAIL;
+        return ARK_PRERHSFN_FAIL;
       }
     }
 
@@ -2332,11 +2327,11 @@ int lsrkStep_TakeStepSSP104(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPt
     }
 
     /* apply user-supplied stage postprocessing function (if supplied) */
-    if (ark_mem->PostProcessStage != NULL)
+    if (ark_mem->PostProcessStageFn)
     {
-      retval = ark_mem->PostProcessStage(ark_mem->tcur + ((sunrealtype)j - THREE) *
+      retval = ark_mem->PostProcessStageFn(ark_mem->tcur + ((sunrealtype)j - THREE) *
                                                            onesixth * ark_mem->h,
-                                         ark_mem->ycur, ark_mem->user_data);
+                                           ark_mem->ycur, ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -2346,16 +2341,16 @@ int lsrkStep_TakeStepSSP104(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPt
     }
   }
 
-  /* apply user-supplied stage preprocessing function (if supplied) */
-  if (ark_mem->PreRHSProcess != NULL)
+  /* call the user-supplied pre-RHS function (if supplied) */
+  if (ark_mem->PreRhsFn)
   {
-    retval = ark_mem->PreRHSProcess(ark_mem->tcur + ark_mem->h, ark_mem->ycur,
-                                    ark_mem->user_data);
+    retval = ark_mem->PreRhsFn(ark_mem->tcur + ark_mem->h, ark_mem->ycur,
+                               ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
                  "status = failed preprocess rhs, retval = %i", retval);
-      return ARK_PREPROCESS_RHS_FAIL;
+      return ARK_PRERHSFN_FAIL;
     }
   }
 
@@ -2386,10 +2381,10 @@ int lsrkStep_TakeStepSSP104(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPt
   }
 
   /* apply user-supplied stage postprocessing function (if supplied) */
-  if (ark_mem->PostProcessStage != NULL)
+  if (ark_mem->PostProcessStageFn)
   {
-    retval = ark_mem->PostProcessStage(ark_mem->tn + ark_mem->h, ark_mem->ycur,
-                                       ark_mem->user_data);
+    retval = ark_mem->PostProcessStageFn(ark_mem->tn + ark_mem->h, ark_mem->ycur,
+                                         ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -2781,12 +2776,11 @@ int lsrkStep_DQJtimes(void* arkode_mem, N_Vector v, N_Vector Jv)
   if ((!ark_mem->fn_is_current && ark_mem->initsetup) ||
       (step_mem->step_nst != ark_mem->nst))
   {
-    /* apply user-supplied stage preprocessing function (if supplied) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(ark_mem->tn, ark_mem->yn,
-                                      ark_mem->user_data);
-      if (retval != 0) { return ARK_PREPROCESS_RHS_FAIL; }
+      retval = ark_mem->PreRhsFn(ark_mem->tn, ark_mem->yn, ark_mem->user_data);
+      if (retval != 0) { return ARK_PRERHSFN_FAIL; }
     }
 
     retval = step_mem->fe(ark_mem->tn, ark_mem->yn, ark_mem->fn,
@@ -2811,12 +2805,13 @@ int lsrkStep_DQJtimes(void* arkode_mem, N_Vector v, N_Vector Jv)
     /* Set work = y + sig*v */
     N_VLinearSum(sig, v, ONE, y, work);
 
-    /* Set Jv = f(tn, y+sig*v) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(t, work, ark_mem->user_data);
-      if (retval != 0) { return ARK_PREPROCESS_RHS_FAIL; }
+      retval = ark_mem->PreRhsFn(t, work, ark_mem->user_data);
+      if (retval != 0) { return ARK_PRERHSFN_FAIL; }
     }
+    /* Set Jv = f(tn, y+sig*v) */
     retval = step_mem->fe(t, work, Jv, ark_mem->user_data);
     step_mem->nfeDQ++;
     if (retval == 0) { break; }

--- a/src/arkode/arkode_lsrkstep.c
+++ b/src/arkode/arkode_lsrkstep.c
@@ -771,8 +771,8 @@ int lsrkStep_TakeStepRKC(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
       return ARK_VECTOROP_ERR;
     }
 
-    /* apply user-supplied stage postprocessing function (if supplied) */
-    if (ark_mem->PostProcessStageFn)
+    /* apply user-supplied stage or step postprocessing function (if supplied) */
+    if (j < step_mem->req_stages && ark_mem->PostProcessStageFn)
     {
       retval = ark_mem->PostProcessStageFn(ark_mem->tcur + ark_mem->h * thj,
                                            ark_mem->ycur, ark_mem->user_data);
@@ -781,6 +781,17 @@ int lsrkStep_TakeStepRKC(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
                    "status = failed postprocess stage, retval = %i", retval);
         return ARK_POSTPROCESS_STAGE_FAIL;
+      }
+    }
+    else if (j == step_mem->req_stages && ark_mem->PostProcessStepFn)
+    {
+      retval = ark_mem->PostProcessStepFn(ark_mem->tcur + ark_mem->h * thj,
+                                          ark_mem->ycur, ark_mem->user_data);
+      if (retval != 0)
+      {
+        SUNLogInfo(ARK_LOGGER, "end-stages-list",
+                   "status = failed postprocess step, retval = %i", retval);
+        return ARK_POSTPROCESS_STEP_FAIL;
       }
     }
 
@@ -1117,8 +1128,8 @@ int lsrkStep_TakeStepRKL(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
       return ARK_VECTOROP_ERR;
     }
 
-    /* apply user-supplied stage postprocessing function (if supplied) */
-    if (ark_mem->PostProcessStageFn)
+    /* apply user-supplied stage or step postprocessing function (if supplied) */
+    if (j < step_mem->req_stages && ark_mem->PostProcessStageFn)
     {
       retval = ark_mem->PostProcessStageFn(ark_mem->tcur + ark_mem->h * cj,
                                            ark_mem->ycur, ark_mem->user_data);
@@ -1127,6 +1138,17 @@ int lsrkStep_TakeStepRKL(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
                    "status = failed postprocess stage, retval = %i", retval);
         return ARK_POSTPROCESS_STAGE_FAIL;
+      }
+    }
+    else if (j == step_mem->req_stages && ark_mem->PostProcessStepFn)
+    {
+      retval = ark_mem->PostProcessStepFn(ark_mem->tcur + ark_mem->h * cj,
+                                          ark_mem->ycur, ark_mem->user_data);
+      if (retval != 0)
+      {
+        SUNLogInfo(ARK_LOGGER, "end-stages-list",
+                   "status = failed postprocess step, retval = %i", retval);
+        return ARK_POSTPROCESS_STEP_FAIL;
       }
     }
 
@@ -1420,16 +1442,16 @@ int lsrkStep_TakeStepSSPs2(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
     return ARK_VECTOROP_ERR;
   }
 
-  /* apply user-supplied stage postprocessing function (if supplied) */
-  if (ark_mem->PostProcessStageFn)
+  /* apply user-supplied step postprocessing function (if supplied) */
+  if (ark_mem->PostProcessStepFn)
   {
-    retval = ark_mem->PostProcessStageFn(ark_mem->tn + ark_mem->h, ark_mem->ycur,
-                                         ark_mem->user_data);
+    retval = ark_mem->PostProcessStepFn(ark_mem->tn + ark_mem->h, ark_mem->ycur,
+                                        ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
-                 "status = failed postprocess stage, retval = %i", retval);
-      return ARK_POSTPROCESS_STAGE_FAIL;
+                 "status = failed postprocess step, retval = %i", retval);
+      return ARK_POSTPROCESS_STEP_FAIL;
     }
   }
 
@@ -1780,8 +1802,8 @@ int lsrkStep_TakeStepSSPs3(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
                    ark_mem->tempv1);
     }
 
-    /* apply user-supplied stage postprocessing function (if supplied) */
-    if (ark_mem->PostProcessStageFn)
+    /* apply user-supplied stage or step postprocessing function (if supplied) */
+    if (j < step_mem->req_stages && ark_mem->PostProcessStageFn)
     {
       retval = ark_mem->PostProcessStageFn(ark_mem->tcur + ((sunrealtype)j - rn) *
                                                            rat * ark_mem->h,
@@ -1791,6 +1813,17 @@ int lsrkStep_TakeStepSSPs3(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
                    "status = failed postprocess stage, retval = %i", retval);
         return ARK_POSTPROCESS_STAGE_FAIL;
+      }
+    }
+    else if (j == step_mem->req_stages && ark_mem->PostProcessStepFn)
+    {
+      retval = ark_mem->PostProcessStepFn(ark_mem->tn + ark_mem->h, ark_mem->ycur,
+                                          ark_mem->user_data);
+      if (retval != 0)
+      {
+        SUNLogInfo(ARK_LOGGER, "end-stages-list",
+                   "status = failed postprocess step, retval = %i", retval);
+        return ARK_POSTPROCESS_STEP_FAIL;
       }
     }
   }
@@ -2056,16 +2089,16 @@ int lsrkStep_TakeStepSSP43(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr
   N_VLinearSum(ONE, ark_mem->ycur, ark_mem->h * p5, ark_mem->tempv3,
                ark_mem->ycur);
 
-  /* apply user-supplied stage postprocessing function (if supplied) */
-  if (ark_mem->PostProcessStageFn)
+  /* apply user-supplied step postprocessing function (if supplied) */
+  if (ark_mem->PostProcessStepFn)
   {
-    retval = ark_mem->PostProcessStageFn(ark_mem->tn + ark_mem->h, ark_mem->ycur,
-                                         ark_mem->user_data);
+    retval = ark_mem->PostProcessStepFn(ark_mem->tn + ark_mem->h, ark_mem->ycur,
+                                        ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
-                 "status = failed postprocess stage, retval = %i", retval);
-      return ARK_POSTPROCESS_STAGE_FAIL;
+                 "status = failed postprocess step, retval = %i", retval);
+      return ARK_POSTPROCESS_STEP_FAIL;
     }
   }
 
@@ -2380,16 +2413,16 @@ int lsrkStep_TakeStepSSP104(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPt
     return ARK_VECTOROP_ERR;
   }
 
-  /* apply user-supplied stage postprocessing function (if supplied) */
-  if (ark_mem->PostProcessStageFn)
+  /* apply user-supplied step postprocessing function (if supplied) */
+  if (ark_mem->PostProcessStepFn)
   {
-    retval = ark_mem->PostProcessStageFn(ark_mem->tn + ark_mem->h, ark_mem->ycur,
-                                         ark_mem->user_data);
+    retval = ark_mem->PostProcessStepFn(ark_mem->tn + ark_mem->h, ark_mem->ycur,
+                                        ark_mem->user_data);
     if (retval != 0)
     {
       SUNLogInfo(ARK_LOGGER, "end-stages-list",
-                 "status = failed postprocess stage, retval = %i", retval);
-      return ARK_POSTPROCESS_STAGE_FAIL;
+                 "status = failed postprocess step, retval = %i", retval);
+      return ARK_POSTPROCESS_STEP_FAIL;
     }
   }
 

--- a/src/arkode/arkode_mristep.c
+++ b/src/arkode/arkode_mristep.c
@@ -2178,19 +2178,6 @@ int mriStep_TakeStepMRIGARK(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPt
     }
     if (retval != ARK_SUCCESS) { return retval; }
 
-    /* apply user-supplied stage postprocessing function (if supplied) */
-    if (ark_mem->PostProcessStageFn)
-    {
-      retval = ark_mem->PostProcessStageFn(ark_mem->tcur, ark_mem->ycur,
-                                           ark_mem->user_data);
-      if (retval != 0)
-      {
-        SUNLogInfo(ARK_LOGGER, "end-stages-list",
-                   "status = failed postprocess stage, retval = %i", retval);
-        return (ARK_POSTPROCESS_STAGE_FAIL);
-      }
-    }
-
     SUNLogExtraDebugVec(ARK_LOGGER, "embedded solution", ark_mem->ycur,
                         "y_embedded(:) =");
 
@@ -2676,7 +2663,7 @@ int mriStep_TakeStepMRISR(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
         return (ARK_INNERSTEP_FAIL);
       }
     }
-    else if ((solution || embedding) && ark_mem->PostProcessStepFn)
+    else if (solution && ark_mem->PostProcessStepFn)
     {
       retval = ark_mem->PostProcessStepFn(ark_mem->tcur, ark_mem->ycur,
                                           ark_mem->user_data);
@@ -3109,7 +3096,7 @@ int mriStep_TakeStepMERK(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
           return (ARK_INNERSTEP_FAIL);
         }
       }
-      else if ((solution || embedding) && ark_mem->PostProcessStepFn)
+      else if (solution && ark_mem->PostProcessStepFn)
       {
         retval = ark_mem->PostProcessStepFn(ark_mem->tcur, ark_mem->ycur,
                                             ark_mem->user_data);
@@ -3119,7 +3106,7 @@ int mriStep_TakeStepMERK(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
                      "status = failed postprocess step, retval = %i", retval);
           SUNLogInfo(ARK_LOGGER, "end-groups-list",
                      "status = failed stage computation, retval = %i", retval);
-          return (ARK_POSTPROCESS_STAGE_FAIL);
+          return (ARK_POSTPROCESS_STEP_FAIL);
         }
 
         retval = mriStepInnerStepper_Reset(step_mem->stepper, ark_mem->tcur,

--- a/src/arkode/arkode_mristep.c
+++ b/src/arkode/arkode_mristep.c
@@ -2266,17 +2266,17 @@ int mriStep_TakeStepMRIGARK(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPt
 
     SUNLogExtraDebugVec(ARK_LOGGER, "slow stage", ark_mem->ycur, "z_%i(:) =", is);
 
-    /* apply user-supplied stage postprocessing function (if supplied) */
-    if ((ark_mem->PostProcessStageFn) &&
+    /* apply user-supplied step postprocessing function (if supplied) */
+    if ((ark_mem->PostProcessStepFn) &&
         (step_mem->stagetypes[is] != MRISTAGE_STIFF_ACC))
     {
-      retval = ark_mem->PostProcessStageFn(ark_mem->tcur, ark_mem->ycur,
-                                           ark_mem->user_data);
+      retval = ark_mem->PostProcessStepFn(ark_mem->tcur, ark_mem->ycur,
+                                          ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
-                   "status = failed postprocess stage, retval = %i", retval);
-        return (ARK_POSTPROCESS_STAGE_FAIL);
+                   "status = failed postprocess step, retval = %i", retval);
+        return (ARK_POSTPROCESS_STEP_FAIL);
       }
     }
 
@@ -2284,7 +2284,7 @@ int mriStep_TakeStepMRIGARK(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPt
     if (step_mem->stagetypes[is] != MRISTAGE_STIFF_ACC)
     {
       if ((step_mem->stagetypes[is] != MRISTAGE_ERK_FAST) ||
-          (ark_mem->PostProcessStageFn))
+          (ark_mem->PostProcessStepFn))
       {
         retval = mriStepInnerStepper_Reset(step_mem->stepper, tf, ark_mem->ycur);
         if (retval != ARK_SUCCESS)
@@ -2653,9 +2653,9 @@ int mriStep_TakeStepMRISR(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
     SUNLogExtraDebugVec(ARK_LOGGER, "slow stage", ark_mem->ycur,
                         "z_%i(:) =", stage);
 
-    /* apply user-supplied stage postprocessing function (if supplied),
+    /* apply user-supplied stage or step postprocessing function (if supplied),
        and reset the inner integrator with the modified stage solution */
-    if (ark_mem->PostProcessStageFn)
+    if (!solution && !embedding && ark_mem->PostProcessStageFn)
     {
       retval = ark_mem->PostProcessStageFn(ark_mem->tcur, ark_mem->ycur,
                                            ark_mem->user_data);
@@ -2664,6 +2664,27 @@ int mriStep_TakeStepMRISR(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
                    "status = failed postprocess stage, retval = %i", retval);
         return (ARK_POSTPROCESS_STAGE_FAIL);
+      }
+      retval = mriStepInnerStepper_Reset(step_mem->stepper, ark_mem->tcur,
+                                         ark_mem->ycur);
+      if (retval != ARK_SUCCESS)
+      {
+        SUNLogInfo(ARK_LOGGER, "end-stages-list",
+                   "status = failed reset, retval = %i", retval);
+        arkProcessError(ark_mem, ARK_INNERSTEP_FAIL, __LINE__, __func__,
+                        __FILE__, "Unable to reset the inner stepper");
+        return (ARK_INNERSTEP_FAIL);
+      }
+    }
+    else if ((solution || embedding) && ark_mem->PostProcessStepFn)
+    {
+      retval = ark_mem->PostProcessStepFn(ark_mem->tcur, ark_mem->ycur,
+                                          ark_mem->user_data);
+      if (retval != 0)
+      {
+        SUNLogInfo(ARK_LOGGER, "end-stages-list",
+                   "status = failed postprocess step, retval = %i", retval);
+        return (ARK_POSTPROCESS_STEP_FAIL);
       }
       retval = mriStepInnerStepper_Reset(step_mem->stepper, ark_mem->tcur,
                                          ark_mem->ycur);
@@ -3062,7 +3083,7 @@ int mriStep_TakeStepMERK(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
 
       /* apply user-supplied stage postprocessing function (if supplied),
          and reset the inner integrator with the modified stage solution */
-      if (ark_mem->PostProcessStageFn)
+      if (!solution && !embedding && ark_mem->PostProcessStageFn)
       {
         retval = ark_mem->PostProcessStageFn(ark_mem->tcur, ark_mem->ycur,
                                              ark_mem->user_data);
@@ -3070,6 +3091,32 @@ int mriStep_TakeStepMERK(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
         {
           SUNLogInfo(ARK_LOGGER, "end-stages-list",
                      "status = failed postprocess stage, retval = %i", retval);
+          SUNLogInfo(ARK_LOGGER, "end-groups-list",
+                     "status = failed stage computation, retval = %i", retval);
+          return (ARK_POSTPROCESS_STAGE_FAIL);
+        }
+
+        retval = mriStepInnerStepper_Reset(step_mem->stepper, ark_mem->tcur,
+                                           ark_mem->ycur);
+        if (retval != ARK_SUCCESS)
+        {
+          SUNLogInfo(ARK_LOGGER, "end-stages-list",
+                     "status = failed reset, retval = %i", retval);
+          SUNLogInfo(ARK_LOGGER, "end-groups-list",
+                     "status = failed stage computation, retval = %i", retval);
+          arkProcessError(ark_mem, ARK_INNERSTEP_FAIL, __LINE__, __func__,
+                          __FILE__, "Unable to reset the inner stepper");
+          return (ARK_INNERSTEP_FAIL);
+        }
+      }
+      else if ((solution || embedding) && ark_mem->PostProcessStepFn)
+      {
+        retval = ark_mem->PostProcessStepFn(ark_mem->tcur, ark_mem->ycur,
+                                            ark_mem->user_data);
+        if (retval != 0)
+        {
+          SUNLogInfo(ARK_LOGGER, "end-stages-list",
+                     "status = failed postprocess step, retval = %i", retval);
           SUNLogInfo(ARK_LOGGER, "end-groups-list",
                      "status = failed stage computation, retval = %i", retval);
           return (ARK_POSTPROCESS_STAGE_FAIL);

--- a/src/arkode/arkode_mristep.c
+++ b/src/arkode/arkode_mristep.c
@@ -1476,11 +1476,11 @@ int mriStep_FullRHS(ARKodeMem ark_mem, sunrealtype t, N_Vector y, N_Vector f,
     step_mem->Xvecs[nvec] = f;
     nvec++;
 
-    /* apply user-supplied stage preprocessing function (if supplied) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(t, y, ark_mem->user_data);
-      if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+      retval = ark_mem->PreRhsFn(t, y, ark_mem->user_data);
+      if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
     }
 
     /* compute the implicit component and store in sdata */
@@ -1604,13 +1604,13 @@ int mriStep_UpdateF0(ARKodeMem ark_mem, ARKodeMRIStepMem step_mem,
 
     /* update the RHS components */
 
-    /* apply user-supplied stage preprocessing function (if supplied) */
-    if ((ark_mem->PreRHSProcess != NULL) &&
+    /* call the user-supplied pre-RHS function (if supplied) */
+    if ((ark_mem->PreRhsFn) &&
         ((!step_mem->fse_is_current || !ark_mem->fn_is_current) ||
          (!step_mem->fsi_is_current || !ark_mem->fn_is_current)))
     {
-      retval = ark_mem->PreRHSProcess(t, y, ark_mem->user_data);
-      if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+      retval = ark_mem->PreRhsFn(t, y, ark_mem->user_data);
+      if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
     }
 
     /*   implicit component */
@@ -1678,11 +1678,11 @@ int mriStep_UpdateF0(ARKodeMem ark_mem, ARKodeMRIStepMem step_mem,
     /* compute the full RHS */
     if (!(ark_mem->fn_is_current))
     {
-      /* apply user-supplied stage preprocessing function (if supplied) */
-      if (ark_mem->PreRHSProcess != NULL)
+      /* call the user-supplied pre-RHS function (if supplied) */
+      if (ark_mem->PreRhsFn)
       {
-        retval = ark_mem->PreRHSProcess(t, y, ark_mem->user_data);
-        if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+        retval = ark_mem->PreRhsFn(t, y, ark_mem->user_data);
+        if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
       }
 
       /* compute the implicit component */
@@ -1976,11 +1976,11 @@ int mriStep_TakeStepMRIGARK(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPt
     SUNLogExtraDebugVec(ARK_LOGGER, "slow stage", ark_mem->ycur, "z_%i(:) =", is);
 
     /* apply user-supplied stage postprocessing function (if supplied) */
-    if ((ark_mem->PostProcessStage != NULL) &&
+    if ((ark_mem->PostProcessStageFn) &&
         (step_mem->stagetypes[is] != MRISTAGE_STIFF_ACC))
     {
-      retval = ark_mem->PostProcessStage(ark_mem->tcur, ark_mem->ycur,
-                                         ark_mem->user_data);
+      retval = ark_mem->PostProcessStageFn(ark_mem->tcur, ark_mem->ycur,
+                                           ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -1993,7 +1993,7 @@ int mriStep_TakeStepMRIGARK(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPt
     if (step_mem->stagetypes[is] != MRISTAGE_STIFF_ACC)
     {
       if ((step_mem->stagetypes[is] != MRISTAGE_ERK_FAST) ||
-          (ark_mem->PostProcessStage != NULL))
+          (ark_mem->PostProcessStageFn))
       {
         retval = mriStepInnerStepper_Reset(step_mem->stepper, tf, ark_mem->ycur);
         if (retval != ARK_SUCCESS)
@@ -2018,21 +2018,21 @@ int mriStep_TakeStepMRIGARK(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPt
     }
     if (calc_fslow)
     {
-      /* apply user-supplied stage preprocessing function (if supplied) */
-      if (ark_mem->PreRHSProcess != NULL)
+      /* call the user-supplied pre-RHS function (if supplied) */
+      if (ark_mem->PreRhsFn)
       {
         if (step_mem->explicit_rhs ||
             (step_mem->implicit_rhs &&
              (!step_mem->deduce_rhs ||
               (step_mem->stagetypes[is] != MRISTAGE_DIRK_NOFAST))))
         {
-          retval = ark_mem->PreRHSProcess(ark_mem->tcur, ark_mem->ycur,
-                                          ark_mem->user_data);
+          retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur,
+                                     ark_mem->user_data);
           if (retval != 0)
           {
             SUNLogInfo(ARK_LOGGER, "end-stages-list",
                        "status = failed preprocess rhs, retval = %i", retval);
-            return (ARK_PREPROCESS_RHS_FAIL);
+            return (ARK_PRERHSFN_FAIL);
           }
         }
       }
@@ -2179,10 +2179,10 @@ int mriStep_TakeStepMRIGARK(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPt
     if (retval != ARK_SUCCESS) { return retval; }
 
     /* apply user-supplied stage postprocessing function (if supplied) */
-    if (ark_mem->PostProcessStage != NULL)
+    if (ark_mem->PostProcessStageFn)
     {
-      retval = ark_mem->PostProcessStage(ark_mem->tcur, ark_mem->ycur,
-                                         ark_mem->user_data);
+      retval = ark_mem->PostProcessStageFn(ark_mem->tcur, ark_mem->ycur,
+                                           ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -2267,11 +2267,11 @@ int mriStep_TakeStepMRIGARK(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPt
     SUNLogExtraDebugVec(ARK_LOGGER, "slow stage", ark_mem->ycur, "z_%i(:) =", is);
 
     /* apply user-supplied stage postprocessing function (if supplied) */
-    if ((ark_mem->PostProcessStage != NULL) &&
+    if ((ark_mem->PostProcessStageFn) &&
         (step_mem->stagetypes[is] != MRISTAGE_STIFF_ACC))
     {
-      retval = ark_mem->PostProcessStage(ark_mem->tcur, ark_mem->ycur,
-                                         ark_mem->user_data);
+      retval = ark_mem->PostProcessStageFn(ark_mem->tcur, ark_mem->ycur,
+                                           ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -2284,7 +2284,7 @@ int mriStep_TakeStepMRIGARK(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPt
     if (step_mem->stagetypes[is] != MRISTAGE_STIFF_ACC)
     {
       if ((step_mem->stagetypes[is] != MRISTAGE_ERK_FAST) ||
-          (ark_mem->PostProcessStage != NULL))
+          (ark_mem->PostProcessStageFn))
       {
         retval = mriStepInnerStepper_Reset(step_mem->stepper, tf, ark_mem->ycur);
         if (retval != ARK_SUCCESS)
@@ -2655,10 +2655,10 @@ int mriStep_TakeStepMRISR(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
 
     /* apply user-supplied stage postprocessing function (if supplied),
        and reset the inner integrator with the modified stage solution */
-    if (ark_mem->PostProcessStage != NULL)
+    if (ark_mem->PostProcessStageFn)
     {
-      retval = ark_mem->PostProcessStage(ark_mem->tcur, ark_mem->ycur,
-                                         ark_mem->user_data);
+      retval = ark_mem->PostProcessStageFn(ark_mem->tcur, ark_mem->ycur,
+                                           ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -2680,19 +2680,19 @@ int mriStep_TakeStepMRISR(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
     /* Compute updated slow RHS (except for final solution or embedding) */
     if ((!solution) && (!embedding))
     {
-      /* apply user-supplied stage preprocessing function (if supplied) */
-      if (ark_mem->PreRHSProcess != NULL)
+      /* call the user-supplied pre-RHS function (if supplied) */
+      if (ark_mem->PreRhsFn)
       {
         if (step_mem->explicit_rhs ||
             (step_mem->implicit_rhs && (!step_mem->deduce_rhs || !impl_corr)))
         {
-          retval = ark_mem->PreRHSProcess(ark_mem->tcur, ark_mem->ycur,
-                                          ark_mem->user_data);
+          retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur,
+                                     ark_mem->user_data);
           if (retval != 0)
           {
             SUNLogInfo(ARK_LOGGER, "end-stages-list",
                        "status = failed preprocess rhs, retval = %i", retval);
-            return (ARK_PREPROCESS_RHS_FAIL);
+            return (ARK_PRERHSFN_FAIL);
           }
         }
       }
@@ -3062,10 +3062,10 @@ int mriStep_TakeStepMERK(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
 
       /* apply user-supplied stage postprocessing function (if supplied),
          and reset the inner integrator with the modified stage solution */
-      if (ark_mem->PostProcessStage != NULL)
+      if (ark_mem->PostProcessStageFn)
       {
-        retval = ark_mem->PostProcessStage(ark_mem->tcur, ark_mem->ycur,
-                                           ark_mem->user_data);
+        retval = ark_mem->PostProcessStageFn(ark_mem->tcur, ark_mem->ycur,
+                                             ark_mem->user_data);
         if (retval != 0)
         {
           SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -3092,18 +3092,18 @@ int mriStep_TakeStepMERK(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
       /* Compute updated slow RHS (except for final solution or embedding) */
       if ((!solution) && (!embedding))
       {
-        /* apply user-supplied stage preprocessing function (if supplied) */
-        if (ark_mem->PreRHSProcess != NULL)
+        /* call the user-supplied pre-RHS function (if supplied) */
+        if (ark_mem->PreRhsFn)
         {
-          retval = ark_mem->PreRHSProcess(ark_mem->tcur, ark_mem->ycur,
-                                          ark_mem->user_data);
+          retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur,
+                                     ark_mem->user_data);
           if (retval != 0)
           {
             SUNLogInfo(ARK_LOGGER, "end-stages-list",
                        "status = failed preprocess rhs, retval = %i", retval);
             SUNLogInfo(ARK_LOGGER, "end-groups-list",
                        "status = failed stage computation, retval = %i", retval);
-            return (ARK_PREPROCESS_RHS_FAIL);
+            return (ARK_PRERHSFN_FAIL);
           }
         }
 
@@ -4253,11 +4253,11 @@ int mriStep_SlowRHS(ARKodeMem ark_mem, sunrealtype t, N_Vector y, N_Vector f,
   retval = mriStep_AccessStepMem(ark_mem, __func__, &step_mem);
   if (retval != ARK_SUCCESS) { return (retval); }
 
-  /* apply user-supplied stage preprocessing function (if supplied) */
-  if (ark_mem->PreRHSProcess != NULL)
+  /* call the user-supplied pre-RHS function (if supplied) */
+  if (ark_mem->PreRhsFn)
   {
-    retval = ark_mem->PreRHSProcess(t, y, ark_mem->user_data);
-    if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+    retval = ark_mem->PreRhsFn(t, y, ark_mem->user_data);
+    if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
   }
 
   /* call fsi if the problem has an implicit component */

--- a/src/arkode/arkode_mristep_nls.c
+++ b/src/arkode/arkode_mristep_nls.c
@@ -474,12 +474,11 @@ int mriStep_NlsResidual(N_Vector zcor, N_Vector r, void* arkode_mem)
   /* update 'ycur' value as stored predictor + current corrector */
   N_VLinearSum(ONE, step_mem->zpred, ONE, zcor, ark_mem->ycur);
 
-  /* apply user-supplied RHS preprocessing function (if supplied), and then call RHS */
-  if (ark_mem->PreRHSProcess != NULL)
+  /* call the user-supplied pre-RHS function (if supplied), then call RHS */
+  if (ark_mem->PreRhsFn)
   {
-    retval = ark_mem->PreRHSProcess(ark_mem->tcur, ark_mem->ycur,
-                                    ark_mem->user_data);
-    if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+    retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur, ark_mem->user_data);
+    if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
   }
   retval = step_mem->nls_fsi(ark_mem->tcur, ark_mem->ycur,
                              step_mem->Fsi[step_mem->stage_map[step_mem->istage]],
@@ -535,12 +534,11 @@ int mriStep_NlsFPFunction(N_Vector zcor, N_Vector g, void* arkode_mem)
   /* update 'ycur' value as stored predictor + current corrector */
   N_VLinearSum(ONE, step_mem->zpred, ONE, zcor, ark_mem->ycur);
 
-  /* apply user-supplied RHS preprocessing function (if supplied), and then call RHS */
-  if (ark_mem->PreRHSProcess != NULL)
+  /* call the user-supplied pre-RHS function (if supplied), then call RHS */
+  if (ark_mem->PreRhsFn)
   {
-    retval = ark_mem->PreRHSProcess(ark_mem->tcur, ark_mem->ycur,
-                                    ark_mem->user_data);
-    if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+    retval = ark_mem->PreRhsFn(ark_mem->tcur, ark_mem->ycur, ark_mem->user_data);
+    if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
   }
   retval = step_mem->nls_fsi(ark_mem->tcur, ark_mem->ycur,
                              step_mem->Fsi[step_mem->stage_map[step_mem->istage]],

--- a/src/arkode/arkode_sprkstep.c
+++ b/src/arkode/arkode_sprkstep.c
@@ -648,7 +648,7 @@ int sprkStep_TakeStep(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
     }
 
     /* apply user-supplied stage postprocessing function (if supplied) */
-    if (ark_mem->PostProcessStageFn)
+    if (is < step_mem->method->stages - 1 && ark_mem->PostProcessStageFn)
     {
       retval = ark_mem->PostProcessStageFn(ark_mem->tcur, ark_mem->ycur,
                                            ark_mem->user_data);
@@ -657,6 +657,17 @@ int sprkStep_TakeStep(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
                    "status = failed postprocess stage, retval = %i", retval);
         return (ARK_POSTPROCESS_STAGE_FAIL);
+      }
+    }
+    else if (is == step_mem->method->stages - 1 && ark_mem->PostProcessStepFn)
+    {
+      retval = ark_mem->PostProcessStepFn(ark_mem->tcur, ark_mem->ycur,
+                                          ark_mem->user_data);
+      if (retval != 0)
+      {
+        SUNLogInfo(ARK_LOGGER, "end-stages-list",
+                   "status = failed postprocess step, retval = %i", retval);
+        return (ARK_POSTPROCESS_STEP_FAIL);
       }
     }
 
@@ -706,7 +717,8 @@ int sprkStep_TakeStep_Compensated(ARKodeMem ark_mem, sunrealtype* dsmPtr,
 
   /* if user-supplied stage preprocessing or postprocessing functions,
     * we error out since those won't work with the increment form */
-  if ((ark_mem->PreRhsFn) || (ark_mem->PostProcessStageFn))
+  if ((ark_mem->PreRhsFn) || (ark_mem->PostProcessStageFn) ||
+      (ark_mem->PostProcessStepFn))
   {
     SUNLogInfo(ARK_LOGGER, "begin-stages-list",
                "status = failed stage stage processing, retval = %i",

--- a/src/arkode/arkode_sprkstep.c
+++ b/src/arkode/arkode_sprkstep.c
@@ -492,11 +492,11 @@ int sprkStep_FullRHS(ARKodeMem ark_mem, sunrealtype t, N_Vector y, N_Vector f,
   case ARK_FULLRHS_END:
   case ARK_FULLRHS_OTHER:
 
-    /* apply user-supplied stage preprocessing function (if supplied) */
-    if (ark_mem->PreRHSProcess != NULL)
+    /* call the user-supplied pre-RHS function (if supplied) */
+    if (ark_mem->PreRhsFn)
     {
-      retval = ark_mem->PreRHSProcess(t, y, ark_mem->user_data);
-      if (retval != 0) { return (ARK_PREPROCESS_RHS_FAIL); }
+      retval = ark_mem->PreRhsFn(t, y, ark_mem->user_data);
+      if (retval != 0) { return (ARK_PRERHSFN_FAIL); }
     }
 
     /* Since f1 and f2 do not have overlapping outputs and so the f vector is
@@ -573,16 +573,16 @@ int sprkStep_TakeStep(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
       N_VConst(ZERO, step_mem->sdata); /* either have to do this or ask user to
                                           set other outputs to zero */
 
-      /* apply user-supplied stage preprocessing function (if supplied) */
-      if (ark_mem->PreRHSProcess != NULL)
+      /* call the user-supplied pre-RHS function (if supplied) */
+      if (ark_mem->PreRhsFn)
       {
-        retval = ark_mem->PreRHSProcess(ark_mem->tn + chati * ark_mem->h,
-                                        prev_stage, ark_mem->user_data);
+        retval = ark_mem->PreRhsFn(ark_mem->tn + chati * ark_mem->h,
+                                   prev_stage, ark_mem->user_data);
         if (retval != 0)
         {
           SUNLogInfo(ARK_LOGGER, "end-stages-list",
                      "status = failed preprocess rhs, retval = %i", retval);
-          return (ARK_PREPROCESS_RHS_FAIL);
+          return (ARK_PRERHSFN_FAIL);
         }
       }
 
@@ -616,16 +616,16 @@ int sprkStep_TakeStep(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
       N_VConst(ZERO, step_mem->sdata); /* either have to do this or ask user to
                                         set other outputs to zero */
 
-      /* apply user-supplied stage preprocessing function (if supplied) */
-      if (ark_mem->PreRHSProcess != NULL)
+      /* call the user-supplied pre-RHS function (if supplied) */
+      if (ark_mem->PreRhsFn)
       {
-        retval = ark_mem->PreRHSProcess(ark_mem->tn + ci * ark_mem->h,
-                                        curr_stage, ark_mem->user_data);
+        retval = ark_mem->PreRhsFn(ark_mem->tn + ci * ark_mem->h,
+                                   curr_stage, ark_mem->user_data);
         if (retval != 0)
         {
           SUNLogInfo(ARK_LOGGER, "end-stages-list",
                      "status = failed preprocess rhs, retval = %i", retval);
-          return (ARK_PREPROCESS_RHS_FAIL);
+          return (ARK_PRERHSFN_FAIL);
         }
       }
 
@@ -648,10 +648,10 @@ int sprkStep_TakeStep(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
     }
 
     /* apply user-supplied stage postprocessing function (if supplied) */
-    if (ark_mem->PostProcessStage != NULL)
+    if (ark_mem->PostProcessStageFn)
     {
-      retval = ark_mem->PostProcessStage(ark_mem->tcur, ark_mem->ycur,
-                                         ark_mem->user_data);
+      retval = ark_mem->PostProcessStageFn(ark_mem->tcur, ark_mem->ycur,
+                                           ark_mem->user_data);
       if (retval != 0)
       {
         SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -706,11 +706,11 @@ int sprkStep_TakeStep_Compensated(ARKodeMem ark_mem, sunrealtype* dsmPtr,
 
   /* if user-supplied stage preprocessing or postprocessing functions,
     * we error out since those won't work with the increment form */
-  if ((ark_mem->PreRHSProcess != NULL) || (ark_mem->PostProcessStage != NULL))
+  if ((ark_mem->PreRhsFn) || (ark_mem->PostProcessStageFn))
   {
     SUNLogInfo(ARK_LOGGER, "begin-stages-list",
                "status = failed stage stage processing, retval = %i",
-               ARK_PREPROCESS_RHS_FAIL);
+               ARK_PRERHSFN_FAIL);
     arkProcessError(ark_mem, ARK_POSTPROCESS_STAGE_FAIL, __LINE__, __func__,
                     __FILE__,
                     "Compensated summation is not compatible with stage "

--- a/src/arkode/arkode_sprkstep.c
+++ b/src/arkode/arkode_sprkstep.c
@@ -576,8 +576,8 @@ int sprkStep_TakeStep(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
       /* call the user-supplied pre-RHS function (if supplied) */
       if (ark_mem->PreRhsFn)
       {
-        retval = ark_mem->PreRhsFn(ark_mem->tn + chati * ark_mem->h,
-                                   prev_stage, ark_mem->user_data);
+        retval = ark_mem->PreRhsFn(ark_mem->tn + chati * ark_mem->h, prev_stage,
+                                   ark_mem->user_data);
         if (retval != 0)
         {
           SUNLogInfo(ARK_LOGGER, "end-stages-list",
@@ -619,8 +619,8 @@ int sprkStep_TakeStep(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
       /* call the user-supplied pre-RHS function (if supplied) */
       if (ark_mem->PreRhsFn)
       {
-        retval = ark_mem->PreRhsFn(ark_mem->tn + ci * ark_mem->h,
-                                   curr_stage, ark_mem->user_data);
+        retval = ark_mem->PreRhsFn(ark_mem->tn + ci * ark_mem->h, curr_stage,
+                                   ark_mem->user_data);
         if (retval != 0)
         {
           SUNLogInfo(ARK_LOGGER, "end-stages-list",

--- a/src/arkode/fmod_int32/farkode_mod.c
+++ b/src/arkode/fmod_int32/farkode_mod.c
@@ -650,15 +650,43 @@ SWIGEXPORT int _wrap_FARKodeSetUserData(void *farg1, void *farg2) {
 }
 
 
-SWIGEXPORT int _wrap_FARKodeSetPreprocessStepFn(void *farg1, ARKPostProcessFn farg2) {
+SWIGEXPORT int _wrap_FARKodeSetPreStepFn(void *farg1, ARKPreStepFn farg2) {
   int fresult ;
   void *arg1 = (void *) 0 ;
-  ARKPostProcessFn arg2 = (ARKPostProcessFn) 0 ;
+  ARKPreStepFn arg2 = (ARKPreStepFn) 0 ;
   int result;
   
   arg1 = (void *)(farg1);
-  arg2 = (ARKPostProcessFn)(farg2);
-  result = (int)ARKodeSetPreprocessStepFn(arg1,arg2);
+  arg2 = (ARKPreStepFn)(farg2);
+  result = (int)ARKodeSetPreStepFn(arg1,arg2);
+  fresult = (int)(result);
+  return fresult;
+}
+
+
+SWIGEXPORT int _wrap_FARKodeSetPostStepFn(void *farg1, ARKPostStepFn farg2) {
+  int fresult ;
+  void *arg1 = (void *) 0 ;
+  ARKPostStepFn arg2 = (ARKPostStepFn) 0 ;
+  int result;
+  
+  arg1 = (void *)(farg1);
+  arg2 = (ARKPostStepFn)(farg2);
+  result = (int)ARKodeSetPostStepFn(arg1,arg2);
+  fresult = (int)(result);
+  return fresult;
+}
+
+
+SWIGEXPORT int _wrap_FARKodeSetPreRhsFn(void *farg1, ARKPreRhsFn farg2) {
+  int fresult ;
+  void *arg1 = (void *) 0 ;
+  ARKPreRhsFn arg2 = (ARKPreRhsFn) 0 ;
+  int result;
+  
+  arg1 = (void *)(farg1);
+  arg2 = (ARKPreRhsFn)(farg2);
+  result = (int)ARKodeSetPreRhsFn(arg1,arg2);
   fresult = (int)(result);
   return fresult;
 }
@@ -673,34 +701,6 @@ SWIGEXPORT int _wrap_FARKodeSetPostprocessStepFn(void *farg1, ARKPostProcessFn f
   arg1 = (void *)(farg1);
   arg2 = (ARKPostProcessFn)(farg2);
   result = (int)ARKodeSetPostprocessStepFn(arg1,arg2);
-  fresult = (int)(result);
-  return fresult;
-}
-
-
-SWIGEXPORT int _wrap_FARKodeSetPostprocessStepFailFn(void *farg1, ARKPostProcessFn farg2) {
-  int fresult ;
-  void *arg1 = (void *) 0 ;
-  ARKPostProcessFn arg2 = (ARKPostProcessFn) 0 ;
-  int result;
-  
-  arg1 = (void *)(farg1);
-  arg2 = (ARKPostProcessFn)(farg2);
-  result = (int)ARKodeSetPostprocessStepFailFn(arg1,arg2);
-  fresult = (int)(result);
-  return fresult;
-}
-
-
-SWIGEXPORT int _wrap_FARKodeSetPreRHSProcessFn(void *farg1, ARKPostProcessFn farg2) {
-  int fresult ;
-  void *arg1 = (void *) 0 ;
-  ARKPostProcessFn arg2 = (ARKPostProcessFn) 0 ;
-  int result;
-  
-  arg1 = (void *)(farg1);
-  arg2 = (ARKPostProcessFn)(farg2);
-  result = (int)ARKodeSetPreRHSProcessFn(arg1,arg2);
   fresult = (int)(result);
   return fresult;
 }

--- a/src/arkode/fmod_int32/farkode_mod.f90
+++ b/src/arkode/fmod_int32/farkode_mod.f90
@@ -87,9 +87,9 @@ module farkode_mod
  integer(C_INT), parameter, public :: ARK_POSTPROCESS_FAIL = -37_C_INT
  integer(C_INT), parameter, public :: ARK_POSTPROCESS_STEP_FAIL = -37_C_INT
  integer(C_INT), parameter, public :: ARK_POSTPROCESS_STAGE_FAIL = -38_C_INT
- integer(C_INT), parameter, public :: ARK_POSTPROCESS_FAILED_STEP_FAIL = -39_C_INT
- integer(C_INT), parameter, public :: ARK_PREPROCESS_STEP_FAIL = -40_C_INT
- integer(C_INT), parameter, public :: ARK_PREPROCESS_RHS_FAIL = -41_C_INT
+ integer(C_INT), parameter, public :: ARK_PRESTEPFN_FAIL = -39_C_INT
+ integer(C_INT), parameter, public :: ARK_POSTSTEPFN_FAIL = -40_C_INT
+ integer(C_INT), parameter, public :: ARK_PRERHSFN_FAIL = -41_C_INT
  integer(C_INT), parameter, public :: ARK_USER_PREDICT_FAIL = -42_C_INT
  integer(C_INT), parameter, public :: ARK_INTERP_FAIL = -43_C_INT
  integer(C_INT), parameter, public :: ARK_INVALID_TABLE = -44_C_INT
@@ -148,10 +148,10 @@ module farkode_mod
  public :: FARKodeSetFixedStep
  public :: FARKodeSetStepDirection
  public :: FARKodeSetUserData
- public :: FARKodeSetPreprocessStepFn
+ public :: FARKodeSetPreStepFn
+ public :: FARKodeSetPostStepFn
+ public :: FARKodeSetPreRhsFn
  public :: FARKodeSetPostprocessStepFn
- public :: FARKodeSetPostprocessStepFailFn
- public :: FARKodeSetPreRHSProcessFn
  public :: FARKodeSetPostprocessStageFn
  public :: FARKodeSetNonlinearSolver
  public :: FARKodeSetLinear
@@ -711,8 +711,26 @@ type(C_PTR), value :: farg2
 integer(C_INT) :: fresult
 end function
 
-function swigc_FARKodeSetPreprocessStepFn(farg1, farg2) &
-bind(C, name="_wrap_FARKodeSetPreprocessStepFn") &
+function swigc_FARKodeSetPreStepFn(farg1, farg2) &
+bind(C, name="_wrap_FARKodeSetPreStepFn") &
+result(fresult)
+use, intrinsic :: ISO_C_BINDING
+type(C_PTR), value :: farg1
+type(C_FUNPTR), value :: farg2
+integer(C_INT) :: fresult
+end function
+
+function swigc_FARKodeSetPostStepFn(farg1, farg2) &
+bind(C, name="_wrap_FARKodeSetPostStepFn") &
+result(fresult)
+use, intrinsic :: ISO_C_BINDING
+type(C_PTR), value :: farg1
+type(C_FUNPTR), value :: farg2
+integer(C_INT) :: fresult
+end function
+
+function swigc_FARKodeSetPreRhsFn(farg1, farg2) &
+bind(C, name="_wrap_FARKodeSetPreRhsFn") &
 result(fresult)
 use, intrinsic :: ISO_C_BINDING
 type(C_PTR), value :: farg1
@@ -722,24 +740,6 @@ end function
 
 function swigc_FARKodeSetPostprocessStepFn(farg1, farg2) &
 bind(C, name="_wrap_FARKodeSetPostprocessStepFn") &
-result(fresult)
-use, intrinsic :: ISO_C_BINDING
-type(C_PTR), value :: farg1
-type(C_FUNPTR), value :: farg2
-integer(C_INT) :: fresult
-end function
-
-function swigc_FARKodeSetPostprocessStepFailFn(farg1, farg2) &
-bind(C, name="_wrap_FARKodeSetPostprocessStepFailFn") &
-result(fresult)
-use, intrinsic :: ISO_C_BINDING
-type(C_PTR), value :: farg1
-type(C_FUNPTR), value :: farg2
-integer(C_INT) :: fresult
-end function
-
-function swigc_FARKodeSetPreRHSProcessFn(farg1, farg2) &
-bind(C, name="_wrap_FARKodeSetPreRHSProcessFn") &
 result(fresult)
 use, intrinsic :: ISO_C_BINDING
 type(C_PTR), value :: farg1
@@ -2929,19 +2929,51 @@ fresult = swigc_FARKodeSetUserData(farg1, farg2)
 swig_result = fresult
 end function
 
-function FARKodeSetPreprocessStepFn(arkode_mem, processstep) &
+function FARKodeSetPreStepFn(arkode_mem, prestep_fn) &
 result(swig_result)
 use, intrinsic :: ISO_C_BINDING
 integer(C_INT) :: swig_result
 type(C_PTR) :: arkode_mem
-type(C_FUNPTR), intent(in), value :: processstep
+type(C_FUNPTR), intent(in), value :: prestep_fn
 integer(C_INT) :: fresult 
 type(C_PTR) :: farg1 
 type(C_FUNPTR) :: farg2 
 
 farg1 = arkode_mem
-farg2 = processstep
-fresult = swigc_FARKodeSetPreprocessStepFn(farg1, farg2)
+farg2 = prestep_fn
+fresult = swigc_FARKodeSetPreStepFn(farg1, farg2)
+swig_result = fresult
+end function
+
+function FARKodeSetPostStepFn(arkode_mem, poststep_fn) &
+result(swig_result)
+use, intrinsic :: ISO_C_BINDING
+integer(C_INT) :: swig_result
+type(C_PTR) :: arkode_mem
+type(C_FUNPTR), intent(in), value :: poststep_fn
+integer(C_INT) :: fresult 
+type(C_PTR) :: farg1 
+type(C_FUNPTR) :: farg2 
+
+farg1 = arkode_mem
+farg2 = poststep_fn
+fresult = swigc_FARKodeSetPostStepFn(farg1, farg2)
+swig_result = fresult
+end function
+
+function FARKodeSetPreRhsFn(arkode_mem, prerhs_fn) &
+result(swig_result)
+use, intrinsic :: ISO_C_BINDING
+integer(C_INT) :: swig_result
+type(C_PTR) :: arkode_mem
+type(C_FUNPTR), intent(in), value :: prerhs_fn
+integer(C_INT) :: fresult 
+type(C_PTR) :: farg1 
+type(C_FUNPTR) :: farg2 
+
+farg1 = arkode_mem
+farg2 = prerhs_fn
+fresult = swigc_FARKodeSetPreRhsFn(farg1, farg2)
 swig_result = fresult
 end function
 
@@ -2958,38 +2990,6 @@ type(C_FUNPTR) :: farg2
 farg1 = arkode_mem
 farg2 = processstep
 fresult = swigc_FARKodeSetPostprocessStepFn(farg1, farg2)
-swig_result = fresult
-end function
-
-function FARKodeSetPostprocessStepFailFn(arkode_mem, processstep) &
-result(swig_result)
-use, intrinsic :: ISO_C_BINDING
-integer(C_INT) :: swig_result
-type(C_PTR) :: arkode_mem
-type(C_FUNPTR), intent(in), value :: processstep
-integer(C_INT) :: fresult 
-type(C_PTR) :: farg1 
-type(C_FUNPTR) :: farg2 
-
-farg1 = arkode_mem
-farg2 = processstep
-fresult = swigc_FARKodeSetPostprocessStepFailFn(farg1, farg2)
-swig_result = fresult
-end function
-
-function FARKodeSetPreRHSProcessFn(arkode_mem, prerhsprocess) &
-result(swig_result)
-use, intrinsic :: ISO_C_BINDING
-integer(C_INT) :: swig_result
-type(C_PTR) :: arkode_mem
-type(C_FUNPTR), intent(in), value :: prerhsprocess
-integer(C_INT) :: fresult 
-type(C_PTR) :: farg1 
-type(C_FUNPTR) :: farg2 
-
-farg1 = arkode_mem
-farg2 = prerhsprocess
-fresult = swigc_FARKodeSetPreRHSProcessFn(farg1, farg2)
 swig_result = fresult
 end function
 

--- a/src/arkode/fmod_int64/farkode_mod.c
+++ b/src/arkode/fmod_int64/farkode_mod.c
@@ -650,15 +650,43 @@ SWIGEXPORT int _wrap_FARKodeSetUserData(void *farg1, void *farg2) {
 }
 
 
-SWIGEXPORT int _wrap_FARKodeSetPreprocessStepFn(void *farg1, ARKPostProcessFn farg2) {
+SWIGEXPORT int _wrap_FARKodeSetPreStepFn(void *farg1, ARKPreStepFn farg2) {
   int fresult ;
   void *arg1 = (void *) 0 ;
-  ARKPostProcessFn arg2 = (ARKPostProcessFn) 0 ;
+  ARKPreStepFn arg2 = (ARKPreStepFn) 0 ;
   int result;
   
   arg1 = (void *)(farg1);
-  arg2 = (ARKPostProcessFn)(farg2);
-  result = (int)ARKodeSetPreprocessStepFn(arg1,arg2);
+  arg2 = (ARKPreStepFn)(farg2);
+  result = (int)ARKodeSetPreStepFn(arg1,arg2);
+  fresult = (int)(result);
+  return fresult;
+}
+
+
+SWIGEXPORT int _wrap_FARKodeSetPostStepFn(void *farg1, ARKPostStepFn farg2) {
+  int fresult ;
+  void *arg1 = (void *) 0 ;
+  ARKPostStepFn arg2 = (ARKPostStepFn) 0 ;
+  int result;
+  
+  arg1 = (void *)(farg1);
+  arg2 = (ARKPostStepFn)(farg2);
+  result = (int)ARKodeSetPostStepFn(arg1,arg2);
+  fresult = (int)(result);
+  return fresult;
+}
+
+
+SWIGEXPORT int _wrap_FARKodeSetPreRhsFn(void *farg1, ARKPreRhsFn farg2) {
+  int fresult ;
+  void *arg1 = (void *) 0 ;
+  ARKPreRhsFn arg2 = (ARKPreRhsFn) 0 ;
+  int result;
+  
+  arg1 = (void *)(farg1);
+  arg2 = (ARKPreRhsFn)(farg2);
+  result = (int)ARKodeSetPreRhsFn(arg1,arg2);
   fresult = (int)(result);
   return fresult;
 }
@@ -673,34 +701,6 @@ SWIGEXPORT int _wrap_FARKodeSetPostprocessStepFn(void *farg1, ARKPostProcessFn f
   arg1 = (void *)(farg1);
   arg2 = (ARKPostProcessFn)(farg2);
   result = (int)ARKodeSetPostprocessStepFn(arg1,arg2);
-  fresult = (int)(result);
-  return fresult;
-}
-
-
-SWIGEXPORT int _wrap_FARKodeSetPostprocessStepFailFn(void *farg1, ARKPostProcessFn farg2) {
-  int fresult ;
-  void *arg1 = (void *) 0 ;
-  ARKPostProcessFn arg2 = (ARKPostProcessFn) 0 ;
-  int result;
-  
-  arg1 = (void *)(farg1);
-  arg2 = (ARKPostProcessFn)(farg2);
-  result = (int)ARKodeSetPostprocessStepFailFn(arg1,arg2);
-  fresult = (int)(result);
-  return fresult;
-}
-
-
-SWIGEXPORT int _wrap_FARKodeSetPreRHSProcessFn(void *farg1, ARKPostProcessFn farg2) {
-  int fresult ;
-  void *arg1 = (void *) 0 ;
-  ARKPostProcessFn arg2 = (ARKPostProcessFn) 0 ;
-  int result;
-  
-  arg1 = (void *)(farg1);
-  arg2 = (ARKPostProcessFn)(farg2);
-  result = (int)ARKodeSetPreRHSProcessFn(arg1,arg2);
   fresult = (int)(result);
   return fresult;
 }

--- a/src/arkode/fmod_int64/farkode_mod.f90
+++ b/src/arkode/fmod_int64/farkode_mod.f90
@@ -87,9 +87,9 @@ module farkode_mod
  integer(C_INT), parameter, public :: ARK_POSTPROCESS_FAIL = -37_C_INT
  integer(C_INT), parameter, public :: ARK_POSTPROCESS_STEP_FAIL = -37_C_INT
  integer(C_INT), parameter, public :: ARK_POSTPROCESS_STAGE_FAIL = -38_C_INT
- integer(C_INT), parameter, public :: ARK_POSTPROCESS_FAILED_STEP_FAIL = -39_C_INT
- integer(C_INT), parameter, public :: ARK_PREPROCESS_STEP_FAIL = -40_C_INT
- integer(C_INT), parameter, public :: ARK_PREPROCESS_RHS_FAIL = -41_C_INT
+ integer(C_INT), parameter, public :: ARK_PRESTEPFN_FAIL = -39_C_INT
+ integer(C_INT), parameter, public :: ARK_POSTSTEPFN_FAIL = -40_C_INT
+ integer(C_INT), parameter, public :: ARK_PRERHSFN_FAIL = -41_C_INT
  integer(C_INT), parameter, public :: ARK_USER_PREDICT_FAIL = -42_C_INT
  integer(C_INT), parameter, public :: ARK_INTERP_FAIL = -43_C_INT
  integer(C_INT), parameter, public :: ARK_INVALID_TABLE = -44_C_INT
@@ -148,10 +148,10 @@ module farkode_mod
  public :: FARKodeSetFixedStep
  public :: FARKodeSetStepDirection
  public :: FARKodeSetUserData
- public :: FARKodeSetPreprocessStepFn
+ public :: FARKodeSetPreStepFn
+ public :: FARKodeSetPostStepFn
+ public :: FARKodeSetPreRhsFn
  public :: FARKodeSetPostprocessStepFn
- public :: FARKodeSetPostprocessStepFailFn
- public :: FARKodeSetPreRHSProcessFn
  public :: FARKodeSetPostprocessStageFn
  public :: FARKodeSetNonlinearSolver
  public :: FARKodeSetLinear
@@ -711,8 +711,26 @@ type(C_PTR), value :: farg2
 integer(C_INT) :: fresult
 end function
 
-function swigc_FARKodeSetPreprocessStepFn(farg1, farg2) &
-bind(C, name="_wrap_FARKodeSetPreprocessStepFn") &
+function swigc_FARKodeSetPreStepFn(farg1, farg2) &
+bind(C, name="_wrap_FARKodeSetPreStepFn") &
+result(fresult)
+use, intrinsic :: ISO_C_BINDING
+type(C_PTR), value :: farg1
+type(C_FUNPTR), value :: farg2
+integer(C_INT) :: fresult
+end function
+
+function swigc_FARKodeSetPostStepFn(farg1, farg2) &
+bind(C, name="_wrap_FARKodeSetPostStepFn") &
+result(fresult)
+use, intrinsic :: ISO_C_BINDING
+type(C_PTR), value :: farg1
+type(C_FUNPTR), value :: farg2
+integer(C_INT) :: fresult
+end function
+
+function swigc_FARKodeSetPreRhsFn(farg1, farg2) &
+bind(C, name="_wrap_FARKodeSetPreRhsFn") &
 result(fresult)
 use, intrinsic :: ISO_C_BINDING
 type(C_PTR), value :: farg1
@@ -722,24 +740,6 @@ end function
 
 function swigc_FARKodeSetPostprocessStepFn(farg1, farg2) &
 bind(C, name="_wrap_FARKodeSetPostprocessStepFn") &
-result(fresult)
-use, intrinsic :: ISO_C_BINDING
-type(C_PTR), value :: farg1
-type(C_FUNPTR), value :: farg2
-integer(C_INT) :: fresult
-end function
-
-function swigc_FARKodeSetPostprocessStepFailFn(farg1, farg2) &
-bind(C, name="_wrap_FARKodeSetPostprocessStepFailFn") &
-result(fresult)
-use, intrinsic :: ISO_C_BINDING
-type(C_PTR), value :: farg1
-type(C_FUNPTR), value :: farg2
-integer(C_INT) :: fresult
-end function
-
-function swigc_FARKodeSetPreRHSProcessFn(farg1, farg2) &
-bind(C, name="_wrap_FARKodeSetPreRHSProcessFn") &
 result(fresult)
 use, intrinsic :: ISO_C_BINDING
 type(C_PTR), value :: farg1
@@ -2929,19 +2929,51 @@ fresult = swigc_FARKodeSetUserData(farg1, farg2)
 swig_result = fresult
 end function
 
-function FARKodeSetPreprocessStepFn(arkode_mem, processstep) &
+function FARKodeSetPreStepFn(arkode_mem, prestep_fn) &
 result(swig_result)
 use, intrinsic :: ISO_C_BINDING
 integer(C_INT) :: swig_result
 type(C_PTR) :: arkode_mem
-type(C_FUNPTR), intent(in), value :: processstep
+type(C_FUNPTR), intent(in), value :: prestep_fn
 integer(C_INT) :: fresult 
 type(C_PTR) :: farg1 
 type(C_FUNPTR) :: farg2 
 
 farg1 = arkode_mem
-farg2 = processstep
-fresult = swigc_FARKodeSetPreprocessStepFn(farg1, farg2)
+farg2 = prestep_fn
+fresult = swigc_FARKodeSetPreStepFn(farg1, farg2)
+swig_result = fresult
+end function
+
+function FARKodeSetPostStepFn(arkode_mem, poststep_fn) &
+result(swig_result)
+use, intrinsic :: ISO_C_BINDING
+integer(C_INT) :: swig_result
+type(C_PTR) :: arkode_mem
+type(C_FUNPTR), intent(in), value :: poststep_fn
+integer(C_INT) :: fresult 
+type(C_PTR) :: farg1 
+type(C_FUNPTR) :: farg2 
+
+farg1 = arkode_mem
+farg2 = poststep_fn
+fresult = swigc_FARKodeSetPostStepFn(farg1, farg2)
+swig_result = fresult
+end function
+
+function FARKodeSetPreRhsFn(arkode_mem, prerhs_fn) &
+result(swig_result)
+use, intrinsic :: ISO_C_BINDING
+integer(C_INT) :: swig_result
+type(C_PTR) :: arkode_mem
+type(C_FUNPTR), intent(in), value :: prerhs_fn
+integer(C_INT) :: fresult 
+type(C_PTR) :: farg1 
+type(C_FUNPTR) :: farg2 
+
+farg1 = arkode_mem
+farg2 = prerhs_fn
+fresult = swigc_FARKodeSetPreRhsFn(farg1, farg2)
 swig_result = fresult
 end function
 
@@ -2958,38 +2990,6 @@ type(C_FUNPTR) :: farg2
 farg1 = arkode_mem
 farg2 = processstep
 fresult = swigc_FARKodeSetPostprocessStepFn(farg1, farg2)
-swig_result = fresult
-end function
-
-function FARKodeSetPostprocessStepFailFn(arkode_mem, processstep) &
-result(swig_result)
-use, intrinsic :: ISO_C_BINDING
-integer(C_INT) :: swig_result
-type(C_PTR) :: arkode_mem
-type(C_FUNPTR), intent(in), value :: processstep
-integer(C_INT) :: fresult 
-type(C_PTR) :: farg1 
-type(C_FUNPTR) :: farg2 
-
-farg1 = arkode_mem
-farg2 = processstep
-fresult = swigc_FARKodeSetPostprocessStepFailFn(farg1, farg2)
-swig_result = fresult
-end function
-
-function FARKodeSetPreRHSProcessFn(arkode_mem, prerhsprocess) &
-result(swig_result)
-use, intrinsic :: ISO_C_BINDING
-integer(C_INT) :: swig_result
-type(C_PTR) :: arkode_mem
-type(C_FUNPTR), intent(in), value :: prerhsprocess
-integer(C_INT) :: fresult 
-type(C_PTR) :: farg1 
-type(C_FUNPTR) :: farg2 
-
-farg1 = arkode_mem
-farg2 = prerhsprocess
-fresult = swigc_FARKodeSetPreRHSProcessFn(farg1, farg2)
 swig_result = fresult
 end function
 


### PR DESCRIPTION
Suggested updates to #813

* Replace `PreProcessStep` with `PreStepFn` -- removes "process" from the name, adds the current step and attempt index as inputs, and always call before a step attempt
* Remove `PostProcessStepFail` -- users can handle this case by checking the attempt index in `PreProcessStep`
* Replace `PostProcessStep` call in `arkCompleteStep` with a `PostStepFn`
* Replace `PostProcessStage` calls on the new state in `TakeStep` functions with `PostProcessStep` calls and account cases where the last stage is the new state
* Replace `PreRHSProcess` with `PreRhsFn` to remove the idea of processing from the name

This does not address this additional copy before the time step loop or on a failed step