### PR TITLE
Bugfix: Uninitialzed-istage-fix

### DIFF
--- a/src/arkode/arkode_splittingstep.c
+++ b/src/arkode/arkode_splittingstep.c
@@ -675,6 +675,7 @@ void* SplittingStepCreate(SUNStepper* steppers, int partitions, sunrealtype t0,
   step_mem->steppers          = NULL;
   step_mem->n_stepper_evolves = NULL;
   step_mem->coefficients      = NULL;
+  step_mem->istage            = 0;
   retval = splittingStep_InitStepMem(ark_mem, step_mem, steppers, partitions);
   if (retval != ARK_SUCCESS)
   {


### PR DESCRIPTION
The recent group of PRs added a diagnostic variable to SplittingStep, that was not initialized during construction.  This PR fixes that.

