### PR TITLE
Bugfix: Catch unknown linear solver return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ embedded implicit-explicit MRI-GARK coupling tables.
 
 ### Bug Fixes
 
+Fixed a bug where an unrecognized error return flag from a user-provided
+SUNLinearSolver module would register as a successful linear solve.
+
 Fixed a minor bug where the number of required stages for STS methods
 in the LSRKStep module was incorrectly computed using the spectral
 radius instead of the real part of the Jacobian eigenvalues.
@@ -42,8 +45,8 @@ Fixed a minor bug where STS methods were limited to one fewer than
 the maximum allowed number of stages. STS can now use the full maximum
 number of stages.
 
-Fixed a bug that caused SUNDomEigEstimator_Initialize to overwrite the 
-user-provided initial guess from SUNDomEigEstimator_SetInitialGuess. These 
+Fixed a bug that caused SUNDomEigEstimator_Initialize to overwrite the
+user-provided initial guess from SUNDomEigEstimator_SetInitialGuess. These
 routines are now order-independent.
 
 Fixed memory leaks in CVODES, IDAS, and KINSOL in the unlikely event of a failed

--- a/doc/shared/RecentChanges.rst
+++ b/doc/shared/RecentChanges.rst
@@ -30,20 +30,23 @@ embedded implicit-explicit MRI-GARK coupling tables.
 
 **Bug Fixes**
 
-Fixed a minor bug where the number of required stages for STS methods 
-in the LSRKStep module was incorrectly computed using the spectral 
+Fixed a bug where an unrecognized error return flag from a user-provided
+SUNLinearSolver module would register as a successful linear solve.
+
+Fixed a minor bug where the number of required stages for STS methods
+in the LSRKStep module was incorrectly computed using the spectral
 radius instead of the real part of the Jacobian eigenvalues.
 
 Fixed a minor bug where the negative real extent of the stability region
-for the RKC method was not being properly computed, which could result 
+for the RKC method was not being properly computed, which could result
 in an underestimation of the number of stages required for stability.
 
 Fixed a minor bug where STS methods were limited to one fewer than
 the maximum allowed number of stages. STS can now use the full maximum
 number of stages.
 
-Fixed a bug that caused SUNDomEigEstimator_Initialize to overwrite the 
-user-provided initial guess from SUNDomEigEstimator_SetInitialGuess. These 
+Fixed a bug that caused SUNDomEigEstimator_Initialize to overwrite the
+user-provided initial guess from SUNDomEigEstimator_SetInitialGuess. These
 routines are now order-independent.
 
 Fixed memory leaks in CVODES, IDAS, and KINSOL in the unlikely event of a failed

--- a/src/arkode/arkode_ls.c
+++ b/src/arkode/arkode_ls.c
@@ -3967,7 +3967,7 @@ int arkLsMassSolve(ARKodeMem ark_mem, N_Vector b, sunrealtype nlscoef)
                     __FILE__, MSG_LS_PSOLVE_FAILED);
     return (-1);
     break;
-  case default:
+  default:
      arkProcessError(ark_mem, retval, __LINE__, __func__, __FILE__,
                      "Unrecognized error return value from SUNLinSolSolve");
      return (-1);

--- a/src/arkode/arkode_ls.c
+++ b/src/arkode/arkode_ls.c
@@ -3967,6 +3967,10 @@ int arkLsMassSolve(ARKodeMem ark_mem, N_Vector b, sunrealtype nlscoef)
                     __FILE__, MSG_LS_PSOLVE_FAILED);
     return (-1);
     break;
+  case default:
+     arkProcessError(ark_mem, retval, __LINE__, __func__, __FILE__,
+                     "Unrecognized error return value from SUNLinSolSolve");
+     return (-1);
   }
 
   return (0);

--- a/src/arkode/arkode_ls.c
+++ b/src/arkode/arkode_ls.c
@@ -3968,9 +3968,9 @@ int arkLsMassSolve(ARKodeMem ark_mem, N_Vector b, sunrealtype nlscoef)
     return (-1);
     break;
   default:
-     arkProcessError(ark_mem, retval, __LINE__, __func__, __FILE__,
-                     "Unrecognized error return value from SUNLinSolSolve");
-     return (-1);
+    arkProcessError(ark_mem, retval, __LINE__, __func__, __FILE__,
+                    "Unrecognized error return value from SUNLinSolSolve");
+    return (-1);
   }
 
   return (0);

--- a/src/cvode/cvode_ls.c
+++ b/src/cvode/cvode_ls.c
@@ -1866,7 +1866,7 @@ int cvLsSolve(CVodeMem cv_mem, N_Vector b, N_Vector weight, N_Vector ynow,
                    __FILE__, MSG_LS_PSOLVE_FAILED);
     return (-1);
     break;
-  case default:
+  default:
     cvProcessError(cv_mem, retval, __LINE__, __func__, __FILE__,
                    "Unrecognized error return value from SUNLinSolSolve");
     return (-1);

--- a/src/cvode/cvode_ls.c
+++ b/src/cvode/cvode_ls.c
@@ -1866,6 +1866,10 @@ int cvLsSolve(CVodeMem cv_mem, N_Vector b, N_Vector weight, N_Vector ynow,
                    __FILE__, MSG_LS_PSOLVE_FAILED);
     return (-1);
     break;
