### PR TITLE
Fix issues identified by cppcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bug Fixes
 
+Fixed memory leaks in CVODES, IDAS, and KINSOL in the unlikely event of a failed
+`malloc`.
+
 ### Deprecation Notices
 
 ## Changes to SUNDIALS in release 7.7.0

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -7,4 +7,7 @@
 
 **Bug Fixes**
 
+Fixed memory leaks in CVODES, IDAS, and KINSOL in the unlikely event of a failed
+``malloc``.
+
 **Deprecation Notices**

--- a/src/arkode/arkode_interp.c
+++ b/src/arkode/arkode_interp.c
@@ -256,7 +256,6 @@ void arkInterpFree_Hermite(ARKodeMem ark_mem, ARKInterp interp)
     interp->ops = NULL;
   }
   free(interp);
-  interp = NULL;
 
   return;
 }
@@ -942,7 +941,6 @@ void arkInterpFree_Lagrange(ARKodeMem ark_mem, ARKInterp I)
     I->ops = NULL;
   }
   free(I);
-  I = NULL;
 
   return;
 }

--- a/src/arkode/arkode_sprkstep.c
+++ b/src/arkode/arkode_sprkstep.c
@@ -89,9 +89,14 @@ void* SPRKStepCreate(ARKRhsFn f1, ARKRhsFn f2, sunrealtype t0, N_Vector y0,
   {
     arkProcessError(ark_mem, ARK_MEM_FAIL, __LINE__, __func__, __FILE__,
                     MSG_ARK_ARKMEM_FAIL);
+    ARKodeFree((void**)&ark_mem);
     return (NULL);
   }
   memset(step_mem, 0, sizeof(struct ARKodeSPRKStepMemRec));
+
+  /* Attach stepper memory early so generic cleanup can handle partial setup. */
+  ark_mem->step_free = sprkStep_Free;
+  ark_mem->step_mem  = (void*)step_mem;
 
   /* Allocate vectors in stepper mem */
   if (!arkAllocVec(ark_mem, y0, &(step_mem->sdata)))
@@ -119,12 +124,10 @@ void* SPRKStepCreate(ARKRhsFn f1, ARKRhsFn f2, sunrealtype t0, N_Vector y0,
   ark_mem->step_setusecompensatedsums = sprkStep_SetUseCompensatedSums;
   ark_mem->step_setoptions            = sprkStep_SetOptions;
   ark_mem->step_resize                = sprkStep_Resize;
-  ark_mem->step_free                  = sprkStep_Free;
   ark_mem->step_setdefaults           = sprkStep_SetDefaults;
   ark_mem->step_setorder              = sprkStep_SetOrder;
   ark_mem->step_getnumrhsevals        = sprkStep_GetNumRhsEvals;
   ark_mem->step_getstageindex         = sprkStep_GetStageIndex;
-  ark_mem->step_mem                   = (void*)step_mem;
 
   /* Set default values for optional inputs */
   retval = sprkStep_SetDefaults((void*)ark_mem);

--- a/src/cvodes/cvodea.c
+++ b/src/cvodes/cvodea.c
@@ -692,22 +692,23 @@ int CVodeCreateB(void* cvode_mem, int lmmB, int* which)
   }
   ca_mem = cv_mem->cv_adj_mem;
 
-  /* Create and set a new CVODES object for the backward problem */
-
-  cvodeB_mem = CVodeCreate(lmmB, cv_mem->cv_sunctx);
-  if (cvodeB_mem == NULL)
-  {
-    cvProcessError(cv_mem, CV_MEM_FAIL, __LINE__, __func__, __FILE__,
-                   MSGCV_MEM_FAIL);
-    return (CV_MEM_FAIL);
-  }
-
   /* Allocate space for new CVodeBMem object */
 
   new_cvB_mem = NULL;
   new_cvB_mem = (CVodeBMem)malloc(sizeof(struct CVodeBMemRec));
   if (new_cvB_mem == NULL)
   {
+    cvProcessError(cv_mem, CV_MEM_FAIL, __LINE__, __func__, __FILE__,
+                   MSGCV_MEM_FAIL);
+    return (CV_MEM_FAIL);
+  }
+
+  /* Create and set a new CVODES object for the backward problem */
+
+  cvodeB_mem = CVodeCreate(lmmB, cv_mem->cv_sunctx);
+  if (cvodeB_mem == NULL)
+  {
+    free(new_cvB_mem);
     cvProcessError(cv_mem, CV_MEM_FAIL, __LINE__, __func__, __FILE__,
                    MSGCV_MEM_FAIL);
     return (CV_MEM_FAIL);

--- a/src/cvodes/cvodea.c
+++ b/src/cvodes/cvodea.c
@@ -692,21 +692,21 @@ int CVodeCreateB(void* cvode_mem, int lmmB, int* which)
   }
   ca_mem = cv_mem->cv_adj_mem;
 
-  /* Allocate space for new CVodeBMem object */
+  /* Create and set a new CVODES object for the backward problem */
 
-  new_cvB_mem = NULL;
-  new_cvB_mem = (CVodeBMem)malloc(sizeof(struct CVodeBMemRec));
-  if (new_cvB_mem == NULL)
+  cvodeB_mem = CVodeCreate(lmmB, cv_mem->cv_sunctx);
+  if (cvodeB_mem == NULL)
   {
     cvProcessError(cv_mem, CV_MEM_FAIL, __LINE__, __func__, __FILE__,
                    MSGCV_MEM_FAIL);
     return (CV_MEM_FAIL);
   }
 
-  /* Create and set a new CVODES object for the backward problem */
+  /* Allocate space for new CVodeBMem object */
 
-  cvodeB_mem = CVodeCreate(lmmB, cv_mem->cv_sunctx);
-  if (cvodeB_mem == NULL)
+  new_cvB_mem = NULL;
+  new_cvB_mem = (CVodeBMem)malloc(sizeof(struct CVodeBMemRec));
+  if (new_cvB_mem == NULL)
   {
     cvProcessError(cv_mem, CV_MEM_FAIL, __LINE__, __func__, __FILE__,
                    MSGCV_MEM_FAIL);

--- a/src/idas/idaa.c
+++ b/src/idas/idaa.c
@@ -682,18 +682,18 @@ int IDACreateB(void* ida_mem, int* which)
   }
   IDAADJ_mem = IDA_mem->ida_adj_mem;
 
-  /* Allocate a new IDABMem struct. */
-  new_IDAB_mem = (IDABMem)malloc(sizeof(struct IDABMemRec));
-  if (new_IDAB_mem == NULL)
+  /* Allocate the IDAMem struct needed by this backward problem. */
+  ida_memB = IDACreate(IDA_mem->ida_sunctx);
+  if (ida_memB == NULL)
   {
     IDAProcessError(IDA_mem, IDA_MEM_FAIL, __LINE__, __func__, __FILE__,
                     MSG_MEM_FAIL);
     return (IDA_MEM_FAIL);
   }
 
-  /* Allocate the IDAMem struct needed by this backward problem. */
-  ida_memB = IDACreate(IDA_mem->ida_sunctx);
-  if (ida_memB == NULL)
+  /* Allocate a new IDABMem struct. */
+  new_IDAB_mem = (IDABMem)malloc(sizeof(struct IDABMemRec));
+  if (new_IDAB_mem == NULL)
   {
     IDAProcessError(IDA_mem, IDA_MEM_FAIL, __LINE__, __func__, __FILE__,
                     MSG_MEM_FAIL);

--- a/src/idas/idaa.c
+++ b/src/idas/idaa.c
@@ -682,19 +682,20 @@ int IDACreateB(void* ida_mem, int* which)
   }
   IDAADJ_mem = IDA_mem->ida_adj_mem;
 
-  /* Allocate the IDAMem struct needed by this backward problem. */
-  ida_memB = IDACreate(IDA_mem->ida_sunctx);
-  if (ida_memB == NULL)
+  /* Allocate a new IDABMem struct. */
+  new_IDAB_mem = (IDABMem)malloc(sizeof(struct IDABMemRec));
+  if (new_IDAB_mem == NULL)
   {
     IDAProcessError(IDA_mem, IDA_MEM_FAIL, __LINE__, __func__, __FILE__,
                     MSG_MEM_FAIL);
     return (IDA_MEM_FAIL);
   }
 
-  /* Allocate a new IDABMem struct. */
-  new_IDAB_mem = (IDABMem)malloc(sizeof(struct IDABMemRec));
-  if (new_IDAB_mem == NULL)
+  /* Allocate the IDAMem struct needed by this backward problem. */
+  ida_memB = IDACreate(IDA_mem->ida_sunctx);
+  if (ida_memB == NULL)
   {
+    free(new_IDAB_mem);
     IDAProcessError(IDA_mem, IDA_MEM_FAIL, __LINE__, __func__, __FILE__,
                     MSG_MEM_FAIL);
     return (IDA_MEM_FAIL);

--- a/src/kinsol/kinsol.c
+++ b/src/kinsol/kinsol.c
@@ -391,9 +391,9 @@ int KINInit(void* kinmem, KINSysFn func, N_Vector tmpl)
   {
     KINProcessError(kin_mem, KIN_MEM_FAIL, __LINE__, __func__, __FILE__,
                     MSG_MEM_FAIL);
+    SUNDIALS_MARK_FUNCTION_END(KIN_PROFILER);
     free(kin_mem);
     kin_mem = NULL;
-    SUNDIALS_MARK_FUNCTION_END(KIN_PROFILER);
     return (KIN_MEM_FAIL);
   }
 

--- a/src/nvector/openmpdev/nvector_openmpdev.c
+++ b/src/nvector/openmpdev/nvector_openmpdev.c
@@ -207,7 +207,7 @@ N_Vector N_VNew_OpenMPDEV(sunindextype length)
       N_VDestroy(v);
       return (NULL);
     }
-    NV_DATA_DEV_OMPDEV(v)  = dev_data;
+    NV_DATA_DEV_OMPDEV(v) = dev_data;
   }
 
   return (v);
