### PR TITLE
CMake: remove NO_DEFAULT_PATH and change HINTS to PATHS

### DIFF
--- a/.gitlab/build_and_test.sh
+++ b/.gitlab/build_and_test.sh
@@ -42,6 +42,9 @@ hostname=${hostname%%[0-9]*}
 # number of parallel build jobs
 BUILD_JOBS=${BUILD_JOBS:-"1"}
 
+# LC workaround for MPI / CSM / PSM errors
+export PSM2_KASSIST_MODE="auto"
+
 if [[ "${option}" != "--build-only" && "${option}" != "--test-only" ]]
 then
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,12 @@ Fixed memory leaks in CVODES, IDAS, and KINSOL in the unlikely event of a failed
 Fixed minor bug in reporting the maximum number of stages in `ARKodeGetStageIndex`
 when running SSP methods in LSRKStep.
 
-Removed duplicate logging output that would cause the Python logging tools to fail
-with a repeated key error.
+Removed duplicate logging output that would cause the Python logging tools to
+fail with a repeated key error.
+
+Fixed a CMake issue that prevented finding third-party libraries installed in
+default search locations e.g., paths included in `CMAKE_INSTALL_PREFIX`
+([Issue #935](https://github.com/llnl/sundials/issues/935)).
 
 ### Deprecation Notices
 

--- a/cmake/tpl/FindHYPRE.cmake
+++ b/cmake/tpl/FindHYPRE.cmake
@@ -39,7 +39,7 @@
 find_path(
   temp_HYPRE_INCLUDE_DIR
   NAMES HYPRE.h hypre.h
-  HINTS "${HYPRE_DIR}" "${HYPRE_DIR}/include" "${HYPRE_INCLUDE_DIR}")
+  PATHS "${HYPRE_DIR}" "${HYPRE_DIR}/include" "${HYPRE_INCLUDE_DIR}")
 if(temp_HYPRE_INCLUDE_DIR)
   set(HYPRE_INCLUDE_DIR
       "${temp_HYPRE_INCLUDE_DIR}"
@@ -61,7 +61,7 @@ else()
   find_library(
     HYPRE_LIBRARY
     NAMES ${HYPRE_LIBRARY_NAMES}
-    HINTS "${HYPRE_DIR}" "${HYPRE_DIR}/lib" "${HYPRE_DIR}/lib64"
+    PATHS "${HYPRE_DIR}" "${HYPRE_DIR}/lib" "${HYPRE_DIR}/lib64"
           "${HYPRE_LIBRARY_DIR}")
 endif()
 mark_as_advanced(HYPRE_LIBRARY)

--- a/cmake/tpl/FindKLU.cmake
+++ b/cmake/tpl/FindKLU.cmake
@@ -86,29 +86,25 @@ if(KLU_LIBRARY)
 else()
   # find library with user provided directory path
   set(KLU_LIBRARY_NAME klu)
-  find_library(KLU_LIBRARY ${KLU_LIBRARY_NAME} ${KLU_LIBRARY_DIR}
-               NO_DEFAULT_PATH)
+  find_library(KLU_LIBRARY ${KLU_LIBRARY_NAME} ${KLU_LIBRARY_DIR})
 endif()
 mark_as_advanced(KLU_LIBRARY)
 
 if(NOT AMD_LIBRARY)
   set(AMD_LIBRARY_NAME amd)
-  find_library(AMD_LIBRARY ${AMD_LIBRARY_NAME} ${KLU_LIBRARY_DIR}
-               NO_DEFAULT_PATH)
+  find_library(AMD_LIBRARY ${AMD_LIBRARY_NAME} ${KLU_LIBRARY_DIR})
   mark_as_advanced(AMD_LIBRARY)
 endif()
 
 if(NOT COLAMD_LIBRARY)
   set(COLAMD_LIBRARY_NAME colamd)
-  find_library(COLAMD_LIBRARY ${COLAMD_LIBRARY_NAME} ${KLU_LIBRARY_DIR}
-               NO_DEFAULT_PATH)
+  find_library(COLAMD_LIBRARY ${COLAMD_LIBRARY_NAME} ${KLU_LIBRARY_DIR})
   mark_as_advanced(COLAMD_LIBRARY)
 endif()
 
 if(NOT BTF_LIBRARY)
   set(BTF_LIBRARY_NAME btf)
-  find_library(BTF_LIBRARY ${BTF_LIBRARY_NAME} ${KLU_LIBRARY_DIR}
-               NO_DEFAULT_PATH)
+  find_library(BTF_LIBRARY ${BTF_LIBRARY_NAME} ${KLU_LIBRARY_DIR})
   mark_as_advanced(BTF_LIBRARY)
 endif()
 
@@ -119,7 +115,7 @@ if(NOT SUITESPARSECONFIG_LIBRARY)
     set(CMAKE_FIND_LIBRARY_PREFIXES "")
   endif()
   find_library(SUITESPARSECONFIG_LIBRARY ${SUITESPARSECONFIG_LIBRARY_NAME}
-               ${KLU_LIBRARY_DIR} NO_DEFAULT_PATH)
+               ${KLU_LIBRARY_DIR})
   mark_as_advanced(SUITESPARSECONFIG_LIBRARY)
 endif()
 

--- a/cmake/tpl/FindMAGMA.cmake
+++ b/cmake/tpl/FindMAGMA.cmake
@@ -21,18 +21,16 @@
 find_path(
   MAGMA_INCLUDE_DIR magma_v2.h
   NAMES magma_v2.h
-  HINTS ${MAGMA_DIR} $ENV{MAGMA_DIR}
+  PATHS ${MAGMA_DIR} $ENV{MAGMA_DIR}
   PATH_SUFFIXES include
-  NO_DEFAULT_PATH
   DOC "Directory with MAGMA header")
 
 # find the main MAGMA library
 find_library(
   MAGMA_LIBRARY
   NAMES magma
-  HINTS ${MAGMA_DIR} $ENV{MAGMA_DIR}
+  PATHS ${MAGMA_DIR} $ENV{MAGMA_DIR}
   PATH_SUFFIXES lib lib64
-  NO_DEFAULT_PATH
   DOC "The MAGMA library.")
 
 # Find the optional sparse component
@@ -41,9 +39,8 @@ if("SPARSE" IN_LIST MAGMA_FIND_COMPONENTS)
   find_library(
     MAGMA_SPARSE_LIBRARY
     NAMES magma_sparse
-    HINTS ${MAGMA_DIR} $ENV{MAGMA_DIR}
+    PATHS ${MAGMA_DIR} $ENV{MAGMA_DIR}
     PATH_SUFFIXES lib lib64
-    NO_DEFAULT_PATH
     DOC "The MAGMA sparse library.")
 else()
   set(_sparse_required)

--- a/cmake/tpl/FindPETSC.cmake
+++ b/cmake/tpl/FindPETSC.cmake
@@ -46,7 +46,7 @@ foreach(_next_lib IN LISTS PKG_PETSC_LIBRARIES)
   find_library(
     _petsc_lib_${_next_lib}
     NAMES ${_next_lib}
-    HINTS ${PKG_PETSC_LIBRARY_DIRS})
+    PATHS ${PKG_PETSC_LIBRARY_DIRS})
   if(_petsc_lib_${_next_lib})
     list(APPEND _petsc_libs "${_petsc_lib_${_next_lib}}")
   endif()
