### PR TITLE
Docs: Add larger warnings for fixed step methods

### DIFF
--- a/doc/arkode/guide/source/Butcher.rst
+++ b/doc/arkode/guide/source/Butcher.rst
@@ -236,6 +236,11 @@ Accessible via the string ``"ARKODE_FORWARD_EULER_1_1"`` to
 :c:func:`ARKodeButcherTable_LoadERKByName`.
 This is the default 1st order explicit method (from :cite:p:`Euler:68`).
 
+.. warning::
+
+   When using this non-embedded table, users must specify the
+   time step by calling :c:func:`ARKodeSetFixedStep`.
+
 .. math::
 
    \renewcommand{\arraystretch}{1.5}
@@ -647,6 +652,11 @@ Accessible via the string ``"ARKODE_KNOTH_WOLKE_3_3"`` to
 :c:func:`ARKodeButcherTable_LoadERKByName`.
 This is the default 3th order slow and fast MRIStep method (from
 :cite:p:`KnWo:98`).
+
+.. warning::
+
+   When using this non-embedded table, users must specify the
+   time step by calling :c:func:`ARKodeSetFixedStep`.
 
 .. math::
 
@@ -1557,6 +1567,11 @@ Accessible via the string ``"ARKODE_BACKWARD_EULER_1_1"`` to
 :c:func:`ARKodeButcherTable_LoadDIRKByName`.
 This is the default 1st order implicit method.  The method is A-, L-, and B-stable.
 
+.. warning::
+
+   When using this non-embedded table, users must specify the
+   time step by calling :c:func:`ARKodeSetFixedStep`.
+
 .. math::
 
    \renewcommand{\arraystretch}{1.5}
@@ -1755,6 +1770,11 @@ Accessible via the string ``"ARKODE_IMPLICIT_MIDPOINT_1_2"`` to
 :c:func:`ARKodeButcherTable_LoadDIRKByName`.
 The method is A- and B-stable.
 
+.. warning::
+
+   When using this non-embedded table, users must specify the
+   time step by calling :c:func:`ARKodeSetFixedStep`.
+
 .. math::
 
    \renewcommand{\arraystretch}{1.5}
@@ -1780,6 +1800,11 @@ Accessible via the string ``"ARKODE_IMPLICIT_TRAPEZOIDAL_2_2"`` to
 :c:func:`ARKStepSetTableName` or
 :c:func:`ARKodeButcherTable_LoadDIRKByName`.
 The method is A-stable.
+
+.. warning::
+
+   When using this non-embedded table, users must specify the
+   time step by calling :c:func:`ARKodeSetFixedStep`.
 
 .. math::
 
@@ -2793,6 +2818,11 @@ symplectic partitioned Butcher tables are provided in the enumeration
 .. c:enum:: ARKODE_SPRKMethodID
 
 with values specified in :numref:`ARKODE.Butcher.SPRK_properties`.
+
+.. warning::
+
+   When using these non-embedded methods, users must specify the
+   time step by calling :c:func:`ARKodeSetFixedStep`.
 
 .. _ARKODE.Butcher.SPRK_properties:
 .. table:: Symplectic partitioned Butcher tables. The default method for each

--- a/doc/arkode/guide/source/Usage/MRIStep/MRIStepCoupling.rst
+++ b/doc/arkode/guide/source/Usage/MRIStep/MRIStepCoupling.rst
@@ -406,6 +406,12 @@ unique ID having type:
 
 with values specified for each method below (e.g., ``ARKODE_MIS_KW3``).
 
+.. warning::
+
+   When using any of the following methods that do not include embeddings
+   (marked with "Embedding Order" shown as "--"), users must specify the
+   time step by calling :c:func:`ARKodeSetFixedStep`.
+
 
 
 .. table:: Explicit MRIStep coupling tables.

--- a/src/arkode/arkode_arkstep.c
+++ b/src/arkode/arkode_arkstep.c
@@ -2737,7 +2737,7 @@ int arkStep_CheckButcherTables(ARKodeMem ark_mem)
   if ((step_mem->p < 1) && (!ark_mem->fixedstep))
   {
     arkProcessError(ark_mem, ARK_INVALID_TABLE, __LINE__, __func__, __FILE__,
-                    "embedding order < 1!");
+                    "embedding order < 1, but ARKodeSetFixedStep was not called!");
     return (ARK_INVALID_TABLE);
   }
 
@@ -2749,7 +2749,7 @@ int arkStep_CheckButcherTables(ARKodeMem ark_mem)
       if (step_mem->Bi->d == NULL)
       {
         arkProcessError(ark_mem, ARK_INVALID_TABLE, __LINE__, __func__,
-                        __FILE__, "no implicit embedding!");
+                        __FILE__, "no implicit embedding, but ARKodeSetFixedStep was not called!");
         return (ARK_INVALID_TABLE);
       }
     }
