### PR TITLE
Bugfix: CMake empty elseif warnings

### DIFF
--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -33,6 +33,7 @@ jobs:
       # Configure CMake in a 'build' subdirectory.
       run: |
         cmake \
+        -W error=dev \
         -B ${{github.workspace}}/build \
         -D CMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
         -D ENABLE_ALL_WARNINGS=ON \

--- a/.github/workflows/ubuntu-latest-clang.yml
+++ b/.github/workflows/ubuntu-latest-clang.yml
@@ -37,6 +37,7 @@ jobs:
       # Configure CMake in a 'build' subdirectory.
       run: |
         cmake \
+        -W error=dev \
         -B ${{github.workspace}}/build \
         -D CMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
         -D CMAKE_C_COMPILER="$(which clang)" \
@@ -94,6 +95,7 @@ jobs:
       # Configure CMake in a 'build' subdirectory.
       run: |
         cmake \
+        -W error=dev \
         -B ${{github.workspace}}/build \
         -D CMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
         -D CMAKE_C_COMPILER="$(which clang)" \

--- a/.github/workflows/ubuntu-latest-oneapi.yml
+++ b/.github/workflows/ubuntu-latest-oneapi.yml
@@ -36,6 +36,7 @@ jobs:
     - name: Configure CMake
       run: |
         cmake \
+        -W error=dev \
         -B ${{github.workspace}}/build \
         -D CMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
         -D CMAKE_C_COMPILER="$(which icx)" \

--- a/.github/workflows/windows-latest-intel.yml
+++ b/.github/workflows/windows-latest-intel.yml
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Configure CMake (Static)
-      run: cmake -G "Ninja" -B ${{github.workspace}}/build_static -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_C_FLAGS=-Wno-deprecated-declarations -DCMAKE_C_COMPILER=icx-cl -DCMAKE_CXX_COMPILER=icx-cl -DCMAKE_Fortran_COMPILER=ifx -DBUILD_STATIC_LIBS=ON -DBUILD_SHARED_LIBS=OFF -DBUILD_FORTRAN_MODULE_INTERFACE=ON -DSUNDIALS_BUILD_WITH_PROFILING=ON -DSUNDIALS_TEST_ENABLE_UNIT_TESTS=OFF -DEXAMPLES_ENABLE_CXX=ON
+      run: cmake -W error=dev -G "Ninja" -B ${{github.workspace}}/build_static -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_C_FLAGS=-Wno-deprecated-declarations -DCMAKE_C_COMPILER=icx-cl -DCMAKE_CXX_COMPILER=icx-cl -DCMAKE_Fortran_COMPILER=ifx -DBUILD_STATIC_LIBS=ON -DBUILD_SHARED_LIBS=OFF -DBUILD_FORTRAN_MODULE_INTERFACE=ON -DSUNDIALS_BUILD_WITH_PROFILING=ON -DSUNDIALS_TEST_ENABLE_UNIT_TESTS=OFF -DEXAMPLES_ENABLE_CXX=ON
 
     - name: Build (Static)
       run: cmake --build ${{github.workspace}}/build_static --verbose
@@ -45,7 +45,7 @@ jobs:
       run: ctest -C ${{env.BUILD_TYPE}} --output-on-failure
 
     - name: Configure CMake (Shared)
