### PR TITLE
CI: Set Python test requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,17 +77,20 @@ jobs:
             HEAD=${{ github.sha }}
           fi
 
+          CHANGED="$(git diff --name-only "$BASE" "$HEAD")"
+
           # Check for changes to trigger documentation build checks
           # Updates in doc, bindings/sundials4py, or tools directories
-          if git diff --name-only "$BASE" "$HEAD" | grep -qE '^(doc/|bindings/sundials4py/|tools/)'; then
+          if echo "$CHANGED" | grep -qE '^(doc/|bindings/sundials4py/|tools/)'; then
             echo "docs=true" >> "$GITHUB_OUTPUT"
           else
             echo "docs=false" >> "$GITHUB_OUTPUT"
           fi
 
-          # Check for changes to trigger build and test jobs
-          # Updates to CMakeLists.txt or include, src, cmake, examples, benchmarks, or test directories
-          if git diff --name-only "$BASE" "$HEAD" | grep -qE '^(CMakeLists\.txt$|include/|src/|cmake/|examples/|benchmarks/|test/)'; then
+          # Check for changes to trigger build and test jobs Updates to
+          # CMakeLists.txt or include, src, cmake, examples (except python),
+          # benchmarks, or test directories
+          if echo "$CHANGED" | grep -v '^examples/python/' | grep -qE '^(CMakeLists\.txt$|include/|src/|cmake/|examples/|benchmarks/|test/)'; then
             echo "src=true" >> "$GITHUB_OUTPUT"
           else
             echo "src=false" >> "$GITHUB_OUTPUT"
@@ -95,7 +98,7 @@ jobs:
 
           # Check for changes to trigger python interface checks
           # Updates in include or bindings/sundials4py directories
-          if git diff --name-only "$BASE" "$HEAD" | grep -qE '^(include/|bindings/sundials4py/|examples/python/)'; then
+          if echo "$CHANGED" | grep -qE '^(include/|bindings/sundials4py/|examples/python/)'; then
             echo "python=true" >> "$GITHUB_OUTPUT"
           else
             echo "python=true" >> "$GITHUB_OUTPUT"
@@ -103,7 +106,7 @@ jobs:
 
           # Check for changes to trigger Fortran interface checks
           # Updates in include or swig directories
-          if git diff --name-only "$BASE" "$HEAD" | grep -qE '^(include/|swig/)'; then
+          if echo "$CHANGED" | grep -qE '^(include/|swig/)'; then
             echo "fortran=true" >> "$GITHUB_OUTPUT"
           else
             echo "fortran=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
 
           # Check for changes to trigger python interface checks
           # Updates in include or bindings/sundials4py directories
-          if git diff --name-only "$BASE" "$HEAD" | grep -qE '^(include/|bindings/sundials4py/)'; then
+          if git diff --name-only "$BASE" "$HEAD" | grep -qE '^(include/|bindings/sundials4py/|examples/python/)'; then
             echo "python=true" >> "$GITHUB_OUTPUT"
           else
             echo "python=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
           if echo "$CHANGED" | grep -qE '^(include/|bindings/sundials4py/|examples/python/)'; then
             echo "python=true" >> "$GITHUB_OUTPUT"
           else
-            echo "python=true" >> "$GITHUB_OUTPUT"
+            echo "python=false" >> "$GITHUB_OUTPUT"
           fi
 
           # Check for changes to trigger Fortran interface checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
           if git diff --name-only "$BASE" "$HEAD" | grep -qE '^(include/|bindings/sundials4py/)'; then
             echo "python=true" >> "$GITHUB_OUTPUT"
           else
-            echo "python=false" >> "$GITHUB_OUTPUT"
+            echo "python=true" >> "$GITHUB_OUTPUT"
           fi
 
           # Check for changes to trigger Fortran interface checks

--- a/.github/workflows/sundials4py-build-and-test.yml
+++ b/.github/workflows/sundials4py-build-and-test.yml
@@ -86,11 +86,21 @@ jobs:
       with:
         submodules: true
 
+    # Double precision - run all tests
     - uses: pypa/cibuildwheel@v3.3
+      if: matrix.precision == 'double'
       env:
         CMAKE_ARGS: "-DSUNDIALS_PRECISION=${{ matrix.precision }} -DSUNDIALS_INDEX_SIZE=${{ matrix.index }}"
         CIBW_TEST_REQUIRES: "pytest matplotlib"
         CIBW_TEST_COMMAND: "pytest {project}/bindings/sundials4py/test {project}/examples/python"
+
+    # Single precision - skip examples
+    - uses: pypa/cibuildwheel@v3.3
+      if: matrix.precision == 'single'
+      env:
+        CMAKE_ARGS: "-DSUNDIALS_PRECISION=${{ matrix.precision }} -DSUNDIALS_INDEX_SIZE=${{ matrix.index }}"
+        CIBW_TEST_REQUIRES: "pytest"
+        CIBW_TEST_COMMAND: "pytest {project}/bindings/sundials4py/test"
 
     - name: Rename wheels to include config
       run: |

--- a/.github/workflows/sundials4py-build-and-test.yml
+++ b/.github/workflows/sundials4py-build-and-test.yml
@@ -53,6 +53,7 @@ jobs:
 
     - uses: pypa/cibuildwheel@v3.3
       env:
+        CIBW_TEST_REQUIRES: "pytest matplotlib"
         CIBW_TEST_COMMAND: "pytest {project}/bindings/sundials4py/test {project}/examples/python"
 
     - name: Upload wheels
@@ -84,6 +85,7 @@ jobs:
     - uses: pypa/cibuildwheel@v3.3
       env:
         CMAKE_ARGS: "-DSUNDIALS_PRECISION=${{ matrix.precision }} -DSUNDIALS_INDEX_SIZE=${{ matrix.index }}"
+        CIBW_TEST_REQUIRES: "pytest matplotlib"
         CIBW_TEST_COMMAND: "pytest {project}/bindings/sundials4py/test {project}/examples/python"
 
     - name: Rename wheels to include config

--- a/.github/workflows/sundials4py-build-and-test.yml
+++ b/.github/workflows/sundials4py-build-and-test.yml
@@ -53,8 +53,12 @@ jobs:
 
     - uses: pypa/cibuildwheel@v3.3
       env:
+        # Default (Linux/macOS): install matplotlib and run both test suites
         CIBW_TEST_REQUIRES: "pytest matplotlib"
         CIBW_TEST_COMMAND: "pytest {project}/bindings/sundials4py/test {project}/examples/python"
+        # Windows: DON'T install matplotlib, and skip the examples
+        CIBW_TEST_REQUIRES_WINDOWS: "pytest"
+        CIBW_TEST_COMMAND_WINDOWS: "pytest {project}/bindings/sundials4py/test"
 
     - name: Upload wheels
       uses: actions/upload-artifact@v7


### PR DESCRIPTION
Add `CIBW_TEST_REQUIRES` to install Python dependencies before running the tests
Only run unit tests on Windows or when using single precision