@@ -2758,7 +2758,7 @@ int arkStep_CheckButcherTables(ARKodeMem ark_mem)
       if (step_mem->Be->d == NULL)
       {
         arkProcessError(ark_mem, ARK_INVALID_TABLE, __LINE__, __func__,
-                        __FILE__, "no explicit embedding!");
+                        __FILE__, "no explicit embedding, but ARKodeSetFixedStep was not called!");
         return (ARK_INVALID_TABLE);
       }
     }
@@ -2820,7 +2820,7 @@ int arkStep_CheckButcherTables(ARKodeMem ark_mem)
     if (step_mem->q < 2)
     {
       arkProcessError(ark_mem, ARK_INVALID_TABLE, __LINE__, __func__, __FILE__,
-                      "The Butcher table(s) must be at least second order!");
+                      "The Butcher table(s) must be at least second order when using relaxation!");
       return ARK_INVALID_TABLE;
     }
 
@@ -2833,7 +2833,7 @@ int arkStep_CheckButcherTables(ARKodeMem ark_mem)
         {
           arkProcessError(ark_mem, ARK_INVALID_TABLE, __LINE__, __func__,
                           __FILE__,
-                          "The explicit Butcher table has a negative b value!");
+                          "The explicit Butcher table has a negative b value but relaxation enabled!");
           return ARK_INVALID_TABLE;
         }
       }
@@ -2848,7 +2848,7 @@ int arkStep_CheckButcherTables(ARKodeMem ark_mem)
         {
           arkProcessError(ark_mem, ARK_INVALID_TABLE, __LINE__, __func__,
                           __FILE__,
-                          "The implicit Butcher table has a negative b value!");
+                          "The implicit Butcher table has a negative b value but relaxation enabled!");
           return ARK_INVALID_TABLE;
         }
       }

--- a/src/arkode/arkode_arkstep.c
+++ b/src/arkode/arkode_arkstep.c
@@ -2736,8 +2736,8 @@ int arkStep_CheckButcherTables(ARKodeMem ark_mem)
   /* check that embedding order p > 0 */
   if ((step_mem->p < 1) && (!ark_mem->fixedstep))
   {
-    arkProcessError(ark_mem, ARK_INVALID_TABLE, __LINE__, __func__, __FILE__,
-                    "embedding order < 1, but ARKodeSetFixedStep was not called!");
+    arkProcessError(ark_mem, ARK_INVALID_TABLE, __LINE__, __func__,
+                    __FILE__, "embedding order < 1, but ARKodeSetFixedStep was not called!");
     return (ARK_INVALID_TABLE);
   }
 
@@ -2819,8 +2819,8 @@ int arkStep_CheckButcherTables(ARKodeMem ark_mem)
   {
     if (step_mem->q < 2)
     {
-      arkProcessError(ark_mem, ARK_INVALID_TABLE, __LINE__, __func__, __FILE__,
-                      "The Butcher table(s) must be at least second order when using relaxation!");
+      arkProcessError(ark_mem, ARK_INVALID_TABLE, __LINE__, __func__,
+                      __FILE__, "The Butcher table(s) must be at least second order when using relaxation!");
       return ARK_INVALID_TABLE;
     }
 
@@ -2832,8 +2832,7 @@ int arkStep_CheckButcherTables(ARKodeMem ark_mem)
         if (step_mem->Be->b[i] < ZERO)
         {
           arkProcessError(ark_mem, ARK_INVALID_TABLE, __LINE__, __func__,
-                          __FILE__,
-                          "The explicit Butcher table has a negative b value but relaxation enabled!");
+                          __FILE__, "The explicit Butcher table has a negative b value but relaxation enabled!");
           return ARK_INVALID_TABLE;
         }
       }
@@ -2847,8 +2846,7 @@ int arkStep_CheckButcherTables(ARKodeMem ark_mem)
         if (step_mem->Bi->b[i] < ZERO)
         {
           arkProcessError(ark_mem, ARK_INVALID_TABLE, __LINE__, __func__,
-                          __FILE__,
-                          "The implicit Butcher table has a negative b value but relaxation enabled!");
+                          __FILE__, "The implicit Butcher table has a negative b value but relaxation enabled!");
           return ARK_INVALID_TABLE;
         }
       }