-      run: cmake -G "Ninja" -B ${{github.workspace}}/build_shared -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_C_FLAGS=-Wno-deprecated-declarations -DCMAKE_C_COMPILER=icx-cl -DCMAKE_CXX_COMPILER=icx-cl -DCMAKE_Fortran_COMPILER=ifx -DBUILD_STATIC_LIBS=OFF -DBUILD_SHARED_LIBS=ON -DBUILD_FORTRAN_MODULE_INTERFACE=ON -DSUNDIALS_BUILD_WITH_PROFILING=ON -DSUNDIALS_TEST_ENABLE_UNIT_TESTS=OFF -DEXAMPLES_ENABLE_CXX=ON
+      run: cmake -W error=dev -G "Ninja" -B ${{github.workspace}}/build_shared -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_C_FLAGS=-Wno-deprecated-declarations -DCMAKE_C_COMPILER=icx-cl -DCMAKE_CXX_COMPILER=icx-cl -DCMAKE_Fortran_COMPILER=ifx -DBUILD_STATIC_LIBS=OFF -DBUILD_SHARED_LIBS=ON -DBUILD_FORTRAN_MODULE_INTERFACE=ON -DSUNDIALS_BUILD_WITH_PROFILING=ON -DSUNDIALS_TEST_ENABLE_UNIT_TESTS=OFF -DEXAMPLES_ENABLE_CXX=ON
 
     - name: Build (Shared)
       run: cmake --build ${{github.workspace}}/build_shared --verbose

--- a/.github/workflows/windows-latest-mingw.yml
+++ b/.github/workflows/windows-latest-mingw.yml
@@ -59,6 +59,7 @@ jobs:
       # Configure CMake in a 'build' subdirectory
       run: |
         cmake \
+          -W error=dev \
           -G "MSYS Makefiles" \
           -B ${GITHUB_WORKSPACE}/build_static \
           -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
@@ -86,6 +87,7 @@ jobs:
       # Configure CMake in a 'build' subdirectory
       run: |
         cmake \
+          -W error=dev \
           -G "MSYS Makefiles" \
           -B ${GITHUB_WORKSPACE}/build_shared \
           -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \

--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Configure CMake
-      run: cmake -G "Visual Studio 17 2022" -B ${{github.workspace}}/build -DSUNDIALS_BUILD_WITH_PROFILING=ON -DSUNDIALS_TEST_ENABLE_UNIT_TESTS=ON -DEXAMPLES_ENABLE_CXX=ON
+      run: cmake -W error=dev -G "Visual Studio 17 2022" -B ${{github.workspace}}/build -DSUNDIALS_BUILD_WITH_PROFILING=ON -DSUNDIALS_TEST_ENABLE_UNIT_TESTS=ON -DEXAMPLES_ENABLE_CXX=ON
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ when running SSP methods in LSRKStep.
 Removed duplicate logging output that would cause the Python logging tools to fail
 with a repeated key error.
 
+Fixed empty `elseif()` cases in the CMake files for the Fortran interfaces to
+the ManyVector and MPIPlusX vectors which could results in a missing include
+path when compiling if an MPI compiler wrapper is not found.
+
 ### Deprecation Notices
 
 ## Changes to SUNDIALS in release 7.7.0

--- a/cmake/SundialsDeprecated.cmake
+++ b/cmake/SundialsDeprecated.cmake
@@ -40,8 +40,8 @@ endif()
 
 # Deprecated with SUNDIALS 6.4.0
 if(DEFINED SUPERLUDIST_LIBRARY_DIR)
-  message(DEPRECATION "The CMake option SUPERLUDIST_LIBRARY_DIR is deprecated. "
-                      "Use SUPERLUDIST_DIR instead.")
+  message(WARNING "The CMake option SUPERLUDIST_LIBRARY_DIR is deprecated. "
+                  "Use SUPERLUDIST_DIR instead.")
   set(SUPERLUDIST_DIR
       "${SUPERLUDIST_LIBRARY_DIR}/../"
       CACHE BOOL "SuperLU_DIST root directory" FORCE)
@@ -52,8 +52,8 @@ endif()
 
 # Deprecated CUDA_ARCH option
 if(DEFINED CUDA_ARCH)
