### PR TITLE
Bugfix: Resize ERKStep before ARKodeEvolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,9 +43,12 @@ notes in the documentation to always use the SUNDIALS version number with the
 package version number as a parenthetical note when it differs from the SUNDIALS
 version number.
 
-Fixed a bug in sundials4py where the `CVodeGetRootInfo`, `ARKodeGetRootInfo`, and `IDAGetRootInfo` functions
-did not correctly return the rootsfound array. This addresses
-[Issue #937](https://github.com/llnl/sundials/issues/937).
+Fixed a bug in sundials4py where the `CVodeGetRootInfo`, `ARKodeGetRootInfo`,
+and `IDAGetRootInfo` functions did not correctly return the rootsfound
+array. This addresses [Issue #937](https://github.com/llnl/sundials/issues/937).
+
+Fixed a bug in ERKStep where calling `ARKodeResize` before `ARKodeEvolve` or
+`ARKodeInit` would result in a segmentation fault.
 
 ### Deprecation Notices
 

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -42,8 +42,13 @@ notes in the documentation to always use the SUNDIALS version number with the
 package version number as a parenthetical note when it differs from the SUNDIALS
 version number.
 
-Fixed a bug in sundials4py where the `CVodeGetRootInfo`, `ARKodeGetRootInfo`, and `IDAGetRootInfo` functions
-did not correctly return the rootsfound array. This addresses 
-`Issue #937 <https://github.com/llnl/sundials/issues/937>`__.
+Fixed a bug in sundials4py where the :c:func:`CVodeGetRootInfo`,
+:c:func:`ARKodeGetRootInfo`, and :c:func:`IDAGetRootInfo` functions did not
+correctly return the rootsfound array. This addresses `Issue #937
+<https://github.com/llnl/sundials/issues/937>`__.
+
+Fixed a bug in ERKStep where calling :c:func:`ARKodeResize` before
+:c:func:`ARKodeEvolve` or :c:func:`ARKodeInit` would result in a segmentation
+fault.
 
 **Deprecation Notices**

--- a/src/arkode/arkode_erkstep.c
+++ b/src/arkode/arkode_erkstep.c
@@ -254,14 +254,17 @@ int erkStep_Resize(ARKodeMem ark_mem, N_Vector y0,
   ark_mem->liw1 = liw1;
 
   /* Resize the RHS vectors */
-  for (i = 0; i < step_mem->stages; i++)
+  if (step_mem->F)
   {
-    if (!arkResizeVec(ark_mem, resize, resize_data, lrw_diff, liw_diff, y0,
-                      &step_mem->F[i]))
+    for (i = 0; i < step_mem->stages; i++)
     {
-      arkProcessError(ark_mem, ARK_MEM_FAIL, __LINE__, __func__, __FILE__,
-                      "Unable to resize vector");
-      return (ARK_MEM_FAIL);
+      if (!arkResizeVec(ark_mem, resize, resize_data, lrw_diff, liw_diff, y0,
+                        &step_mem->F[i]))
+      {
+        arkProcessError(ark_mem, ARK_MEM_FAIL, __LINE__, __func__, __FILE__,
+                        "Unable to resize vector");
+        return (ARK_MEM_FAIL);
+      }
     }
   }
 


### PR DESCRIPTION
Fix a bug in ERKStep where calling `ARKodeResize` before `ARKodeEvolve` or `ARKodeInit` results in a segmentation fault.