@@ -439,7 +439,7 @@ N_Vector N_VClone_OpenMPDEV(N_Vector w)
     }
 
     /* Attach data */
-    NV_DATA_DEV_OMPDEV(v)  = dev_data;
+    NV_DATA_DEV_OMPDEV(v) = dev_data;
   }
 
   return (v);

--- a/src/nvector/openmpdev/nvector_openmpdev.c
+++ b/src/nvector/openmpdev/nvector_openmpdev.c
@@ -197,6 +197,7 @@ N_Vector N_VNew_OpenMPDEV(sunindextype length)
       N_VDestroy(v);
       return (NULL);
     }
+    NV_DATA_HOST_OMPDEV(v) = data;
 
     /* Allocate memory on device */
     dev      = omp_get_default_device();
@@ -206,9 +207,6 @@ N_Vector N_VNew_OpenMPDEV(sunindextype length)
       N_VDestroy(v);
       return (NULL);
     }
-
-    /* Attach data */
-    NV_DATA_HOST_OMPDEV(v) = data;
     NV_DATA_DEV_OMPDEV(v)  = dev_data;
   }
 
@@ -429,6 +427,8 @@ N_Vector N_VClone_OpenMPDEV(N_Vector w)
       return (NULL);
     }
 
+    NV_DATA_HOST_OMPDEV(v) = data;
+
     /* Allocate memory on device */
     dev      = omp_get_default_device();
     dev_data = omp_target_alloc(length * sizeof(sunrealtype), dev);