-  message(DEPRECATION "The CMake option CUDA_ARCH is deprecated. "
-                      "Use CMAKE_CUDA_ARCHITECTURES instead.")
+  message(WARNING "The CMake option CUDA_ARCH is deprecated. "
+                  "Use CMAKE_CUDA_ARCHITECTURES instead.")
   # convert sm_** to just **
   string(REGEX MATCH "[0-9]+" arch_name "${CUDA_ARCH}")
   set(CMAKE_CUDA_ARCHITECTURES
@@ -66,7 +66,7 @@ endif()
 
 if(SUNDIALS_CALIPER_OUTPUT_DIR)
   message(
-    DEPRECATION
+    WARNING
       "The CMake option SUNDIALS_CALIPER_OUTPUT_DIR is deprecated. "
       "Use SUNDIALS_TEST_CALIPER_OUTPUT_DIR and SUNDIALS_BENCHMARKS_CALIPER_OUTPUT_DIR instead."
   )

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -21,4 +21,8 @@ Fixed minor bug in reporting the maximum number of stages in
 Removed duplicate logging output that would cause the Python logging tools to fail
 with a repeated key error.
 
+Fixed empty ``elseif()`` cases in the CMake files for the Fortran interfaces to
+the ManyVector and MPIPlusX vectors which could results in a missing include
+path when compiling if an MPI compiler wrapper is not found.
+
 **Deprecation Notices**

--- a/src/nvector/manyvector/fmod_int32/CMakeLists.txt
+++ b/src/nvector/manyvector/fmod_int32/CMakeLists.txt
@@ -39,7 +39,7 @@ if(SUNDIALS_ENABLE_NVECTOR_MPIMANYVECTOR)
   if(MPI_C_COMPILER)
     # use MPI wrapper as the compiler
     set(CMAKE_C_COMPILER ${MPI_C_COMPILER})
-  elseif()
+  else()
     # add MPI_INCLUDE_PATH to include directories
     include_directories(${MPI_INCLUDE_PATH})
   endif()

--- a/src/nvector/manyvector/fmod_int64/CMakeLists.txt
+++ b/src/nvector/manyvector/fmod_int64/CMakeLists.txt
@@ -39,7 +39,7 @@ if(SUNDIALS_ENABLE_NVECTOR_MPIMANYVECTOR)
   if(MPI_C_COMPILER)
     # use MPI wrapper as the compiler
     set(CMAKE_C_COMPILER ${MPI_C_COMPILER})
-  elseif()
+  else()
     # add MPI_INCLUDE_PATH to include directories
     include_directories(${MPI_INCLUDE_PATH})
   endif()

--- a/src/nvector/mpiplusx/fmod_int32/CMakeLists.txt
+++ b/src/nvector/mpiplusx/fmod_int32/CMakeLists.txt
@@ -26,7 +26,7 @@ endif()
 if(MPI_C_COMPILER)
   # use MPI wrapper as the compiler
   set(CMAKE_C_COMPILER ${MPI_C_COMPILER})
-elseif()
+else()
   # add MPI_INCLUDE_PATH to include directories
   include_directories(${MPI_INCLUDE_PATH})
 endif()

--- a/src/nvector/mpiplusx/fmod_int64/CMakeLists.txt
+++ b/src/nvector/mpiplusx/fmod_int64/CMakeLists.txt
@@ -26,7 +26,7 @@ endif()
 if(MPI_C_COMPILER)
   # use MPI wrapper as the compiler
   set(CMAKE_C_COMPILER ${MPI_C_COMPILER})
-elseif()
+else()
   # add MPI_INCLUDE_PATH to include directories
   include_directories(${MPI_INCLUDE_PATH})
 endif()

--- a/test/test_driver.sh
+++ b/test/test_driver.sh
@@ -668,7 +668,7 @@ for ((j=0;j<ntestdirs;j++)); do
 
         echo "START CMAKE"
 
-        time cmake -C sundials.cmake ../../. | tee -a configure.log
+        time cmake -W error=dev -C sundials.cmake ../../. | tee -a configure.log
 
         rc=${PIPESTATUS[0]}
         echo -e "\ncmake returned $rc\n" | tee -a configure.log


### PR DESCRIPTION
* Replace empty `elseif()` with `else()` in CMake. If an MPI compiler is not found (unlikely), the MPI include path is not added.
* Update CI to treat CMake developer warnings as errors