### PR TITLE
Maintenance: Remove unreachable code (duplicated `return` statements)

### DIFF
--- a/src/nvector/raja/nvector_raja.cpp
+++ b/src/nvector/raja/nvector_raja.cpp
@@ -1858,7 +1858,6 @@ static int FusedBuffer_CopyPtrArray1D(N_Vector v, N_Vector* X, int nvec,
     SUNDIALS_DEBUG_PRINT("ERROR in FusedBuffer_CopyPtrArray1D: Buffer offset "
                          "is exceedes the buffer size\n");
     return SUN_ERR_GENERIC;
-    return SUN_ERR_GENERIC;
   }
 
   sunrealtype** h_buffer = (sunrealtype**)((char*)(vcp->fused_buffer_host->ptr) +

--- a/src/nvector/sycl/nvector_sycl.cpp
+++ b/src/nvector/sycl/nvector_sycl.cpp
@@ -2307,7 +2307,6 @@ static int FusedBuffer_CopyPtrArray1D(N_Vector v, N_Vector* X, int nvec,
     SUNDIALS_DEBUG_PRINT("ERROR in FusedBuffer_CopyPtrArray1D: Buffer offset "
                          "is exceedes the buffer size\n");
     return SUN_ERR_GENERIC;
-    return SUN_ERR_GENERIC;
   }
 
   sunrealtype** h_buffer = reinterpret_cast<sunrealtype**>(


### PR DESCRIPTION
This change removes unreachable `return` statements. There are no other occurrences of such problem.

For such small change I decided not to update the change logs. If such update would be beneficial, please inform me.
