### PR TITLE
CI: add hubcast configuration file

### DIFF
--- a/.github/hubcast.yml
+++ b/.github/hubcast.yml
@@ -1,0 +1,21 @@
+Repo:
+  # Required: organization or user that owns the repo on CZ GitLab
+  dest_org: sundials
+
+  # Required: name of the destination repository on CZ GitLab
+  dest_name: sundials
+
+  # Optional: name of the CI check as reported back to GitHub (default: gitlab-ci)
+  check_name: llnl-lc-gitlab-ci
+
+  # Optional: granularity of CI statuses reported to GitHub (default: [pipeline])
+  # Set to [pipeline] for overall pipeline status only
+  # Set to [jobs] for individual job statuses only
+  # Set to [pipeline, jobs] to report both
+  check_types: [pipeline, jobs]
+
+  # Optional: delete branches from destination when source PR is closed (default: true)
+  delete_closed: true
+
+  # Optional: sync draft PRs/MRs (default: true)
+  sync_drafts: true


### PR DESCRIPTION
LLNL will be requiring us to switch to the new hubcast tool for mirroring the repo to the LC gitlab for CI. See https://hpc.llnl.gov/technical-bulletins/bulletin-607. 

LLNL developers who have followed the steps to link their LC account to their GitHub account will have their PRs trigger CI on LC automatically. External developers will need an LLNL developer to comment `@lc-hubcast approve` on a PR to trigger the LLNL gitlab CI (which will run as the LLNL developer leaving the comment). 