@@ -439,7 +439,6 @@ N_Vector N_VClone_OpenMPDEV(N_Vector w)
     }
 
     /* Attach data */
-    NV_DATA_HOST_OMPDEV(v) = data;
     NV_DATA_DEV_OMPDEV(v)  = dev_data;
   }
 

--- a/src/sundials/stl/sunstl_vector.h
+++ b/src/sundials/stl/sunstl_vector.h
@@ -76,7 +76,11 @@ static inline SUNStlVectorTtype MAKE_NAME(SUNStlVectorTtype,
   SUNStlVectorTtype self = (SUNStlVectorTtype)malloc(sizeof(*self));
   if (!self) { return NULL; }
   self->values = (TTYPE*)malloc(sizeof(TTYPE) * init_capacity);
-  if (!(self->values)) { return NULL; }
+  if (!(self->values))
+  {
+    free(self);
+    return NULL;
+  }
   self->size         = 0;
   self->capacity     = init_capacity;
   self->destroyValue = destroyValue;

--- a/src/sundials/sundials_direct.c
+++ b/src/sundials/sundials_direct.c
@@ -171,7 +171,6 @@ void SUNDlsMat_DestroyMat(SUNDlsMat A)
   A->data = NULL;
   free(A->cols);
   free(A);
-  A = NULL;
 }
 
 void SUNDlsMat_destroyMat(sunrealtype** a)
@@ -179,7 +178,6 @@ void SUNDlsMat_destroyMat(sunrealtype** a)
   free(a[0]);
   a[0] = NULL;
   free(a);
-  a = NULL;
 }
 
 int* SUNDlsMat_NewIntArray(int N)
@@ -257,13 +255,11 @@ sunrealtype* SUNDlsMat_newRealArray(sunindextype m)
 void SUNDlsMat_DestroyArray(void* V)
 {
   free(V);
-  V = NULL;
 }
 
 void SUNDlsMat_destroyArray(void* v)
 {
   free(v);
-  v = NULL;
 }
 
 void SUNDlsMat_AddIdentity(SUNDlsMat A)

--- a/src/sundials/sundials_direct.c
+++ b/src/sundials/sundials_direct.c
@@ -252,15 +252,9 @@ sunrealtype* SUNDlsMat_newRealArray(sunindextype m)
   return (v);
 }
 
-void SUNDlsMat_DestroyArray(void* V)
-{
-  free(V);
-}
+void SUNDlsMat_DestroyArray(void* V) { free(V); }
 
-void SUNDlsMat_destroyArray(void* v)
-{
-  free(v);
-}
+void SUNDlsMat_destroyArray(void* v) { free(v); }
 
 void SUNDlsMat_AddIdentity(SUNDlsMat A)
 {

--- a/src/sundials/sundials_nvector.c
+++ b/src/sundials/sundials_nvector.c
@@ -1077,7 +1077,6 @@ void N_VDestroyVectorArray(N_Vector* vs, int count)
   }
 
   free(vs);
-  vs = NULL;
 
   return;
 }


### PR DESCRIPTION
cppcheck flagged a few memory leaks in the unlikely case of a malloc failing in a constructor, and codex did a decent job at fixing them. These fixes aren't so important, but they make the cppcheck report shorter so it will be easier to identify more important issues in the future.