### PR TITLE
Potential fix for code scanning alert no. 115: Wrong type of arguments to formatting function

### DIFF
--- a/examples/kinsol/serial/kinRoberts_fp.c
+++ b/examples/kinsol/serial/kinRoberts_fp.c
@@ -251,13 +251,7 @@ static void PrintOutput(N_Vector y)
   y2 = Ith(y, 2);
   y3 = Ith(y, 3);
 
-#if defined(SUNDIALS_EXTENDED_PRECISION)
-  printf("y =%14.6Le  %14.6Le  %14.6Le\n", y1, y2, y3);
-#elif defined(SUNDIALS_DOUBLE_PRECISION)
-  printf("y =%14.6e  %14.6e  %14.6e\n", y1, y2, y3);
-#else
-  printf("y =%14.6e  %14.6e  %14.6e\n", y1, y2, y3);
-#endif
+  printf("y =%14.6" GSYM "  %14.6" GSYM "  %14.6" GSYM "\n", y1, y2, y3);
 
   return;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/llnl/sundials/security/code-scanning/115](https://github.com/llnl/sundials/security/code-scanning/115)

Use the existing precision-dependent format macro (`GSYM`) instead of hardcoded `%e/%Le` in `PrintOutput`.  
This keeps behavior unchanged (still scientific notation with 6 digits) while guaranteeing the specifier matches `sunrealtype` across all build modes.

Best single fix in `examples/kinsol/serial/kinRoberts_fp.c`:
- Replace the `#if/#elif/#else` block in `PrintOutput` (lines 254–260 area) with one `printf` using `%14.6` + `GSYM` for each component.
- No new imports or dependencies are needed.
- No logic changes beyond formatting string construction.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
