### PR TITLE
Feature: Add support for Kokkos 5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### New Features and Enhancements
 
+Updated the Kokkos N_Vector to support Kokkos 5.x versions.
+
 ### Bug Fixes
 
 Fixed a CMake bug where the SuperLU_MT interface would not be built and

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -5,6 +5,8 @@
 
 **New Features and Enhancements**
 
+Updated the Kokkos N_Vector to support Kokkos 5.x versions.
+
 **Bug Fixes**
 
 Fixed a CMake bug where the SuperLU_MT interface would not be built and

--- a/include/nvector/nvector_kokkos.hpp
+++ b/include/nvector/nvector_kokkos.hpp
@@ -476,22 +476,22 @@ template<class ExecutionSpace = Kokkos::DefaultExecutionSpace,
          class MemorySpace    = typename ExecutionSpace::memory_space,
          // Kokkos::MemoryManaged was deprecated in v4.7 and a default added
          // TODO(DJG): Remove 0 when v4.7+ is required
-         class MemoryTraits   = Kokkos::MemoryTraits<0>>
+         class MemoryTraits = Kokkos::MemoryTraits<0>>
 class Vector : public sundials::impl::BaseNVector,
                public sundials::ConvertibleTo<N_Vector>
 {
 public:
-  using view_type      = Kokkos::View<sunrealtype*, MemorySpace, MemoryTraits>;
+  using view_type = Kokkos::View<sunrealtype*, MemorySpace, MemoryTraits>;
 #if KOKKOS_VERSION / 10000 > 4
   using host_view_type = typename view_type::host_mirror_type;
 #else
   using host_view_type = typename view_type::HostMirror;
 #endif
-  using memory_space   = MemorySpace;
-  using memory_traits  = MemoryTraits;
-  using exec_space     = typename MemorySpace::execution_space;
-  using range_policy   = Kokkos::RangePolicy<exec_space>;
-  using size_type      = typename view_type::size_type;
+  using memory_space  = MemorySpace;
+  using memory_traits = MemoryTraits;
+  using exec_space    = typename MemorySpace::execution_space;
+  using range_policy  = Kokkos::RangePolicy<exec_space>;
+  using size_type     = typename view_type::size_type;
 
   // Default constructor
   Vector() = default;

--- a/include/nvector/nvector_kokkos.hpp
+++ b/include/nvector/nvector_kokkos.hpp
@@ -475,7 +475,7 @@ sunrealtype N_VWrmsNormMask_Kokkos(N_Vector x, N_Vector w, N_Vector id)
 template<class ExecutionSpace = Kokkos::DefaultExecutionSpace,
          class MemorySpace    = typename ExecutionSpace::memory_space,
          // Kokkos::MemoryManaged was deprecated in v4.7 and a default added
-         // Remove 0 when v4.7+ is required
+         // TODO(DJG): Remove 0 when v4.7+ is required
          class MemoryTraits   = Kokkos::MemoryTraits<0>>
 class Vector : public sundials::impl::BaseNVector,
                public sundials::ConvertibleTo<N_Vector>
@@ -584,7 +584,7 @@ public:
 
   // Static routines to create clones of the vector that are always managed
   // Kokkos::MemoryManaged was deprecated in v4.7 and a default was added
-  // Remove 0 when v4.7+ is required
+  // TODO(DJG): Remove 0 when v4.7+ is required
 
   static Vector<exec_space, memory_space, Kokkos::MemoryTraits<0>>* Clone(
     const Vector<exec_space, memory_space, Kokkos::MemoryTraits<0>>& that_vector,

--- a/include/nvector/nvector_kokkos.hpp
+++ b/include/nvector/nvector_kokkos.hpp
@@ -474,13 +474,19 @@ sunrealtype N_VWrmsNormMask_Kokkos(N_Vector x, N_Vector w, N_Vector id)
 
 template<class ExecutionSpace = Kokkos::DefaultExecutionSpace,
          class MemorySpace    = typename ExecutionSpace::memory_space,
-         class MemoryTraits   = Kokkos::MemoryManaged>
+         // Kokkos::MemoryManaged was deprecated in v4.7 and a default added
+         // Remove 0 when v4.7+ is required
+         class MemoryTraits   = Kokkos::MemoryTraits<0>>
 class Vector : public sundials::impl::BaseNVector,
                public sundials::ConvertibleTo<N_Vector>
 {
 public:
   using view_type      = Kokkos::View<sunrealtype*, MemorySpace, MemoryTraits>;
+#if KOKKOS_VERSION / 10000 > 4
+  using host_view_type = typename view_type::host_mirror_type;
+#else
   using host_view_type = typename view_type::HostMirror;
+#endif
   using memory_space   = MemorySpace;
   using memory_traits  = MemoryTraits;
   using exec_space     = typename MemorySpace::execution_space;
@@ -577,21 +583,23 @@ public:
   N_Vector get() const noexcept override { return object_.get(); }
 
   // Static routines to create clones of the vector that are always managed
+  // Kokkos::MemoryManaged was deprecated in v4.7 and a default was added
+  // Remove 0 when v4.7+ is required
 
-  static Vector<exec_space, memory_space, Kokkos::MemoryManaged>* Clone(
-    const Vector<exec_space, memory_space, Kokkos::MemoryManaged>& that_vector,
+  static Vector<exec_space, memory_space, Kokkos::MemoryTraits<0>>* Clone(
+    const Vector<exec_space, memory_space, Kokkos::MemoryTraits<0>>& that_vector,
     SUNContext sunctx)
   {
     return new Vector<exec_space, memory_space,
-                      Kokkos::MemoryManaged>(that_vector.Length(), sunctx);
+                      Kokkos::MemoryTraits<0>>(that_vector.Length(), sunctx);
   }
 
-  static Vector<exec_space, memory_space, Kokkos::MemoryManaged>* Clone(
+  static Vector<exec_space, memory_space, Kokkos::MemoryTraits<0>>* Clone(
     const Vector<exec_space, memory_space, Kokkos::MemoryUnmanaged>& that_vector,
     SUNContext sunctx)
   {
     return new Vector<exec_space, memory_space,
-                      Kokkos::MemoryManaged>(that_vector.Length(), sunctx);
+                      Kokkos::MemoryTraits<0>>(that_vector.Length(), sunctx);
   }
 
 private:


### PR DESCRIPTION
Kokkos 5.0 removed `Kokkos::MemoryManaged` and `view_type::HostMirror`
Use `Kokkos::MemoryTraits<0>` until v4.7+ is required
Use `view_type::host_mirror_type` when using v5+