### PR TITLE
Bugfix: small zR instability issue

### DIFF
--- a/src/arkode/arkode_lsrkstep.c
+++ b/src/arkode/arkode_lsrkstep.c
@@ -642,7 +642,7 @@ int lsrkStep_TakeStepRKC(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
   /* Copy ss in case it is needed for falling back to step size adaptivity below */
   int req_stages = ss;
 
-  if (zR < ZERO)
+  if (zR < -SUN_UNIT_ROUNDOFF)
   {
     /* We first check whether the combination of ss, step size, and dominant
       eigenvalue, is stable.  If not, we then check whether it would be stable
@@ -1087,7 +1087,7 @@ int lsrkStep_TakeStepRKL(ARKodeMem ark_mem, sunrealtype* dsmPtr, int* nflagPtr)
   /* Copy ss in case it is needed for falling back to step size adaptivity below */
   int req_stages = ss;
 
-  if (zR < ZERO)
+  if (zR < -SUN_UNIT_ROUNDOFF)
   {
     /* To check stability, we evaluate the analytic stability function or an
       inscribed ellipse approximation. If the stability norm is greater than


### PR DESCRIPTION
This PR fixes a bug in a rare corner case where both `lambdaR` and `hcur` are so small that their product, `zR`, is tiny. In that case, when `zI = 0`, the stability norm becomes

`*stability_norm = SUNRsqrt(SUNSQR((zR + a) / a) + SUNSQR(zI / b)) = 1
`
In general, we do not expect dominant eigenvalues with a nearly zero real part, since such eigenvalues returns zero for all input vectors, similar to a zero matrix. However, we still need to make sure that STS methods work even for this case correctly.