@@ -62,15 +62,15 @@ foreach(_next_lib IN LISTS PKG_PETSC_STATIC_LIBRARIES)
   endif()
   if(_next_lib MATCHES "kokkoskernels")
     if(NOT TARGET Kokkos::kokkoskernels)
-      find_package(KokkosKernels REQUIRED HINTS "${KokkosKernels_DIR}"
-                   "${PKG_PETSC_LIBRARY_DIRS}" NO_DEFAULT_PATH)
+      find_package(KokkosKernels REQUIRED PATHS "${KokkosKernels_DIR}"
+                   "${PKG_PETSC_LIBRARY_DIRS}")
     endif()
     list(APPEND _petsc_libs "Kokkos::kokkoskernels")
   endif()
   if(_next_lib MATCHES "kokkos")
     if(NOT TARGET Kokkos::kokkos)
-      find_package(Kokkos REQUIRED HINTS "${Kokkos_DIR}"
-                   "${PKG_PETSC_LIBRARY_DIRS}" NO_DEFAULT_PATH)
+      find_package(Kokkos REQUIRED PATHS "${Kokkos_DIR}"
+                   "${PKG_PETSC_LIBRARY_DIRS}")
     endif()
     list(APPEND _petsc_libs "Kokkos::kokkos")
   endif()

