### PR TITLE
CI: Remove GTEST check to set C++ standard

### DIFF
--- a/.github/workflows/ubuntu-latest-clang.yml
+++ b/.github/workflows/ubuntu-latest-clang.yml
@@ -41,6 +41,7 @@ jobs:
         -D CMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
         -D CMAKE_C_COMPILER="$(which clang)" \
         -D CMAKE_CXX_COMPILER="$(which clang++)" \
+        -D CMAKE_CXX_STANDARD=17 \
         -D SUNDIALS_LOGGING_LEVEL=${{matrix.logging_level}} \
         -D ENABLE_ALL_WARNINGS=ON \
         -D ENABLE_WARNINGS_AS_ERRORS=ON \

--- a/cmake/SundialsSetupCXX.cmake
+++ b/cmake/SundialsSetupCXX.cmake
@@ -33,8 +33,7 @@ sundials_option(CMAKE_CXX_STANDARD_REQUIRED BOOL "Require C++ standard version"
 
 if(SUNDIALS_ENABLE_PYTHON
    OR SUNDIALS_ENABLE_SYCL
-   OR SUNDIALS_ENABLE_GINKGO
-   OR SUNDIALS_TEST_ENABLE_GTEST)
+   OR SUNDIALS_ENABLE_GINKGO)
   set(DOCSTR "The C++ standard to use if C++ is enabled (17, 20, 23)")
   sundials_option(CMAKE_CXX_STANDARD STRING "${DOCSTR}" "17" OPTIONS "17;20;23")
 else()


### PR DESCRIPTION
Fixes CI tests on Tigoa with CCE compilers and explicitly requesting C++14.