+  case default:
+    cvProcessError(cv_mem, retval, __LINE__, __func__, __FILE__,
+                   "Unrecognized error return value from SUNLinSolSolve");
+    return (-1);
   }
 
   return (0);

--- a/src/cvodes/cvodes_ls.c
+++ b/src/cvodes/cvodes_ls.c
@@ -1962,7 +1962,7 @@ int cvLsSolve(CVodeMem cv_mem, N_Vector b, N_Vector weight, N_Vector ynow,
                    __FILE__, MSG_LS_PSOLVE_FAILED);
     return (-1);
     break;
-  case default:
+  default:
     cvProcessError(cv_mem, retval, __LINE__, __func__, __FILE__,
                    "Unrecognized error return value from SUNLinSolSolve");
     return (-1);

--- a/src/cvodes/cvodes_ls.c
+++ b/src/cvodes/cvodes_ls.c
@@ -1962,6 +1962,10 @@ int cvLsSolve(CVodeMem cv_mem, N_Vector b, N_Vector weight, N_Vector ynow,
                    __FILE__, MSG_LS_PSOLVE_FAILED);
     return (-1);
     break;
+  case default:
+    cvProcessError(cv_mem, retval, __LINE__, __func__, __FILE__,
+                   "Unrecognized error return value from SUNLinSolSolve");
+    return (-1);
   }
 
   return (0);

--- a/src/ida/ida_ls.c
+++ b/src/ida/ida_ls.c
@@ -1622,7 +1622,7 @@ int idaLsSolve(IDAMem IDA_mem, N_Vector b, N_Vector weight, N_Vector ycur,
                     __FILE__, MSG_LS_PSOLVE_FAILED);
     return (-1);
     break;
-  case default:
+  default:
     IDAProcessError(IDA_mem, retval, __LINE__, __func__, __FILE__,
                     "Unrecognized error return value from SUNLinSolSolve");
     return (-1);

--- a/src/ida/ida_ls.c
+++ b/src/ida/ida_ls.c
@@ -1622,6 +1622,10 @@ int idaLsSolve(IDAMem IDA_mem, N_Vector b, N_Vector weight, N_Vector ycur,
                     __FILE__, MSG_LS_PSOLVE_FAILED);
     return (-1);
     break;
+  case default:
+    IDAProcessError(IDA_mem, retval, __LINE__, __func__, __FILE__,
+                    "Unrecognized error return value from SUNLinSolSolve");
+    return (-1);
   }
 
   return (0);

--- a/src/idas/idas_ls.c
+++ b/src/idas/idas_ls.c
@@ -1663,7 +1663,7 @@ int idaLsSolve(IDAMem IDA_mem, N_Vector b, N_Vector weight, N_Vector ycur,
                     __FILE__, MSG_LS_PSOLVE_FAILED);
     return (-1);
     break;
-  case default:
+  default:
     IDAProcessError(IDA_mem, retval, __LINE__, __func__, __FILE__,
                     "Unrecognized error return value from SUNLinSolSolve");
     return (-1);

--- a/src/idas/idas_ls.c
+++ b/src/idas/idas_ls.c
@@ -1663,6 +1663,10 @@ int idaLsSolve(IDAMem IDA_mem, N_Vector b, N_Vector weight, N_Vector ycur,
                     __FILE__, MSG_LS_PSOLVE_FAILED);
     return (-1);
     break;
+  case default:
+    IDAProcessError(IDA_mem, retval, __LINE__, __func__, __FILE__,
+                    "Unrecognized error return value from SUNLinSolSolve");
+    return (-1);
   }
 
   return (0);

--- a/src/kinsol/kinsol_ls.c
+++ b/src/kinsol/kinsol_ls.c
@@ -1296,7 +1296,7 @@ int kinLsSolve(KINMem kin_mem, N_Vector xx, N_Vector bb, sunrealtype* sJpnorm,
       KINProcessError(kin_mem, SUNLS_PSOLVE_FAIL_UNREC, __LINE__, __func__,
                       __FILE__, MSG_LS_PSOLVE_FAILED);
       break;
-    case default:
+    default:
       KINProcessError(kin_mem, retval, __LINE__, __func__, __FILE__,
                       "Unrecognized error return value from SUNLinSolSolve");
     }

--- a/src/kinsol/kinsol_ls.c
+++ b/src/kinsol/kinsol_ls.c
@@ -1296,6 +1296,9 @@ int kinLsSolve(KINMem kin_mem, N_Vector xx, N_Vector bb, sunrealtype* sJpnorm,
       KINProcessError(kin_mem, SUNLS_PSOLVE_FAIL_UNREC, __LINE__, __func__,
                       __FILE__, MSG_LS_PSOLVE_FAILED);
       break;
+    case default:
+      KINProcessError(kin_mem, retval, __LINE__, __func__, __FILE__,
+                      "Unrecognized error return value from SUNLinSolSolve");
     }
     return (retval);
   }


### PR DESCRIPTION
Fixed a bug where an unrecognized error return flag from a user-provided
SUNLinearSolver module would register as a successful linear solve.

This addresses issue #955 