--- a/src/arkode/arkode_erkstep.c
+++ b/src/arkode/arkode_erkstep.c
@@ -1386,7 +1386,7 @@ int erkStep_CheckButcherTable(ARKodeMem ark_mem)
   if ((step_mem->p < 1) && (!ark_mem->fixedstep))
   {
     arkProcessError(ark_mem, ARK_INVALID_TABLE, __LINE__, __func__, __FILE__,
-                    "embedding order < 1!");
+                    "embedding order < 1, but ARKodeSetFixedStep was not called!");
     return (ARK_INVALID_TABLE);
   }
 
@@ -1396,7 +1396,7 @@ int erkStep_CheckButcherTable(ARKodeMem ark_mem)
     if (step_mem->B->d == NULL)
     {
       arkProcessError(ark_mem, ARK_INVALID_TABLE, __LINE__, __func__, __FILE__,
-                      "no embedding!");
+                      "no embedding, but ARKodeSetFixedStep was not called!");
       return (ARK_INVALID_TABLE);
     }
   }
@@ -1423,7 +1423,7 @@ int erkStep_CheckButcherTable(ARKodeMem ark_mem)
     if (step_mem->q < 2)
     {
       arkProcessError(ark_mem, ARK_INVALID_TABLE, __LINE__, __func__, __FILE__,
-                      "The Butcher table must be at least second order!");
+                      "The Butcher table must be at least second order when using relaxation!");
       return ARK_INVALID_TABLE;
     }
 
@@ -1432,7 +1432,7 @@ int erkStep_CheckButcherTable(ARKodeMem ark_mem)
       if (step_mem->B->b[i] < ZERO)
       {
         arkProcessError(ark_mem, ARK_INVALID_TABLE, __LINE__, __func__,
-                        __FILE__, "The Butcher table has a negative b value!");
+                        __FILE__, "The Butcher table has a negative b value but relaxation enabled!");
         return ARK_INVALID_TABLE;
       }
     }

--- a/src/arkode/arkode_erkstep.c
+++ b/src/arkode/arkode_erkstep.c
@@ -1385,8 +1385,8 @@ int erkStep_CheckButcherTable(ARKodeMem ark_mem)
   /* check that embedding order p > 0 */
   if ((step_mem->p < 1) && (!ark_mem->fixedstep))
   {
-    arkProcessError(ark_mem, ARK_INVALID_TABLE, __LINE__, __func__, __FILE__,
-                    "embedding order < 1, but ARKodeSetFixedStep was not called!");
+    arkProcessError(ark_mem, ARK_INVALID_TABLE, __LINE__, __func__,
+                    __FILE__, "embedding order < 1, but ARKodeSetFixedStep was not called!");
     return (ARK_INVALID_TABLE);
   }
 
@@ -1422,8 +1422,8 @@ int erkStep_CheckButcherTable(ARKodeMem ark_mem)
   {
     if (step_mem->q < 2)
     {
-      arkProcessError(ark_mem, ARK_INVALID_TABLE, __LINE__, __func__, __FILE__,
-                      "The Butcher table must be at least second order when using relaxation!");
+      arkProcessError(ark_mem, ARK_INVALID_TABLE, __LINE__, __func__,
+                      __FILE__, "The Butcher table must be at least second order when using relaxation!");
       return ARK_INVALID_TABLE;
     }
 

--- a/src/arkode/arkode_mristep.c
+++ b/src/arkode/arkode_mristep.c
@@ -3463,8 +3463,8 @@ int mriStep_CheckCoupling(ARKodeMem ark_mem)
   /* check that embedding order p > 0 (if adaptive) */
   if ((step_mem->MRIC->p < 1) && (!ark_mem->fixedstep))
   {
-    arkProcessError(ark_mem, ARK_INVALID_TABLE, __LINE__, __func__, __FILE__,
-                    "embedding order < 1, but ARKodeSetFixedStep was not called");
+    arkProcessError(ark_mem, ARK_INVALID_TABLE, __LINE__, __func__,
+                    __FILE__, "embedding order < 1, but ARKodeSetFixedStep was not called");
     return (ARK_INVALID_TABLE);
   }
 

--- a/src/arkode/arkode_mristep.c
+++ b/src/arkode/arkode_mristep.c
@@ -3464,7 +3464,7 @@ int mriStep_CheckCoupling(ARKodeMem ark_mem)
   if ((step_mem->MRIC->p < 1) && (!ark_mem->fixedstep))
   {
     arkProcessError(ark_mem, ARK_INVALID_TABLE, __LINE__, __func__, __FILE__,
-                    "embedding order < 1");
+                    "embedding order < 1, but ARKodeSetFixedStep was not called");
     return (ARK_INVALID_TABLE);
   }
 


### PR DESCRIPTION
Added larger warnings to documentation for non-embedded methods in ARKODE, and clarified corresponding runtime error messages.  Should address at least the first portion of #957.