### PR TITLE
Maintenance: Remove unused <ranges> include

### DIFF
--- a/bindings/sundials4py/sundials/sundials_context_usersupplied.hpp
+++ b/bindings/sundials4py/sundials/sundials_context_usersupplied.hpp
@@ -20,7 +20,6 @@
 
 #include <cstdlib>
 #include <cstring>
-#include <ranges>
 #include <vector>
 
 #include <sundials/sundials_context.h>


### PR DESCRIPTION
We couldn't build the Python interface with a C++17 compiler because of this unnecessary include.