### PR TITLE
docs: cap Sphinx <9 for RTD

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
 numpydoc
-sphinx >=6.0.0
+sphinx >=6.0.0,<9
 sphinx_rtd_theme
 sphinx-copybutton
 sphinx-fortran

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,5 @@
 numpydoc
+# TODO(CJB): Update range when sphinx-toolbox supports Sphinx 9
 sphinx >=6.0.0,<9
 sphinx_rtd_theme
 sphinx-copybutton


### PR DESCRIPTION
Read the Docs is currently installing Sphinx 9.1.0 (because doc/requirements.txt only requires Sphinx >=6), which breaks sphinx-toolbox during extension import with:

ImportError: cannot import name 'logger' from 'sphinx.ext.autodoc'

Cap Sphinx to <9 to keep RTD builds working until sphinx-toolbox supports Sphinx 9.