--- a/cmake/tpl/FindSUPERLUMT.cmake
+++ b/cmake/tpl/FindSUPERLUMT.cmake
@@ -87,9 +87,8 @@ endif()
 # find library
 if(NOT SUPERLUMT_LIBRARY)
   # search user provided directory path
-  find_library(
-    SUPERLUMT_LIBRARY ${SUPERLUMT_LIBRARY_NAME}
-    PATHS ${SUPERLUMT_LIBRARY_DIR})
+  find_library(SUPERLUMT_LIBRARY ${SUPERLUMT_LIBRARY_NAME}
+               PATHS ${SUPERLUMT_LIBRARY_DIR})
   mark_as_advanced(SUPERLUMT_LIBRARY)
 endif()
 

--- a/cmake/tpl/FindSUPERLUMT.cmake
+++ b/cmake/tpl/FindSUPERLUMT.cmake
@@ -89,12 +89,7 @@ if(NOT SUPERLUMT_LIBRARY)
   # search user provided directory path
   find_library(
     SUPERLUMT_LIBRARY ${SUPERLUMT_LIBRARY_NAME}
-    PATHS ${SUPERLUMT_LIBRARY_DIR}
-    NO_DEFAULT_PATH)
-  # if user didn't provide a path, search anywhere
-  if(NOT (SUPERLUMT_LIBRARY_DIR OR SUPERLUMT_LIBRARY))
-    find_library(SUPERLUMT_LIBRARY ${SUPERLUMT_LIBRARY_NAME})
-  endif()
+    PATHS ${SUPERLUMT_LIBRARY_DIR})
   mark_as_advanced(SUPERLUMT_LIBRARY)
 endif()
 

--- a/cmake/tpl/FindXBRAID.cmake
+++ b/cmake/tpl/FindXBRAID.cmake
@@ -140,8 +140,7 @@ else()
     XBRAID_INCLUDE_DIR braid.h
     PATHS ${XBRAID_DIR}
     PATH_SUFFIXES include braid
-    DOC "XBraid include directory"
-    NO_DEFAULT_PATH)
+    DOC "XBraid include directory")
 
   # check if the include directory was found
   if(NOT XBRAID_INCLUDE_DIR)
@@ -157,8 +156,7 @@ else()
     XBRAID_LIBRARY braid
     PATHS ${XBRAID_DIR}
     PATH_SUFFIXES lib braid
-    DOC "XBraid library"
-    NO_DEFAULT_PATH)
+    DOC "XBraid library")
 
   # check if the library was found
   if(NOT XBRAID_LIBRARY)

--- a/cmake/tpl/SundialsGinkgo.cmake
+++ b/cmake/tpl/SundialsGinkgo.cmake
@@ -35,7 +35,7 @@ endif()
 # Section 3: Find the TPL
 # -----------------------------------------------------------------------------
 
-find_package(Ginkgo REQUIRED HINTS "${Ginkgo_DIR}")
+find_package(Ginkgo REQUIRED PATHS "${Ginkgo_DIR}")
 
 message(STATUS "GINKGO VERSION:     ${GINKGO_PROJECT_VERSION}")
 message(STATUS "GINKGO BUILD TYPE:  ${GINKGO_BUILD_TYPE}")

--- a/cmake/tpl/SundialsKokkos.cmake
+++ b/cmake/tpl/SundialsKokkos.cmake
@@ -30,7 +30,7 @@ include_guard(GLOBAL)
 # -----------------------------------------------------------------------------
 # Section 3: Find the TPL
 # -----------------------------------------------------------------------------
-find_package(Kokkos REQUIRED HINTS "${Kokkos_DIR}")
+find_package(Kokkos REQUIRED PATHS "${Kokkos_DIR}")
 
 # We should be able to use Kokkos_DEVICES directly but it seems to get removed
 # or unset in some CMake versions

--- a/cmake/tpl/SundialsKokkosKernels.cmake
+++ b/cmake/tpl/SundialsKokkosKernels.cmake
@@ -30,7 +30,7 @@ include_guard(GLOBAL)
 # -----------------------------------------------------------------------------
 # Section 3: Find the TPL
 # -----------------------------------------------------------------------------
-find_package(KokkosKernels REQUIRED HINTS "${KokkosKernels_DIR}")
+find_package(KokkosKernels REQUIRED PATHS "${KokkosKernels_DIR}")
 
 message(STATUS "Kokkos Kernels VERSION: ${KokkosKernels_VERSION}")
 

--- a/cmake/tpl/SundialsRAJA.cmake
+++ b/cmake/tpl/SundialsRAJA.cmake
@@ -49,7 +49,7 @@ endif()
 # find the library configuration file
 find_file(
   RAJA_CONFIGHPP_PATH config.hpp
-  HINTS "${RAJA_DIR}"
+  PATHS "${RAJA_DIR}"
   PATH_SUFFIXES include include/RAJA)
 mark_as_advanced(FORCE RAJA_CONFIGHPP_PATH)
 
@@ -60,7 +60,6 @@ find_package(
   PATHS
   "${RAJA_DIR}"
   "${RAJA_DIR}/share/raja/cmake"
-  NO_DEFAULT_PATH
   REQUIRED)
 
 # determine the backends

--- a/cmake/tpl/SundialsRAJA.cmake
+++ b/cmake/tpl/SundialsRAJA.cmake
@@ -54,13 +54,8 @@ find_file(
 mark_as_advanced(FORCE RAJA_CONFIGHPP_PATH)
 
 # Look for CMake configuration file in RAJA installation
-find_package(
-  RAJA
-  CONFIG
-  PATHS
-  "${RAJA_DIR}"
-  "${RAJA_DIR}/share/raja/cmake"
-  REQUIRED)
+find_package(RAJA CONFIG PATHS "${RAJA_DIR}" "${RAJA_DIR}/share/raja/cmake"
+             REQUIRED)
 
 # determine the backends
 foreach(_backend CUDA HIP OPENMP TARGET_OPENMP SYCL)

--- a/cmake/tpl/SundialsTrilinos.cmake
+++ b/cmake/tpl/SundialsTrilinos.cmake
@@ -34,7 +34,7 @@ include_guard(GLOBAL)
 # Find Trilinos
 find_package(
   Trilinos REQUIRED
-  COMPONENTS Tpetra HINTS "${Trilinos_DIR}/lib/cmake/Trilinos"
+  COMPONENTS Tpetra PATHS "${Trilinos_DIR}/lib/cmake/Trilinos"
              "${Trilinos_DIR}")
 
 message(STATUS "Trilinos Libraries: ${Trilinos_LIBRARIES}")

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -18,7 +18,11 @@ Fixed memory leaks in CVODES, IDAS, and KINSOL in the unlikely event of a failed
 Fixed minor bug in reporting the maximum number of stages in
 :c:func:`ARKodeGetStageIndex` when running SSP methods in LSRKStep.
 
-Removed duplicate logging output that would cause the Python logging tools to fail
-with a repeated key error.
+Removed duplicate logging output that would cause the Python logging tools to
+fail with a repeated key error.
+
+Fixed a CMake issue that prevented finding third-party libraries installed in
+default search locations e.g., paths included in ``CMAKE_INSTALL_PREFIX``
+(`Issue #935 <https://github.com/llnl/sundials/issues/935>`__).
 
 **Deprecation Notices**


### PR DESCRIPTION
* Remove `NO_DEFAULT_PATH` when searching for TPL installs
* Change `HINTS` to `PATHS` per CMake docs
* Fixes #935 